### PR TITLE
Fix python tests and remove cli logo

### DIFF
--- a/cli/src/semgrep/util.py
+++ b/cli/src/semgrep/util.py
@@ -133,7 +133,7 @@ def welcome() -> None:
     logo = with_logo_color("▢▢▢▢")
     click.echo(
         f"""
-┌──── {logo} ────┐
+┌──────────────┐
 │ Opengrep CLI │
 └──────────────┘
 """,

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product0-/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product0-/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product0-_foo.py/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product0-_foo.py/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product0-foo.py/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product0-foo.py/results.txt
@@ -42,9 +42,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │
@@ -52,7 +49,7 @@
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
   Scan skipped: 1 files matching --exclude patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
+  For a full list of skipped files, run opengrep with the --verbose flag.
 
 CI scan completed successfully.
   Found 1 finding (0 blocking) from 7 rules.

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product1-/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product1-/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product1-_foo.py/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product1-_foo.py/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product1-foo.py/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_app_ignore/ignored_product1-foo.py/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_config_run/autofix/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_config_run/autofix/results.txt
@@ -90,9 +90,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_config_run/noautofix/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_config_run/noautofix/results.txt
@@ -90,9 +90,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_dryrun/None/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_dryrun/None/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_reachable_finding_deduplication/config/base_output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_reachable_finding_deduplication/config/base_output.txt
@@ -41,19 +41,6 @@
 
   CODE RULES
   Nothing to scan.
-
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Basic          2
-  Unknown        1
-
   Current version has 3 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -70,19 +57,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Nothing to scan.
-
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Basic          2
-  Unknown        1
-
 
 
 ┌──────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_reachable_finding_deduplication/config/new_output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_reachable_finding_deduplication/config/new_output.txt
@@ -29,19 +29,6 @@
 
   CODE RULES
   Nothing to scan.
-
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Basic          2
-  Unknown        1
-
   Current version has 3 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -58,19 +45,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Nothing to scan.
-
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Basic          2
-  Unknown        1
-
 
 
 ┌──────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_supply_chain_finding/config/base_output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_supply_chain_finding/config/base_output.txt
@@ -42,9 +42,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_supply_chain_finding/config/new_output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_existing_supply_chain_finding/config/new_output.txt
@@ -29,9 +29,6 @@
 
   CODE RULES
   Nothing to scan.
-
-  SUPPLY CHAIN RULES
-  Nothing to scan.
   Current version has 1 finding.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -47,9 +44,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
 
   CODE RULES
-  Nothing to scan.
-
-  SUPPLY CHAIN RULES
   Nothing to scan.
 
 

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_fail_on_historical_scan_without_secrets/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_fail_on_historical_scan_without_secrets/output.txt
@@ -7,11 +7,11 @@
 === end of stdout - plain
 
 === stderr - plain
-WARNING: `semgrep ci` is meant to be run from the root of a git repo.
-When `semgrep ci` is not run from a git repo, it will not be able to perform all operations.
-When `semgrep ci` is run from a git repo, but not the root, links in the uploaded findings may be broken.
+WARNING: `opengrep ci` is meant to be run from the root of a git repo.
+When `opengrep ci` is not run from a git repo, it will not be able to perform all operations.
+When `opengrep ci` is run from a git repo, but not the root, links in the uploaded findings may be broken.
 
-To run `semgrep ci` on only a subdirectory of a git repo, see `--subdir`.
+To run `opengrep ci` on only a subdirectory of a git repo, see `--subdir`.
 
 
 ┌────────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-azure-pipelines/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-bitbucket/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-buildkite/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-circleci-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-circleci/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-enterprise/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-pr-semgrepconfig/results.txt
@@ -28,9 +28,6 @@ Using <MASKED> as the merge-base of <MASKED> and <MASKED>
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -47,9 +44,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-pr/results.txt
@@ -28,9 +28,6 @@ Using <MASKED> as the merge-base of <MASKED> and <MASKED>
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -47,9 +44,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-push-special-env-vars/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-push-with-app-url/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-push-with-app-url/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-github-push/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-gitlab-push/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-gitlab-special-env-vars/results.txt
@@ -74,9 +74,6 @@
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -93,9 +90,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-gitlab/results.txt
@@ -74,9 +74,6 @@
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -93,9 +90,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-jenkins-missing-vars/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-jenkins/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-local/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-local/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-self-hosted/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-travis-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-travis/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-travis/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/autofix-unparsable_url/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-azure-pipelines-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-azure-pipelines/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-bitbucket-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-bitbucket/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-buildkite-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-buildkite/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-circleci-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-circleci/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-enterprise/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-pr-semgrepconfig/results.txt
@@ -28,9 +28,6 @@ Using <MASKED> as the merge-base of <MASKED> and <MASKED>
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -47,9 +44,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-pr/results.txt
@@ -28,9 +28,6 @@ Using <MASKED> as the merge-base of <MASKED> and <MASKED>
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -47,9 +44,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-push-special-env-vars/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-push-with-app-url/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-push-with-app-url/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-github-push/results.txt
@@ -26,9 +26,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────────────────┐
 │ 6 Blocking Code Findings │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-gitlab-push/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-gitlab-special-env-vars/results.txt
@@ -74,9 +74,6 @@
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -93,9 +90,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-gitlab/results.txt
@@ -74,9 +74,6 @@
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
   Current version has 15 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -93,9 +90,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Scanning 1 file with 4 python rules.
-
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
 
 
 ┌──────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-jenkins-missing-vars/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-jenkins-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-jenkins/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-local/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-local/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-self-hosted/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-travis-overwrite-autodetected-variables/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-travis/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_full_run/noautofix-unparsable_url/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_lockfile_parse_failure_reporting/results.txt
@@ -86,13 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-  Failed to parse [bold]Pipfile.lock[/bold] at [bold]2:1[/bold] - expected one of ['"',
-  '-?(0|[1-9][0-9]*)([.][0-9]+)?([eE][+-]?[0-9]+)?', '[', 'false', 'null', 'true', '{']
-  2 | invalid
-      ^
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/autofix---disable-nosem/output.txt
@@ -97,9 +97,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/autofix---enable-nosem/output.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/noautofix---disable-nosem/output.txt
@@ -97,9 +97,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_nosem/noautofix---enable-nosem/output.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---emacs/results.txt
@@ -38,9 +38,6 @@ poetry.lock:2:1:error(supply-chain1):name = "badlib":found a dependency
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---gitlab-sast/results.txt
@@ -306,9 +306,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---gitlab-secrets/results.txt
@@ -362,9 +362,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---json/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---json/results.txt
@@ -490,9 +490,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---sarif/results.txt
@@ -621,9 +621,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---vim/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/autofix---vim/results.txt
@@ -38,9 +38,6 @@ poetry.lock:2:1:E:supply-chain1:found a dependency
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---emacs/results.txt
@@ -38,9 +38,6 @@ poetry.lock:2:1:error(supply-chain1):name = "badlib":found a dependency
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---gitlab-sast/results.txt
@@ -306,9 +306,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---gitlab-secrets/results.txt
@@ -362,9 +362,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---json/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---json/results.txt
@@ -487,9 +487,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---sarif/results.txt
@@ -567,9 +567,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_outputs/noautofix---vim/results.txt
@@ -38,9 +38,6 @@ poetry.lock:2:1:E:supply-chain1:found a dependency
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_query_dependency/True-config/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_query_dependency/True-config/output.txt
@@ -62,9 +62,6 @@
   CODE RULES
   Scanning 1 file.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/base_output.txt
@@ -58,19 +58,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Basic          2
-  Unknown        1
-
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_reachable_and_unreachable_diff_scan_findings/config/new_output.txt
@@ -41,19 +41,6 @@
 
   CODE RULES
   Nothing to scan.
-
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Basic          2
-  Unknown        1
-
   Current version has 3 findings.
 
 Creating git worktree from '<MASKED>' to scan baseline.
@@ -70,19 +57,6 @@ Creating git worktree from '<MASKED>' to scan baseline.
 
   CODE RULES
   Nothing to scan.
-
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────
-  Pypi            3       1   poetry.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Basic          2
-  Unknown        1
-
 
 
 ┌──────────────┐

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_sarif_output_with_dataflow_traces/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_sarif_output_with_dataflow_traces/results.txt
@@ -655,9 +655,6 @@
   CODE RULES
   Scanning 1 file with 4 python rules.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_subdir/..-False/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_subdir/..-False/output.txt
@@ -7,7 +7,7 @@
 === end of stdout - plain
 
 === stderr - plain
-`semgrep ci --subdir` must be given a directory that is actually a subdirectory of the current directory
+`opengrep ci --subdir` must be given a directory that is actually a subdirectory of the current directory
 There were errors during analysis but Semgrep will succeed because there were no blocking findings, use --no-suppress-errors if you want Semgrep to fail when there are errors.
 
 === end of stderr - plain

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_subdir/..org-False/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_subdir/..org-False/output.txt
@@ -7,7 +7,7 @@
 === end of stdout - plain
 
 === stderr - plain
-`semgrep ci --subdir` must be given a directory that is actually a subdirectory of the current directory
+`opengrep ci --subdir` must be given a directory that is actually a subdirectory of the current directory
 There were errors during analysis but Semgrep will succeed because there were no blocking findings, use --no-suppress-errors if you want Semgrep to fail when there are errors.
 
 === end of stderr - plain

--- a/cli/tests/default/e2e-other/snapshots/test_ci/test_subdir/checkout_project_nameorgexamples-False/output.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ci/test_subdir/checkout_project_nameorgexamples-False/output.txt
@@ -7,7 +7,7 @@
 === end of stdout - plain
 
 === stderr - plain
-`semgrep ci --subdir` must be given a directory that is actually a subdirectory of the current directory
+`opengrep ci --subdir` must be given a directory that is actually a subdirectory of the current directory
 There were errors during analysis but Semgrep will succeed because there were no blocking findings, use --no-suppress-errors if you want Semgrep to fail when there are errors.
 
 === end of stderr - plain

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareansi-html.yaml-dependency_awareansi/results.txt
@@ -92,9 +92,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli-with-manifest/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli-with-manifest/results.txt
@@ -453,18 +453,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ────────────────────────────────────────────────────────────────────────────────────────
-  Pypi            6       1   targets/dependency_aware/awscli-with-manifest/Pipfile.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Unknown        6
-
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareawscli_vuln.yaml-dependency_awareawscli/results.txt
@@ -445,18 +445,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ──────────────────────────────────────────────────────────────────────────
-  Pypi            6       1   targets/dependency_aware/awscli/Pipfile.lock
-
-
-  Analysis   Rules
- ──────────────────
-  Unknown        6
-
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaredart-parity.yaml-dependency_awaredart/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaredart-parity.yaml-dependency_awaredart/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaregeneric-sca.yaml-dependency_awaregeneric/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaregeneric-sca.yaml-dependency_awaregeneric/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 2 files.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarego-sca.yaml-dependency_awarego/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarego-sca.yaml-dependency_awarego/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarego-sca.yaml-dependency_awarego_multi_newline/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarego-sca.yaml-dependency_awarego_multi_newline/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarego-sca.yaml-dependency_awarego_toolchain/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarego-sca.yaml-dependency_awarego_toolchain/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaregradle-guava.yaml-dependency_awaregradle-direct/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaregradle-guava.yaml-dependency_awaregradle-direct/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle-arbitrary-comment/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle-arbitrary-comment/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle-no-comment/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle-no-comment/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle_empty/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle_empty/results.txt
@@ -76,9 +76,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle_trailing_newline/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejava-gradle-sca.yaml-dependency_awaregradle_trailing_newline/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v6/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v6/results.txt
@@ -76,9 +76,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v9/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-v9/results.txt
@@ -76,9 +76,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-workspaces/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm-workspaces/results.txt
@@ -124,18 +124,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ─────────────────────────────────────────────────────────────────────────────────────
-  Npm             2       1   targets/dependency_aware/pnpm-workspaces/pnpm-lock.yaml
-
-
-  Analysis   Rules
- ──────────────────
-  Unknown        2
-
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-pnpm-sca.yaml-dependency_awarepnpm/results.txt
@@ -78,18 +78,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-
-  Ecosystem   Rules   Files   Lockfiles
- ──────────────────────────────────────────────────────────────────────────
-  Npm             2       1   targets/dependency_aware/pnpm/pnpm-lock.yaml
-
-
-  Analysis   Rules
- ──────────────────
-  Unknown        2
-
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-sca.yaml-dependency_awaredeeply_nested_package_lock/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-sca.yaml-dependency_awaredeeply_nested_package_lock/results.txt
@@ -76,9 +76,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-sca.yaml-dependency_awarejs/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-sca.yaml-dependency_awarepackage-lock_resolved_false/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-sca.yaml-dependency_awarepackage-lock_resolved_false/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-yarn2-sca.yaml-dependency_awarepackage-lock-v3/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-yarn2-sca.yaml-dependency_awarepackage-lock-v3/results.txt
@@ -132,9 +132,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-yarn2-sca.yaml-dependency_awareyarn2/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarejs-yarn2-sca.yaml-dependency_awareyarn2/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarelodash-4.17.19.yaml-dependency_awarelodash/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarelodash-4.17.19.yaml-dependency_awarelodash/results.txt
@@ -29,9 +29,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarelog4shell.yaml-dependency_awarelog4j/results.txt
@@ -146,9 +146,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_extra_field/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_extra_field/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_joined/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_joined/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_optional/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_optional/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_release_version/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremaven-guice.yaml-dependency_awaremaven_dep_tree_release_version/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaremonorepo.yaml-dependency_awaremonorepo/results.txt
@@ -130,9 +130,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 3 files.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarenested_package_lock.yaml-dependency_awarenested_package_lock/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarenested_package_lock.yaml-dependency_awarenested_package_lock/results.txt
@@ -81,9 +81,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareno-pattern.yaml-dependency_awareyarn-v1-without-version-constraint/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareno-pattern.yaml-dependency_awareyarn-v1-without-version-constraint/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareno-pattern.yaml-dependency_awareyarn/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareno-pattern.yaml-dependency_awareyarn/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareno-pattern.yaml-dependency_awareyarn_multi_hash/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareno-pattern.yaml-dependency_awareyarn_multi_hash/results.txt
@@ -86,9 +86,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarenuget-sca-simple.yaml-dependency_awarenuget-large/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarenuget-sca-simple.yaml-dependency_awarenuget-large/results.txt
@@ -306,9 +306,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarenuget-sca-simple.yaml-dependency_awarenuget/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarenuget-sca-simple.yaml-dependency_awarenuget/results.txt
@@ -122,9 +122,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarephp-sca.yaml-dependency_awarephp/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarephp-sca.yaml-dependency_awarephp/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-pyhcl-sca.yaml-dependency_awarepipfile_with_vuln_in_dev-packages/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-pyhcl-sca.yaml-dependency_awarepipfile_with_vuln_in_dev-packages/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile_with_empty_dev-packages/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile_with_empty_dev-packages/results.txt
@@ -84,9 +84,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile_with_one_newline_between_sections/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile_with_one_newline_between_sections/results.txt
@@ -84,9 +84,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile_with_uppercase_package_name/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-pipfile-sca.yaml-dependency_awarepipfile_with_uppercase_package_name/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awaremanifest_parse_error/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awaremanifest_parse_error/results.txt
@@ -77,13 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-  Failed to parse [bold]targets/dependency_aware/manifest_parse_error/pyproject.toml[/bold] at [bold]3:1[/bold] -
-  expected one of ['\n+', '("[^"]*"|[^\\s=]+)\\s*=\\s*', 'EOF', '[', '[[', '[tool.poetry.dependencies]\n']
-  3 | name ~ "test"
-      ^
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_comments/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_comments/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_empty_table/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_empty_table/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_quoted_key/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_quoted_key/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_trailing_newlines/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_trailing_newlines/results.txt
@@ -29,9 +29,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_with_arbitrary_starting_comment/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_with_arbitrary_starting_comment/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_with_uppercase_package_name/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-poetry-sca.yaml-dependency_awarepoetry_with_uppercase_package_name/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements3/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements3/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_with_uppercase_package_name/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_with_uppercase_package_name/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareruby-sca.yaml-dependency_awareruby-with-multiple-gem-sections/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareruby-sca.yaml-dependency_awareruby-with-multiple-gem-sections/results.txt
@@ -78,9 +78,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareruby-sca.yaml-dependency_awareruby-with-multiple-remotes/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareruby-sca.yaml-dependency_awareruby-with-multiple-remotes/results.txt
@@ -78,9 +78,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareruby-sca.yaml-dependency_awareruby/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareruby-sca.yaml-dependency_awareruby/results.txt
@@ -78,9 +78,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarerust-sca.yaml-dependency_awarerust/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarerust-sca.yaml-dependency_awarerust/results.txt
@@ -82,9 +82,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarerust-sca.yaml-dependency_awarerust_short_lockfile/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awarerust-sca.yaml-dependency_awarerust_short_lockfile/results.txt
@@ -78,9 +78,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpm_missing_version/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpm_missing_version/results.txt
@@ -29,11 +29,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-  Failed to parse [bold]targets/dependency_aware/swiftpm_missing_version/Package.resolved[/bold] - Unable to determine
-  version of swift lockfile
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv1/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv1/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv2/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv2/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv3/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareswift-sca.yaml-dependency_awareswiftpmv3/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaretransitive_and_direct.yaml-dependency_awaretransitive_and_directdirect_reachable_transitive_unreachable/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaretransitive_and_direct.yaml-dependency_awaretransitive_and_directdirect_reachable_transitive_unreachable/results.txt
@@ -136,9 +136,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaretransitive_and_direct.yaml-dependency_awaretransitive_and_directtransitive_not_reachable_if_direct/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awaretransitive_and_direct.yaml-dependency_awaretransitive_and_directtransitive_not_reachable_if_direct/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareyarn-sass.yaml-dependency_awareyarn/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareyarn-sass.yaml-dependency_awareyarn/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareyarn-sass.yaml-dependency_awareyarn_at_in_version/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc/rulesdependency_awareyarn-sass.yaml-dependency_awareyarn_at_in_version/results.txt
@@ -29,9 +29,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__pypi_package_name_lowercase/rulesdependency_awarepython-pipfile-case-insensitive-package.yaml-dependency_awarepipfile/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__pypi_package_name_lowercase/rulesdependency_awarepython-pipfile-case-insensitive-package.yaml-dependency_awarepipfile/results.txt
@@ -83,9 +83,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__pypi_package_name_lowercase/rulesdependency_awarepython-poetry-case-insensitive-package.yaml-dependency_awarepoetry/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__pypi_package_name_lowercase/rulesdependency_awarepython-poetry-case-insensitive-package.yaml-dependency_awarepoetry/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__pypi_package_name_lowercase/rulesdependency_awarepython-requirements-case-insensitive-package.yaml-dependency_awarerequirements/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__pypi_package_name_lowercase/rulesdependency_awarepython-requirements-case-insensitive-package.yaml-dependency_awarerequirements/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirement/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirement/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirement_pip/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirement_pip/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder_dep_dupes/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder_dep_dupes/results.txt
@@ -128,9 +128,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder_no_src/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder_no_src/results.txt
@@ -78,9 +78,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder_similar_deps/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_folder_similar_deps/results.txt
@@ -128,9 +128,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles/results.txt
@@ -81,9 +81,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_dep_dupes/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_dep_dupes/results.txt
@@ -129,9 +129,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_dep_dupes_no_src/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_dep_dupes_no_src/results.txt
@@ -126,9 +126,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_no_src/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_no_src/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_similar_deps/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_multiple_lockfiles_similar_deps/results.txt
@@ -129,9 +129,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_dep_dupes/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_dep_dupes/results.txt
@@ -125,9 +125,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_folder/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_folder/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_folder_dep_dupes/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_folder_dep_dupes/results.txt
@@ -126,9 +126,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_folder_no_src/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_folder_no_src/results.txt
@@ -78,9 +78,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_no_src/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_nested_no_src/results.txt
@@ -77,9 +77,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Nothing to scan.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_pip/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_pip/results.txt
@@ -79,9 +79,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_pip_folder/results.txt
+++ b/cli/tests/default/e2e-other/snapshots/test_ssc/test_ssc__requirements_lockfiles/rulesdependency_awarepython-requirements-sca.yaml-dependency_awarerequirements_pip_folder/results.txt
@@ -80,9 +80,6 @@
   CODE RULES
   Nothing to scan.
 
-  SUPPLY CHAIN RULES
-  Scanning 1 file.
-
 
 ┌──────────────┐
 │ Scan Summary │

--- a/cli/tests/default/e2e-other/test_login.py
+++ b/cli/tests/default/e2e-other/test_login.py
@@ -7,9 +7,12 @@ from semgrep.config_resolver import ConfigLoader
 
 expected_logout_str = "Logged out (log back in with `semgrep login`)\n"
 
+# NOTE: Disabled because `login` is no longer a command.
+# TODO: Remove.
 
 # it should be ok to logout when not logged in and to logout twice
 @pytest.mark.slow
+@pytest.mark.pysemfail
 def test_logout_not_logged_in(tmp_path, mocker):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},
