### PR TITLE
Fix OSX workflow, fails on main, not on PR

### DIFF
--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -47,7 +47,7 @@ jobs:
         run: opam exec -- make core-test
       - name: Make artifact for ./bin/opengrep-core
         run: |
-          mkdir -p artifacts/lib
+          mkdir artifacts
           
           cp ./bin/opengrep-core artifacts/
 


### PR DESCRIPTION
Remove empty folder `artifacts/lib/`.

For some reason, the workflow failed on `main` but succeeded on the PR branch. Reason seems to be this empty folder which we attempt to copy in one worflow step without the `-R` flag. In fact this subfolder, `lib/`, is not needed.