### PR TITLE
Prepare for pre-release

### DIFF
--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -120,5 +120,5 @@ jobs:
   build-test-manylinux-x86:
     needs:
       - build-core
-      - build-musllinux-x86
+      # - build-musllinux-x86 # NOTE: This is not really necessary.
     uses: ./.github/workflows/build-test-manylinux-x86.yml

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -1,10 +1,10 @@
 name: build-test-osx-arm64
 on:
   push:
-      branches:
-        - main
-        - osx/**
-        # - dm/osx-arm64-build # branch where this change was introduced
+    branches:
+      - main
+      - osx/**
+      # - dm/osx-arm64-build # branch where this change was introduced
   workflow_call:
     inputs:
       use-cache:
@@ -101,7 +101,7 @@ jobs:
           tar czf artifacts.tgz artifacts
       - uses: actions/upload-artifact@v4
         with:
-          name: opengrep-osx-arm64 #-${{ github.sha }}
+          name: opengrep-osx-arm64
           path: artifacts.tgz
 
   build-wheels:
@@ -117,7 +117,7 @@ jobs:
           submodules: true
       - uses: actions/download-artifact@v4
         with:
-          name: opengrep-osx-arm64 #-${{ github.sha }}
+          name: opengrep-osx-arm64
       - run: |
           tar xvfz artifacts.tgz
           cp artifacts/* cli/src/semgrep/bin

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -31,9 +31,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+      - name: Debug use-cache input
+        run: |
+          echo "use-cache value: ${{ inputs.use-cache }}"
       - env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-        if: ${{ inputs.use-cache == 'true' || inputs.use-cache == null }}
+        # if: ${{ inputs.use-cache == 'true' || inputs.use-cache == '' }}
         name: Set GHA cache for OPAM in ~/.opam
         uses: actions/cache@v4
         with:

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -1,0 +1,69 @@
+name: rolling-release
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: the tag to use
+        required: true
+        default: v1.0.0-alpha
+        type: string
+  # push:
+  #   tags:
+  #     - 'v*'
+  #   # branches:
+  #   #   - dm/** # for testing.
+
+permissions:
+  contents: write
+
+jobs:
+
+  build-linux-x86:
+    uses: ./.github/workflows/build-test-core-x86.yml
+
+  build-osx-arm64:
+    uses: ./.github/workflows/build-test-osx-arm64.yml
+
+  release:
+    runs-on: ubuntu-latest
+
+    needs:
+      - build-linux-x86
+      - build-osx-arm64
+
+    steps:
+      - name: Download All Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # merge-multiple: true
+          path: artifacts/
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Prepare wheels
+        run: |
+          pushd artifacts/
+          unzip -j ./manylinux-x86-wheel/dist.zip "*.whl"
+          unzip -j ./osx-arm64-wheel/dist.zip "*.whl"
+          ls -R
+          for file in *.whl; do
+            mv "$file" "${file/semgrep-/opengrep-}"
+          done
+          ls -l *.whl
+          popd
+
+      - name: Create or Update Rolling Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ inputs.tag }}
+          name: Rolling Release (Latest Build)
+          draft: true
+          prerelease: true
+          body: |
+            This is a rolling release from `main`.
+          files: |
+            artifacts/*.whl
+          # fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,54 @@
-<!--
-   Unfortunately GitHub doesn't render symlinks as clickable, otherwise
-   this file would be a symlink.
--->
+# Introduction
 
 Thank you for your interest in contributing to the Opengrep source code!
 
-Find contribution guidelines in `CONTRIBUTING.md`.
+Please ensure you have read the `README.md` and `CODE_OF_CONDUCT.md` documents.
+
+# Contribution guidelines
+
+### Semi-linear history with merge commits
+
+We prefer a semi-linear git history with merge commits. This means that PR 
+authors should try to ensure that their branches are rebased on top of the 
+target branch, which in most cases will be `main`.
+
+Therefore, a merge commit is created for every merge, but the branch is only 
+merged if a fast-forward merge is possible. This ensures that if the merge 
+request build succeeded, the target branch build also succeeds after the merge.
+
+As a corrolary of the above: please do not merge `main` into your PR branch.
+
+### Clean and informative commits
+
+Contributors are requested to submit PRs with a well-organised, clean sequence 
+of commits. This ensures that we can trace changes in case of issues and more 
+generally that we can pinpoint when changes have been made.
+
+If a commit is closing an issue, please mention the issue number in the commit 
+message.
+
+When a PR is marked open for review, it is expected that the commit history will 
+be in a clean, informative state. It's ok to rewrite history in _your_ branch 
+while you are working on a PR, assuming all PR authors are synchronised about this 
+kind of operation.
+
+Also, remember that smaller PRs make life easier for everyone and will allow 
+your contributions to be merged in faster.
+
+### Tests
+
+All new features should include appropriate tests, and all CI test workflows 
+must pass.
+
+### Informative PR descriptions
+
+Please ensure that reviewers have all the information needed to evaluate your 
+contribution. 
+
+This includes: 
+
+- a detailed description of what you are contributing; 
+- the justification for the feature or change, for example which issue(s) are 
+  being closed; 
+- when necessary, recommendations to reviewers in order to help them do a good 
+  job in reviewing your contributions.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,15 +45,9 @@ The Semgrep project has two main parts:
 ## Reproducible and standalone build with Docker
 
 The main [`Dockerfile`](Dockerfile) serves as a reference on how to
-build Semgrep for Linux. The usual instructions for building a Docker
+build Opengrep for Linux. The usual instructions for building a Docker
 image apply. It should be:
 
 ```
 $ docker build -t opengrep .
 ```
-
-## Contribution guidelines
-
-Contribution guidelines and developer documentation
-are [available from Semgrep's documentation
-website](https://semgrep.dev/docs/contributing/contributing/).

--- a/README.md
+++ b/README.md
@@ -11,4 +11,200 @@
 
 ### Welcome to Opengrep, a fork of Semgrep, under the LGPL 2.1 license
 This project is a fork of Semgrep, created by Semgrep Inc. Opengrep is not affiliated with or endorsed by Semgrep Inc.
-***
+
+# Opengrep: Fast and Powerful Code Pattern Search
+
+Opengrep is a lightning-fast static analysis tool for searching code patterns with the power of semantic grep. Analyze code at the speed of thought with intuitive pattern matching and customizable rules.
+
+Opengrep supports 30+ languages, including:
+
+Apex · Bash · C · C++ · C# · Clojure · Dart · Dockerfile · Elixir · HTML · Go · Java · JavaScript · JSX · JSON · Julia · Jsonnet · Kotlin · Lisp · Lua · OCaml · PHP · Python · R · Ruby · Rust · Scala · Scheme · Solidity · Swift · Terraform · TypeScript · TSX · YAML · XML · Generic (ERB, Jinja, etc.)
+
+## Installation
+
+Get started in seconds with our pre-built packages. Requires Python 3.7+.
+
+```bash
+# For macOS (Apple Silicon)
+pip install opengrep --no-index --find-links https://github.com/opengrep/opengrep/releases/download/v1.0.0-alpha/opengrep-1.100.0-cp39.cp310.cp311.py39.py310.py311-none-macosx_11_0_arm64.whl
+```
+
+```bash
+# For Linux (x86_64)
+pip install opengrep --no-index --find-links https://github.com/opengrep/opengrep/releases/download/v1.0.0-alpha/opengrep-1.100.0-cp39.cp310.cp311.py39.py310.py311-none-musllinux_1_0_x86_64.manylinux2014_x86_64.whl
+```
+ 
+## Getting started
+
+Create a file with a rule as follows: 
+
+```bash
+───────┬──────────────────────────────────────────────────────────────────
+       │ File: rules/demo-rust-unwrap.yaml
+───────┼──────────────────────────────────────────────────────────────────
+   1   │ rules:
+   2   │ - id: unwrapped-result
+   3   │   pattern: $VAR.unwrap()
+   4   │   message: "Unwrap detected - potential panic risk"
+   5   │   languages: [rust]
+   6   │   severity: WARNING
+───────┴──────────────────────────────────────────────────────────────────
+```
+
+and a file to check: 
+
+```rust
+───────┬──────────────────────────────────────────────────────────────────
+       │ File: code/rust/main.rs
+───────┼──────────────────────────────────────────────────────────────────
+   1   │ fn divide(a: i32, b: i32) -> Result<i32, String> {
+   2   │     if b == 0 {
+   3   │         return Err("Division by zero".to_string());
+   4   │     }
+   5   │     Ok(a / b)
+   6   │ }
+   7   │
+   8   │ fn main() {
+   9   │     let result = divide(10, 0).unwrap(); // Risky unwrap!
+  10   │     println!("Result: {}", result);
+  11   │ }
+───────┴──────────────────────────────────────────────────────────────────
+```
+
+You should now have: 
+
+``` shell
+.
+├── code
+│   └── rust
+│       └── main.rs
+└── rules
+    └── demo-rust-unwrap.yaml
+```
+
+Now run: 
+
+```bash
+❯ opengrep scan -f rules code/rust
+
+┌──────────────┐
+│ Opengrep CLI │
+└──────────────┘
+
+
+Scanning 1 file (only git-tracked) with 1 Code rule:
+
+  CODE RULES
+  Scanning 1 file.
+
+  PROGRESS
+
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    code/rust/main.rs
+    ❯❯ rules.unwrapped-result
+          Unwrap detected - potential panic risk
+
+            9┆ let result = divide(10, 0).unwrap(); // Risky unwrap!
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+
+Ran 1 rule on 1 file: 1 finding.
+```
+
+To obtain SARIF output: 
+
+```bash
+❯ opengrep scan --sarif-output=sarif.json -f rules code
+  ...
+❯ cat sarif.json | jq
+{
+  "version": "2.1.0",
+  "runs": [
+    {
+      "invocations": [
+        {
+          "executionSuccessful": true,
+          "toolExecutionNotifications": []
+        }
+      ],
+      "results": [
+        {
+          "fingerprints": {
+            "matchBasedId/v1": "a0ff5ed82149206a74ee7146b075c8cb9e79c4baf86ff4f8f1c21abea6ced504e3d33bb15a7e7dfa979230256603a379edee524cf6a5fd000bc0ab29043721d8_0"
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "code/rust/main.rs",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "endColumn": 40,
+                  "endLine": 9,
+                  "snippet": {
+                    "text": "    let result = divide(10, 0).unwrap(); // Risky unwrap!"
+                  },
+                  "startColumn": 18,
+                  "startLine": 9
+                }
+              }
+            }
+          ],
+          "message": {
+            "text": "Unwrap detected - potential panic risk"
+          },
+          "properties": {},
+          "ruleId": "rules.unwrapped-result"
+        }
+      ],
+      "tool": {
+        "driver": {
+          "name": "Opengrep OSS",
+          "rules": [
+            {
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "fullDescription": {
+                "text": "Unwrap detected - potential panic risk"
+              },
+              "help": {
+                "markdown": "Unwrap detected - potential panic risk",
+                "text": "Unwrap detected - potential panic risk"
+              },
+              "id": "rules.unwrapped-result",
+              "name": "rules.unwrapped-result",
+              "properties": {
+                "precision": "very-high",
+                "tags": []
+              },
+              "shortDescription": {
+                "text": "Opengrep Finding: rules.unwrapped-result"
+              }
+            }
+          ],
+          "semanticVersion": "1.100.0"
+        }
+      }
+    }
+  ],
+  "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json"
+}
+```
+
+## More
+
+- [Contributing](CONTRIBUTING.md)
+- [Build instructions for developers](INSTALL.md)
+- [License (LGPL-2.1)](LICENSE)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -61,9 +61,7 @@ else:
 
 if IS_WINDOWS and not SEMGREP_FORCE_INSTALL:
     raise Exception(
-        "Semgrep does not support Windows yet, please try again with WSL "
-        "or visit the following for more information: "
-        "https://github.com/semgrep/semgrep/issues/1330"
+        "Opengrep does not support Windows yet, please try again with WSL."
     )
 
 try:
@@ -111,6 +109,7 @@ install_requires = [
     # coupling: if you add a dep here, it would be appreciated if you could add
     # it to the top level flake.nix file as well, in
     # pysemgrep.propagatedBuildInputs
+    # NOTE: maybe add here `protobuf` and `jaraco`.
     "attrs>=21.3",
     "boltons~=21.0",
     "click-option-group~=0.5",
@@ -141,12 +140,13 @@ setuptools.setup(
     version="1.100.0",
     author="Semgrep Inc.",
     author_email="support@semgrep.com",
+    # TODO: Edit this?
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",
     cmdclass=cmdclass,
     install_requires=install_requires,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/returntocorp/semgrep",
+    url="https://github.com/opengrep/opengrep",
     # creates a .exe wrapper on windows
     entry_points={
         "console_scripts": [

--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -13,6 +13,8 @@ python3 -m pip install --upgrade pip
 # Need latest versions here otherwise we end up with a malformed package where
 # it marks the README as an RST file which fails to parse.
 python3 -m pip install --upgrade setuptools wheel twine
+# NOTE: https://packaging.python.org/en/latest/discussions/setup-py-deprecated/
+# So we should do `python3 -m build`.
 cd cli && python3 setup.py sdist bdist_wheel "$@"
 
 # Do some sanity checks on the built packages. These checks are done as part of

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -119,7 +119,7 @@ let rule hide_nudge (rule_id, rule) : Sarif.reporting_descriptor =
     match JSON.member "shortDescription" metadata with
     | Some (JSON.String shortDescription) -> shortDescription
     | Some _ -> raise Impossible
-    | None -> spf "Semgrep Finding: %s" (Rule_ID.to_string rule_id)
+    | None -> spf "Opengrep Finding: %s" (Rule_ID.to_string rule_id)
   and source =
     match JSON.member "source" metadata with
     | Some (JSON.String source) -> Some source
@@ -157,7 +157,7 @@ let rule hide_nudge (rule_id, rule) : Sarif.reporting_descriptor =
   let text_suffix = if hide_nudge then "" else nudge_plaintext in
   let markdown_interstitial = if hide_nudge then "" else nudge_md in
   let references =
-    Option.to_list (Option.map (fun s -> spf "[Semgrep Rule](%s)" s) source)
+    Option.to_list (Option.map (fun s -> spf "[Opengrep Rule](%s)" s) source)
   in
   let other_references =
     match JSON.member "references" metadata with
@@ -198,7 +198,7 @@ let rule hide_nudge (rule_id, rule) : Sarif.reporting_descriptor =
 let sarif_fixes (cli_match : Out.cli_match) : Sarif.fix list option =
   let* fixed_lines = cli_match.extra.fixed_lines in
   let description_text =
-    spf "%s\n Autofix: Semgrep rule suggested fix" cli_match.extra.message
+    spf "%s\n Autofix: Opengrep rule suggested fix" cli_match.extra.message
   in
   let fix =
     let artifact_change =
@@ -402,7 +402,7 @@ let sarif_output hrules (cli_output : Out.cli_output)
     let tool =
       let driver =
         Sarif.create_tool_component
-          ~name:(spf "Semgrep %s" engine_label)
+          ~name:(spf "Opengrep %s" engine_label)
           ~semantic_version:Version.version ?rules ()
       in
       Sarif.create_tool ~driver ()


### PR DESCRIPTION
### Changes

- Adds a workflow that produces a draft release with python wheels for mac osx (arm) and linux (manylinux x86).
  - The workflow can be dispatched manually; 
  - The workflow triggers when there is anything looking like a release tag.
- Adapts README and other documents.
- Fixes SARIF output so that it prints "Opengrep".

NOTE: If we merge this we should make public the draft release produced with a tag `v1.0.0-alpha`.