@@ -27,6 +30,7 @@ def test_logout_not_logged_in(tmp_path, mocker):
 # it should fail when run from a non-terminal shell
 @pytest.mark.slow
 @pytest.mark.osemfail
+@pytest.mark.pysemfail
 def test_login_no_tty(tmp_path, mocker):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},
@@ -50,6 +54,7 @@ def test_login_no_tty(tmp_path, mocker):
 # it should login by using SEMGREP_APP_TOKEN
 @pytest.mark.slow
 @pytest.mark.osemfail
+@pytest.mark.pysemfail
 def test_login_env_token(tmp_path, mocker):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},
@@ -88,6 +93,7 @@ def test_login_env_token(tmp_path, mocker):
 # it should give access to the registry once logged in
 @pytest.mark.slow
 @pytest.mark.osemfail
+@pytest.mark.pysemfail
 def test_login_and_use_registry(tmp_path, mocker):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},

--- a/cli/tests/default/e2e-other/test_publish.py
+++ b/cli/tests/default/e2e-other/test_publish.py
@@ -6,10 +6,12 @@ from tests.semgrep_runner import SemgrepRunner
 
 from semgrep.cli import cli
 
+# TODO: Remove? We may have something similar in the future.
 
 @pytest.mark.kinda_slow
 # osemfail, but now translated to Test_publish_subcommand.ml
 @pytest.mark.osemfail
