### PR TITLE
Fix rolling release artifact prep step

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -46,10 +46,6 @@ jobs:
           pushd artifacts/
           unzip -j ./manylinux-x86-wheel/dist.zip "*.whl"
           unzip -j ./osx-arm64-wheel/dist.zip "*.whl"
-          ls -R
-          for file in *.whl; do
-            mv "$file" "${file/semgrep-/opengrep-}"
-          done
           ls -l *.whl
           popd
 


### PR DESCRIPTION
We don not need to rename the wheels any more.