### PR TITLE
Workflow: create static linux binary and run tests

### DIFF
--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -10,11 +10,10 @@ LIBS = \
   libs/semgrep.libsonnet \
 
 # NOTE: Removed temporarily because we don't generate from jsonnet right now:
-# build-test-windows-x86.yml
+# build-test-windows-x86.yml, build-test-core-x86.yml
 OBJS = \
   semgrep.yml \
   lint.yml \
-  build-test-core-x86.yml \
   build-test-osx-x86.yml build-test-osx-arm64.yml \
   build-test-manylinux-x86.yml build-test-manylinux-aarch64.yml \
   tests.yml \

--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -10,12 +10,12 @@ LIBS = \
   libs/semgrep.libsonnet \
 
 # NOTE: Removed temporarily because we don't generate from jsonnet right now:
-# build-test-windows-x86.yml, build-test-core-x86.yml
+# build-test-windows-x86.yml, build-test-core-x86.yml build-test-manylinux-x86.yml 
 OBJS = \
   semgrep.yml \
   lint.yml \
   build-test-osx-x86.yml build-test-osx-arm64.yml \
-  build-test-manylinux-x86.yml build-test-manylinux-aarch64.yml \
+  build-test-manylinux-aarch64.yml \
   tests.yml \
   test-e2e-semgrep-ci.yml nightly.yml \
   build-test-docker.yml push-docker.yml \

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -1,0 +1,90 @@
+name: build-test-core-x86
+on:
+  push:
+    branches:
+      - main
+      - linux/**
+      # - dm/linux-static-build-workflow # branch where this change was introduced
+  pull_request:
+    branches:
+      - main
+  workflow_call: null
+  workflow_dispatch: null
+
+jobs:
+
+  build-core:
+    container:
+      image: ocamlpro/ocaml:5.2.1
+      # NOTE: Can also match the UID between Alpine and Ubuntu users, removing `--user root`.
+      # See: https://github.com/actions/checkout/issues/956.
+      # But this suggest to run as root: https://docs.github.com/en/enterprise-server@3.12/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
+      options: --user root
+    runs-on: ubuntu-latest
+    # env:
+    #   HOME: /home/ocaml # NOTE: Pointless?
+    steps:
+      - name: Make checkout speedy
+        run: git config --global fetch.parallel 50
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Configure git safedir properly
+        run: git config --global --add safe.directory $(pwd)
+
+      - name: Add system packages
+        run: |
+          # gnu tar and zstd needed for cache, see:
+          # https://github.com/actions/cache/issues/580
+          apk add --no-cache build-base zip bash libffi-dev \
+            libpsl-static zstd-static libidn2-static \
+            libunistring-static tar zstd
+
+      - name: Set GHA cache for OPAM 
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-${{ hashFiles('semgrep.opam') }}
+          path: _opam
+
+      - name: Create switch
+        run: |
+          if [ ! -d "_opam" ]; then
+            opam switch --no-install create . ocaml-system
+          else
+            echo "OPAM switch already exists, skipping creation."
+          fi
+          
+          eval $(opam env)
+          opam exec -- ocaml -version
+
+      # TODO: Remove `opam update` to make it faster, it's not needed
+      # for these images since they are frequently updated.
+      - name: Install dependencies
+        run: |
+          eval $(opam env)
+          # TODO: Try without the scripts/build-static-libcurl.sh part,
+          # in which case we can embed the new apk deps into the previous
+          # step and just execute the second command.
+          make install-deps-ALPINE-for-semgrep-core
+          make install-deps-for-semgrep-core
+
+      - name: Build opengrep-core
+        run: |
+          opam exec -- make core
+  
+      - name: Test opengrep-core
+        run: |
+          opam exec -- make core-test
+
+      - name: Make artifact for bin/opengrep-core
+        run: |
+          mkdir artifacts
+          cp bin/opengrep-core artifacts/
+          tar czf artifacts.tgz artifacts
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opengrep-core-x86-artifact
+          path: artifacts.tgz

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -88,3 +88,8 @@ jobs:
         with:
           name: opengrep-core-x86-artifact
           path: artifacts.tgz
+
+  build-test-manylinux-x86:
+    needs:
+      - build-core
+    uses: ./.github/workflows/build-test-manylinux-x86.yml

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -89,7 +89,36 @@ jobs:
           name: opengrep-core-x86-artifact
           path: artifacts.tgz
 
+  build-musllinux-x86:
+    needs:
+      - build-core
+    container: quay.io/pypa/musllinux_1_2_x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Make checkout speedy
+        run: git config --global fetch.parallel 50
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: |
+          apk update
+          apk add --no-cache zip python3 py3-pip py3-virtualenv python3-dev gcc musl-dev
+      - uses: actions/download-artifact@v4
+        with:
+          name: opengrep-core-x86-artifact
+      - run: |
+          tar xf artifacts.tgz
+          cp artifacts/opengrep-core cli/src/semgrep/bin
+          python3 -m venv venv
+          . venv/bin/activate
+          ./scripts/build-wheels.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: musllinux-x86-wheel
+          path: cli/dist.zip
+
   build-test-manylinux-x86:
     needs:
       - build-core
+      - build-musllinux-x86
     uses: ./.github/workflows/build-test-manylinux-x86.yml

--- a/.github/workflows/build-test-manylinux-x86.yml
+++ b/.github/workflows/build-test-manylinux-x86.yml
@@ -1,0 +1,118 @@
+name: build-test-manylinux-x86
+on:
+  workflow_call: null
+  workflow_dispatch: null
+  # workflow_run:
+  #   workflows:
+  #     - build-test-core-x86
+  #   types:
+  #     - completed
+  #   branches:
+  #     - main
+  #     - linux/**
+  #     - dm/linux-static-build-workflow
+  # push:
+  #   branches:
+  #     - main
+  #     - linux/**
+  #     - dm/linux-static-build-workflow # branch where this change was introduced
+
+jobs:
+
+  build-wheels:
+    container: quay.io/pypa/manylinux_2_28_x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Make checkout speedy
+        run: git config --global fetch.parallel 50
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - run: |
+          yum update -y
+          yum install -y zip python3-pip python3.9
+          alternatives --remove-all python3
+          alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+          alternatives --auto python3
+      - uses: actions/download-artifact@v4
+        with:
+          name: opengrep-core-x86-artifact
+      - run: |
+          tar xf artifacts.tgz
+          cp artifacts/opengrep-core cli/src/semgrep/bin
+          ./scripts/build-wheels.sh
+      - uses: actions/upload-artifact@v4
+        with:
+          name: manylinux-x86-wheel
+          path: cli/dist.zip
+
+  test-wheels:
+    container: quay.io/pypa/manylinux_2_28_x86_64
+    needs:
+      - build-wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: manylinux-x86-wheel
+      - run: unzip dist.zip
+      - name: install package
+        run: /opt/python/cp39-cp39/bin/pip install dist/*.whl
+      - name: test package
+        run: |
+          export PATH=/opt/python/cp39-cp39/bin:$PATH
+          opengrep --version
+      - name: e2e opengrep-core test
+        run: |
+          export PATH=/opt/python/cp39-cp39/bin:$PATH
+          echo '1 == 1' | opengrep -l python -e '$X == $X' -
+
+  test-wheels-venv:
+    container: quay.io/pypa/manylinux_2_28_x86_64
+    needs:
+      - build-wheels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: manylinux-x86-wheel
+      - run: unzip dist.zip
+      - name: create venv
+        run: /opt/python/cp39-cp39/bin/python3 -m venv env
+      - name: install package
+        run: env/bin/pip install dist/*.whl
+      - name: test package
+        run: |
+          env/bin/opengrep --version
+      - name: e2e opengrep-core test
+        run: |
+          echo '1 == 1' | env/bin/opengrep -l python -e '$X == $X' -
+
+  test-wheels-wsl:
+    needs:
+      - build-wheels
+    runs-on: windows-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: manylinux-x86-wheel
+      - run: unzip dist.zip
+      - uses: Vampire/setup-wsl@v3
+      - name: Install Python
+        run: |
+          sudo apt update -y
+          sudo apt install -y make python3 python3-pip
+          sudo ln -s /usr/bin/python3 /usr/bin/python
+        shell: wsl-bash {0}
+      - name: install package
+        run: python3 -m pip install dist/*.whl
+        shell: wsl-bash {0}
+      - name: test package
+        run: |
+          opengrep --version
+        shell: wsl-bash {0}
+      - name: e2e opengrep-core test
+        run: |
+          echo '1 == 1' | opengrep -l python -e '$X == $X' -
+        shell: wsl-bash {0}
+

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -1,5 +1,6 @@
 # NOTE: This workflow is adapted from `build-test-windows-x86.yml` in Semgrep v1.100.0.
 # NOTE: Do *NOT* generate from jsonnet, this is written direct in .yml for now.
+# TODO: Ensure that the `use-cache` options works as intended.
 
 name: build-test-windows-x86
 on:
@@ -160,7 +161,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: opengrep-core-and-dependent-libs-w64-artifact-${{ github.sha }}
+          name: opengrep-core-and-dependent-libs-w64-artifact
           path: artifacts.tgz
 
   build-wheels:
@@ -176,7 +177,7 @@ jobs:
           submodules: true
       - uses: actions/download-artifact@v4
         with:
-          name: opengrep-core-and-dependent-libs-w64-artifact-${{ github.sha }}
+          name: opengrep-core-and-dependent-libs-w64-artifact
       - env:
           SEMGREP_FORCE_INSTALL: 1
         run: |
@@ -185,7 +186,7 @@ jobs:
           ./scripts/build-wheels.sh --plat-name win_amd64
       - uses: actions/upload-artifact@v4
         with:
-          name: windows-x86-wheel-${{ github.sha }}
+          name: windows-x86-wheel
           path: cli/dist.tgz
 
   test-wheels:
@@ -198,12 +199,12 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: windows-x86-wheel-${{ github.sha }}
+          name: windows-x86-wheel
       - run: tar xzvf dist.tgz
       - name: install package
         run: pip3 install dist/*.whl
       - name: test package
         run: opengrep --version
       - name: e2e opengrep-core test
-        # FIXME: the -f param is probably removed, adapt.
-        run: echo '1 == 1' > test.py; opengrep -l python -e '$X == $X' test.py
+        # TODO: This fails only on the Windows workflow, investigate.
+        run: echo '1 == 1' | opengrep -l python -e '$X == $X' -

--- a/src/main/flags.sh
+++ b/src/main/flags.sh
@@ -67,7 +67,7 @@ else
             # old: was just '--copt -static --copy -no-pie' before we depended
             # on libcurl
             FLAGS=()
-            CCLIB=("-lssl" "-lcrypto" "-lz")
+            CCLIB=("-lidn2" "-lunistring" "-lpsl" "-lssl" "-lcrypto" "-lz")
             CCOPT=("-static" "-no-pie")
         else
             # On non-Alpine Linux distros (e.g., Ubuntu), we just dynamically


### PR DESCRIPTION
### Changes

Adds workflow that: 

- builds a statically linked binary for `opengrep-core` (OCaml).
- uploads the artifact.
- runs `make core-test`.
- creates and uploads a musllinux wheel.
- invokes workflow that builds the manylinux wheel and tests that the wheel works.

Note: only the OCaml tests are executed at this stage.

This triggers on every PR to `main` and on every push to `main`.