+@pytest.mark.pysemfail
 def test_publish(tmp_path, mocker):
     runner = SemgrepRunner(
         env={"SEMGREP_SETTINGS_FILE": str(tmp_path / ".settings.yaml")},

--- a/cli/tests/default/e2e/snapshots/test_exclude_include_formatting/test_exclude_include_verbose_sorted_1/results.err
+++ b/cli/tests/default/e2e/snapshots/test_exclude_include_formatting/test_exclude_include_verbose_sorted_1/results.err
@@ -17,7 +17,7 @@ Rules:
 Files skipped:
 ========================================
 
-  Always skipped by Semgrep:
+  Always skipped by Opengrep:
 
    • <none>
 
@@ -51,7 +51,7 @@ Files skipped:
 
    • <none>
 
-  Partially analyzed due to parsing or internal Semgrep errors
+  Partially analyzed due to parsing or internal Opengrep errors
 
    • <none>
 
@@ -63,7 +63,7 @@ Files skipped:
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
   Scan skipped: 4 files matching --exclude patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
+  For a full list of skipped files, run opengrep with the --verbose flag.
 
 Ran 4 rules on 0 files: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_exclude_include_formatting/test_exclude_include_verbose_sorted_2/results.err
+++ b/cli/tests/default/e2e/snapshots/test_exclude_include_formatting/test_exclude_include_verbose_sorted_2/results.err
@@ -14,7 +14,7 @@ Rules:
 Files skipped:
 ========================================
 
-  Always skipped by Semgrep:
+  Always skipped by Opengrep:
 
    • <none>
 
@@ -61,7 +61,7 @@ Files skipped:
 
    • <none>
 
-  Partially analyzed due to parsing or internal Semgrep errors
+  Partially analyzed due to parsing or internal Opengrep errors
 
    • <none>
 
@@ -73,7 +73,7 @@ Files skipped:
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
   Scan skipped: 17 files matching --exclude patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
+  For a full list of skipped files, run opengrep with the --verbose flag.
 
 Ran 1 rule on 0 files: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_nosemgrep/test_nosem_rule__invalid_id/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_nosemgrep/test_nosem_rule__invalid_id/error.txt
@@ -12,6 +12,6 @@
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 1 file: 3 findings.

--- a/cli/tests/default/e2e/snapshots/test_output/test_semgrepignore_ignore_log_report/report.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_semgrepignore_ignore_log_report/report.txt
@@ -1,4 +1,4 @@
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
   Scan skipped: 1 files not matching --include patterns, 1 files matching --exclude patterns, 3 files matching .semgrepignore patterns.
-  For a full list of skipped files, run semgrep with the --verbose flag.
+  For a full list of skipped files, run opengrep with the --verbose flag.

--- a/cli/tests/default/e2e/snapshots/test_output/test_semgrepignore_ignore_log_report_pysemgrep/report.txt
+++ b/cli/tests/default/e2e/snapshots/test_output/test_semgrepignore_ignore_log_report_pysemgrep/report.txt
@@ -1,4 +1,4 @@
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
   Scan skipped: 1 files not matching --include patterns, 1 files matching --exclude patterns, 1 files matching .semgrepignore patterns
-  For a full list of skipped files, run semgrep with the --verbose flag.
+  For a full list of skipped files, run opengrep with the --verbose flag.

--- a/cli/tests/default/e2e/snapshots/test_process_limits/test_max_memory/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_process_limits/test_max_memory/error.txt
@@ -14,7 +14,7 @@ Rules:
 Files skipped:
 ========================================
 
-  Always skipped by Semgrep:
+  Always skipped by Opengrep:
 
    • <none>
 
@@ -45,7 +45,7 @@ Files skipped:
 
    • <none>
 
-  Partially analyzed due to parsing or internal Semgrep errors
+  Partially analyzed due to parsing or internal Opengrep errors
 
    • targets/equivalence/open_redirect.py
 
@@ -56,7 +56,7 @@ Files skipped:
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_process_limits/test_spacegrep_timeout/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_process_limits/test_spacegrep_timeout/error.txt
@@ -12,6 +12,6 @@ Warning: 1 timeout error(s) in targets/spacegrep_timeout/gnu-lgplv2.txt when run
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 1 file: 0 findings.

--- a/cli/tests/default/e2e/snapshots/test_process_limits/test_timeout_threshold/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_process_limits/test_timeout_threshold/error.txt
@@ -20,7 +20,7 @@ threshold` for more info.[0m
 Files skipped:
 ========================================
 
-  [1m[24mAlways skipped by Semgrep:[0m
+  [1m[24mAlways skipped by Opengrep:[0m
 
    • <none>
 
@@ -51,7 +51,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
+  [1m[24mPartially analyzed due to parsing or internal Opengrep errors[0m
 
    • [36m[22m[24mtargets/equivalence/open_redirect.py with rule rules.forcetimeout[0m
 
@@ -62,7 +62,7 @@ Files skipped:
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 3 rules on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_process_limits/test_timeout_threshold/error_2.txt
+++ b/cli/tests/default/e2e/snapshots/test_process_limits/test_timeout_threshold/error_2.txt
@@ -20,7 +20,7 @@ threshold` for more info.[0m
 Files skipped:
 ========================================
 
-  [1m[24mAlways skipped by Semgrep:[0m
+  [1m[24mAlways skipped by Opengrep:[0m
 
    • <none>
 
@@ -51,7 +51,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
+  [1m[24mPartially analyzed due to parsing or internal Opengrep errors[0m
 
    • [36m[22m[24mtargets/equivalence/open_redirect.py with 2 rules (e.g. rules.forcetimeout)[0m
 
@@ -62,7 +62,7 @@ Files skipped:
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 3 rules on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_regex/test_regex_rule__invalid_expression/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_regex/test_regex_rule__invalid_expression/error.txt
@@ -12,6 +12,6 @@
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 11 files: 0 findings.

--- a/cli/tests/default/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
+++ b/cli/tests/default/e2e/snapshots/test_rule_parser/test_rule_parser__failure__error_messages/badpattern/error-in-color.txt
@@ -18,6 +18,6 @@ $X == $X 3
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 11 files: 0 findings.

--- a/cli/tests/default/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_rule_parser/test_rule_parser_cli_pattern/error.txt
@@ -18,6 +18,6 @@
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 1 file: 0 findings.

--- a/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings0/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings0/error.txt
@@ -14,7 +14,7 @@ Rules:
 Files skipped:
 ========================================
 
-  [1m[24mAlways skipped by Semgrep:[0m
+  [1m[24mAlways skipped by Opengrep:[0m
 
    • <none>
 
@@ -45,7 +45,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
+  [1m[24mPartially analyzed due to parsing or internal Opengrep errors[0m
 
    • [36m[22m[24mtargets/bad/invalid_go.go (2 lines skipped)[0m
 
@@ -55,7 +55,7 @@ Files skipped:
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_file_parser__failure__error_messages/settings1/error.txt
@@ -15,7 +15,7 @@ Rules:
 Files skipped:
 ========================================
 
-  [1m[24mAlways skipped by Semgrep:[0m
+  [1m[24mAlways skipped by Opengrep:[0m
 
    • <none>
 
@@ -46,7 +46,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
+  [1m[24mPartially analyzed due to parsing or internal Opengrep errors[0m
 
    • [36m[22m[24mtargets/bad/invalid_python.py (3 lines skipped)[0m
 
@@ -56,7 +56,7 @@ Files skipped:
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 2 rules on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_parse_errors/errors.txt
+++ b/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_parse_errors/errors.txt
@@ -17,7 +17,7 @@ Rules:
 Files skipped:
 ========================================
 
-  [1m[24mAlways skipped by Semgrep:[0m
+  [1m[24mAlways skipped by Opengrep:[0m
 
    • <none>
 
@@ -48,7 +48,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
+  [1m[24mPartially analyzed due to parsing or internal Opengrep errors[0m
 
    • [36m[22m[24mtargets/bad/invalid_javascript.js (2 lines skipped)[0m
 
@@ -58,7 +58,7 @@ Files skipped:
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 2 rules on 1 file: 3 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/error.txt
+++ b/cli/tests/default/e2e/snapshots/test_semgrep_core_parse_error/test_rule_parser__failure__error_messages/settings0/error.txt
@@ -14,7 +14,7 @@ Rules:
 Files skipped:
 ========================================
 
-  [1m[24mAlways skipped by Semgrep:[0m
+  [1m[24mAlways skipped by Opengrep:[0m
 
    • <none>
 
@@ -45,7 +45,7 @@ Files skipped:
 
    • <none>
 
-  [1m[24mPartially analyzed due to parsing or internal Semgrep errors[0m
+  [1m[24mPartially analyzed due to parsing or internal Opengrep errors[0m
 
    • [36m[22m[24m<MASKED> with rule rules.broken-rule[0m
 
@@ -55,7 +55,7 @@ Files skipped:
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
-  Partially scanned: 1 files only partially analyzed due to parsing or internal Semgrep errors
+  Partially scanned: 1 files only partially analyzed due to parsing or internal Opengrep errors
 
 Ran 1 rule on 1 file: 0 findings.
 Not sending pseudonymous metrics since metrics are configured to OFF and registry usage is False

--- a/cli/tests/default/e2e/test_output.py
+++ b/cli/tests/default/e2e/test_output.py
@@ -355,7 +355,7 @@ def test_json_output_with_dataflow_traces(run_semgrep_in_tmp: RunSemgrep, snapsh
 
 IGNORE_LOG_REPORT_FIRST_LINE = "Some files were skipped or only partially analyzed."
 IGNORE_LOG_REPORT_LAST_LINE = (
-    "  For a full list of skipped files, run semgrep with the --verbose flag."
+    "  For a full list of skipped files, run opengrep with the --verbose flag.\n"
 )
 
 

--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -41,7 +41,7 @@ let print_help (stdout : Cap.Console.stdout) =
   (* TODO: add a Out.printf_color? *)
   CapConsole.ocolor_format_printf stdout
     {|
-┌──── @{<green>▢▢▢▢@} ────┐
+┌──────────────┐
 │ Opengrep CLI │
 └──────────────┘
 Opengrep CLI scans your code for bugs, security and dependency vulnerabilities.

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -316,7 +316,7 @@ let print_logo () : unit =
   let logo =
     Ocolor_format.asprintf
       {|
-┌──── @{<green>▢▢▢▢@} ────┐
+┌──────────────┐
 │ Opengrep CLI │
 └──────────────┘
 |}

--- a/tests/snapshots/semgrep-core/bc2f173cbf29/stdxxx
+++ b/tests/snapshots/semgrep-core/bc2f173cbf29/stdxxx
@@ -13,7 +13,7 @@ Initialized empty Git repository in <TMP>/<MASKED>/.git/
  create mode 100644 rules.yml
  create mode 100644 stupid.py
 
-┌──── [32m▢▢▢▢[39m ────┐
+┌──────────────┐
 │ Opengrep CLI │
 └──────────────┘
 


### PR DESCRIPTION
### Changes 

The CLI now outputs this: 

```
┌──────────────┐
│ Opengrep CLI │
└──────────────┘
```

More importantly, the python tests run with `make ci-test` should now pass in Linux CI.

- Snapshots were regenerated to match the name change and also, in the case of `e2e-other` which has more PRO stuff, to remove output that is no longer produced.
- A few tests that check `login` and `publish` have been disabled.
- There is a test that does not pass, but I suspect this might succeed in CI.

Note: the workflow running `make ci-test` will be added later, as part of a general workflow revamp.