### PR TITLE
Workflow: create osx arm64 binary

### DIFF
--- a/.github/workflows/Makefile
+++ b/.github/workflows/Makefile
@@ -10,11 +10,12 @@ LIBS = \
   libs/semgrep.libsonnet \
 
 # NOTE: Removed temporarily because we don't generate from jsonnet right now:
-# build-test-windows-x86.yml, build-test-core-x86.yml build-test-manylinux-x86.yml 
+# build-test-windows-x86.yml, build-test-core-x86.yml, build-test-manylinux-x86.yml
+# build-test-osx-arm64.yml
 OBJS = \
   semgrep.yml \
   lint.yml \
-  build-test-osx-x86.yml build-test-osx-arm64.yml \
+  build-test-osx-x86.yml  \
   build-test-manylinux-aarch64.yml \
   tests.yml \
   test-e2e-semgrep-ci.yml nightly.yml \

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -1,0 +1,147 @@
+name: build-test-osx-arm64
+on:
+  push:
+      branches:
+        - main
+        - osx/**
+        # - dm/osx-arm64-build # branch where this change was introduced
+  workflow_call:
+    inputs:
+      use-cache:
+        default: true
+        description: Use Opam Cache - uncheck the box to disable use of the opam cache, meaning a long-running but completely from-scratch build.
+        required: false
+        type: boolean
+  workflow_dispatch:
+    inputs:
+      use-cache:
+        default: true
+        description: Use Opam Cache - uncheck the box to disable use of the opam cache, meaning a long-running but completely from-scratch build.
+        required: true
+        type: boolean
+
+jobs:
+
+  build-core:
+    runs-on: macos-13-xlarge # NOTE: For intel, we need macos-13-large it seems.
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+        if: ${{ inputs.use-cache == 'true' || inputs.use-cache == null }}
+        name: Set GHA cache for OPAM in ~/.opam
+        uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-${{ hashFiles('semgrep.opam') }}
+          path: ~/.opam
+      - name: Install dependencies
+        run: ./scripts/osx-setup-for-release.sh "5.2.1"
+      - name: Compile opengrep
+        run: opam exec -- make core
+      - name: Test opengrep-core
+        run: opam exec -- make core-test
+      - name: Make artifact for ./bin/opengrep-core
+        run: |
+          mkdir -p artifacts/lib
+          
+          cp ./bin/opengrep-core artifacts/
+
+          pushd artifacts
+
+          install_name_tool -change \
+            /opt/homebrew/opt/zstd/lib/libzstd.1.dylib \
+            @loader_path/libzstd.1.dylib \
+            opengrep-core
+
+          install_name_tool -change \
+            /opt/homebrew/opt/gmp/lib/libgmp.10.dylib \
+            @loader_path/libgmp.10.dylib \
+            opengrep-core
+          
+          install_name_tool -change \
+            /opt/homebrew/opt/libev/lib/libev.4.dylib \
+            @loader_path/libev.4.dylib \
+            opengrep-core
+
+          install_name_tool -change \
+            /opt/homebrew/opt/pcre2/lib/libpcre2-8.0.dylib \
+            @loader_path/libpcre2-8.0.dylib \
+            opengrep-core
+
+          install_name_tool -change \
+            /opt/homebrew/opt/pcre/lib/libpcre.1.dylib \
+            @loader_path/libpcre.1.dylib \
+            opengrep-core
+
+          install_name_tool -change \
+            /Users/runner/work/opengrep/opengrep/libs/ocaml-tree-sitter-core/tree-sitter/lib/libtree-sitter.0.dylib \
+            @loader_path/libtree-sitter.0.dylib \
+            opengrep-core
+
+          install_name_tool -delete_rpath \
+            /Users/runner/work/opengrep/opengrep/libs/ocaml-tree-sitter-core/tree-sitter/lib \
+            opengrep-core
+          
+          # otool -l opengrep-core
+          otool -L opengrep-core | grep -v "^\\s*/usr/lib/"
+
+          cp /opt/homebrew/opt/zstd/lib/libzstd.1.dylib . 
+          cp /opt/homebrew/opt/gmp/lib/libgmp.10.dylib . 
+          cp /opt/homebrew/opt/libev/lib/libev.4.dylib . 
+          cp /opt/homebrew/opt/pcre2/lib/libpcre2-8.0.dylib . 
+          cp /opt/homebrew/opt/pcre/lib/libpcre.1.dylib .
+          cp /Users/runner/work/opengrep/opengrep/libs/ocaml-tree-sitter-core/tree-sitter/lib/libtree-sitter.0.dylib .
+
+          popd
+          tar czf artifacts.tgz artifacts
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opengrep-osx-arm64 #-${{ github.sha }}
+          path: artifacts.tgz
+
+  build-wheels:
+    needs:
+      - build-core
+    runs-on: macos-13-xlarge
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: opengrep-osx-arm64 #-${{ github.sha }}
+      - run: |
+          tar xvfz artifacts.tgz
+          cp artifacts/* cli/src/semgrep/bin
+          ./scripts/build-wheels.sh --plat-name macosx_11_0_arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: osx-arm64-wheel
+          path: cli/dist.zip
+
+  test-wheels:
+    needs:
+      - build-wheels
+    runs-on: macos-13-xlarge
+    steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - uses: actions/download-artifact@v4
+        with:
+          name: osx-arm64-wheel
+      - run: unzip dist.zip
+      - name: install package
+        run: pip3 install dist/*.whl
+      - run: opengrep --version
+      - name: e2e opengrep-core test
+        run: echo '1 == 1' | opengrep -l python -e '$X == $X' -
+        shell: bash {0}

--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-# Setup the environment under MacOS to build and release semgrep-core.
+# Setup the environment under MacOS to build and release opengrep-core.
 
 # history: there used to be a separate osx-m1-release.sh script
 # that was mostly a copy of this file, but now the
@@ -24,13 +24,13 @@ opam init --no-setup --bare
 # Some CI runners have tree-sitter preinstalled which interfere with
 # out static linking plans below so better to remove it.
 # TODO: fix setup-m1-builder.sh instead?
-brew uninstall --force semgrep
+# brew uninstall --force semgrep
 brew uninstall --force tree-sitter
 
-SWITCH_NAME="${1:-4.14.0}"
+SWITCH_NAME="${1:-5.2.1}"
 
 #coupling: this should be the same version than in our Dockerfile
-if opam switch "${SWITCH_NAME}" ; then
+if opam switch "${SWITCH_NAME}" 2>/dev/null; then
     # This happens because the self-hosted CI runners do not
     # cleanup things between each run.
     echo "Switch ${SWITCH_NAME} exists, continuing"


### PR DESCRIPTION
### Changes

Adds workflow that: 

- builds a dynamically linked OSX binary for `opengrep-core` (OCaml).
- uploads the artifact.
- runs `make core-test`.
- creates and uploads an OSX python wheel.
- tests that the wheel works.

### Notes

- Only the OCaml tests are executed at this stage.
- The OCaml executable is instrumented to look for dynamically linked libraries (the `*.dylib` files) in the same directory as the OCaml binary, which works well since we copy these in the `bin/` directory of the wheel.

This triggers on every push to `main`.
