### PR TITLE
Python 3.13 compatible  wheels

### DIFF
--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -90,7 +90,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: opengrep-core-x86-artifact
+          name: opengrep-core-x86
           path: artifacts.tgz
 
   build-musllinux-x86:
@@ -109,7 +109,7 @@ jobs:
           apk add --no-cache zip python3 py3-pip py3-virtualenv python3-dev gcc musl-dev
       - uses: actions/download-artifact@v4
         with:
-          name: opengrep-core-x86-artifact
+          name: opengrep-core-x86
       - run: |
           tar xf artifacts.tgz
           cp artifacts/opengrep-core cli/src/semgrep/bin

--- a/.github/workflows/build-test-manylinux-x86.yml
+++ b/.github/workflows/build-test-manylinux-x86.yml
@@ -36,7 +36,7 @@ jobs:
           alternatives --auto python3
       - uses: actions/download-artifact@v4
         with:
-          name: opengrep-core-x86-artifact
+          name: opengrep-core-x86
       - run: |
           tar xf artifacts.tgz
           cp artifacts/opengrep-core cli/src/semgrep/bin

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Opengrep is open to any individual or organization to leverage and contribute, [
 
 # Opengrep: Fast and Powerful Code Pattern Search
 
-Opengrep is an ultra-fast static analysis tool for searching code patterns with the power of semantic grep. Analyze large code bases at the speed of thought with intuitive pattern matching and customizable rules. Fix and fix security vulnerabilities, fast– ship more secure code.
+Opengrep is an ultra-fast static analysis tool for searching code patterns with the power of semantic grep. Analyze large code bases at the speed of thought with intuitive pattern matching and customizable rules. Find and fix security vulnerabilities, fast – ship more secure code.
 
 Opengrep supports 30+ languages, including:
 
@@ -31,7 +31,7 @@ Apex · Bash · C · C++ · C# · Clojure · Dart · Dockerfile · Elixir · HTM
 
 ## Installation
 
-Get started in seconds with our pre-built packages. Requires Python 3.7+.
+Get started in seconds with our pre-built packages. Requires Python 3.9+.
 
 ```bash
 # For macOS (Apple Silicon)

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ Get started in seconds with our pre-built packages. Requires Python 3.9+.
 
 ```bash
 # For macOS (Apple Silicon)
-pip install opengrep --find-links https://github.com/opengrep/opengrep/releases/download/v1.0.0-alpha.1/opengrep-1.0.0a1-cp39.cp310.cp311.py39.py310.py311-none-macosx_11_0_arm64.whl
+pip install opengrep --find-links https://github.com/opengrep/opengrep/releases/download/v1.0.0-alpha.2/opengrep-1.0.0a1-cp39.cp310.cp311.cp312.cp313.py39.py310.py311.py312.py313-none-macosx_11_0_arm64.whl
 ```
 
 ```bash
 # For Linux (x86_64)
-pip install opengrep --find-links https://github.com/opengrep/opengrep/releases/download/v1.0.0-alpha.1/opengrep-1.0.0a1-cp39.cp310.cp311.py39.py310.py311-none-musllinux_1_0_x86_64.manylinux2014_x86_64.whl
+pip install opengrep --find-links https://github.com/opengrep/opengrep/releases/download/v1.0.0-alpha.2/opengrep-1.0.0a1-cp39.cp310.cp311.cp312.cp313.py39.py310.py311.py312.py313-none-musllinux_1_0_x86_64.manylinux2014_x86_64.whl
 ```
  
 ## Getting started

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -39,7 +39,7 @@ if WHEEL_CMD in sys.argv:
             # and a few workflows as show for example in this PR:
             # https://github.com/semgrep/semgrep-proprietary/pull/2606/files
             # coupling: semgrep.libsonnet default_python_version
-            python = "cp39.cp310.cp311.py39.py310.py311"
+            python = "cp39.cp310.cp311.cp312.cp313.py39.py310.py311.py312.py313"
 
             # We don't require a specific Python ABI
             abi = "none"


### PR DESCRIPTION
### Changes

- Generate python wheels with tags up to Python 3.13

NOTE: In the (near?) future we should start to use [cibuildwheel](https://github.com/pypa/cibuildwheel)