### PR TITLE
Create PyInstaller binaries

### DIFF
--- a/.github/workflows/build-manylinux-binary-x86.yml
+++ b/.github/workflows/build-manylinux-binary-x86.yml
@@ -1,0 +1,109 @@
+name: build-manylinux-binary-x86
+on:
+  workflow_call: null
+  workflow_dispatch: null
+
+jobs:
+
+  build-self-contained-manylinux-binary:
+    # NOTE: The image below has GLIBC 2.28, but there are others for even older version.
+    # See: https://github.com/pypa/manylinux
+    container:
+      image: quay.io/pypa/manylinux_2_28_x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - run: yum install -y zip
+          
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - uses: actions/download-artifact@v4
+        with:
+          name: manylinux-x86-wheel
+
+      # - name: Install GitHub CLI
+      #   run: |
+      #     # Install yum-utils if not already installed
+      #     type -p yum-config-manager >/dev/null || yum install -y yum-utils
+
+      #     # Add GitHub CLI repository
+      #     yum-config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+
+      #     # Install GitHub CLI
+      #     yum install -y gh
+
+      # - name: Authenticate GitHub CLI
+      #   run: |
+      #     gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      # - name: Get Latest Successful Run ID
+      #   id: get-run-id
+      #   run: |
+      #     # Fetch the latest successful run ID for the workflow
+      #     RUN_ID=$(gh run list --repo opengrep/opengrep --workflow build-test-core-x86 --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+      #     echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
+      # - name: Output Run ID
+      #   run: |
+      #     echo "The latest successful run ID is: ${{ steps.get-run-id.outputs.run_id }}"
+
+      # - name: Download Artifact
+      #   run: |
+      #     gh run download ${{ steps.get-run-id.outputs.run_id }} \
+      #       -R opengrep/opengrep -n manylinux-x86-wheel
+          
+      - run: unzip dist.zip
+
+      - name: install pyinstaller
+        run: |
+          /opt/python/cp312-cp312/bin/pip install pyinstaller
+          # python3 -m pip install pyinstaller
+      - name: install package
+        run: |
+          /opt/python/cp312-cp312/bin/pip install dist/*.whl --target ./_opengrepinstall
+          # python3 -m pip install dist/*.whl --target ./_opengrepinstall
+
+      - name: Create executable
+        run: |
+          export PATH=/opt/python/cp312-cp312/bin:$PATH
+          export LD_LIBRARY_PATH=/__t/Python/3.12.8/x64/lib/:$LD_LIBRARY_PATH
+
+          { echo '#!/usr/bin/env python3'; cat ./_opengrepinstall/semgrep/main.py; echo 'sys.exit(main())';} > tempfile
+
+          mv tempfile ./_opengrepinstall/semgrep/main.py
+
+          cp ./_opengrepinstall/semgrep/main.py ./_opengrepinstall/semgrep/__main__.py
+
+          cat ./_opengrepinstall/semgrep/main.py
+
+          # Package Opengrep using PyInstaller 
+
+          pip install --upgrade setuptools
+          pip install protobuf
+
+          cp cli/spec/opengrep.spec .
+
+          pyinstaller opengrep.spec
+          
+      - name: Zip artifact
+        run: zip -j opengrep.zip dist/opengrep
+      
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opengrep_manylinux_binary_x86_64
+          path: opengrep.zip
+
+  test-manylinux-binary:
+    needs: build-self-contained-manylinux-binary
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: opengrep_manylinux_binary_x86_64
+      - run: unzip opengrep.zip
+      - run: chmod +x opengrep
+      - run: |
+          ./opengrep --version
+      - run: |
+          echo '1 == 1' | ./opengrep -l python -e '$X == $X' -

--- a/.github/workflows/build-osx-binary-arm64.yml
+++ b/.github/workflows/build-osx-binary-arm64.yml
@@ -1,0 +1,80 @@
+name: build-osx-binary-arm64
+on:
+  workflow_call: null
+  workflow_dispatch: null
+
+jobs:
+
+  build-self-contained-osx-binary:
+    runs-on: macos-13-xlarge
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install pipenv
+        run: |
+          python -m pip install --no-cache-dir --upgrade pipenv
+      - name: Install pyinstaller
+        run: pipenv run pip install pyinstaller protobuf
+      
+      - uses: actions/download-artifact@v4
+        with:
+          name: osx-arm64-wheel
+
+      # - name: Authenticate GitHub CLI
+      #   run: |
+      #     gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      # - name: Get Latest Successful Run ID
+      #   id: get-run-id
+      #   run: |
+      #     # Fetch the latest successful run ID for the workflow
+      #     RUN_ID=$(gh run list --repo opengrep/opengrep --workflow build-test-osx-arm64 --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+      #     echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
+      # - name: Output Run ID
+      #   run: |
+      #     echo "The latest successful run ID is: ${{ steps.get-run-id.outputs.run_id }}"
+
+      # - name: Download Artifact
+      #   run: |
+      #     gh run download ${{ steps.get-run-id.outputs.run_id }} \
+      #       -R opengrep/opengrep -n osx-arm64-wheel
+          
+      - run: unzip dist.zip
+
+      - name: install package
+        run: pipenv run pip install dist/*.whl --target ./_opengrepinstall
+      - name: Rename file 
+        run: |
+          { echo '#!/usr/bin/env python3'; cat ./_opengrepinstall/semgrep/main.py; echo 'sys.exit(main())';} > tempfile
+          mv tempfile ./_opengrepinstall/semgrep/main.py
+          cp ./_opengrepinstall/semgrep/main.py ./_opengrepinstall/semgrep/__main__.py
+          cat ./_opengrepinstall/semgrep/main.py
+
+      - name: Build executable
+        run: |
+          cp cli/spec/opengrep.spec .
+          pipenv run pyinstaller opengrep.spec
+
+      - name: Zip artifact
+        run: zip -j opengrep.zip dist/opengrep
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opengrep_osx_binary_arm64
+          path: opengrep.zip 
+
+  test-osx-binary:
+    needs: build-self-contained-osx-binary
+    runs-on: macos-13-xlarge
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: opengrep_osx_binary_arm64
+      - run: unzip opengrep.zip
+      - run: chmod +x opengrep 
+      - run: |
+          ./opengrep --version
+      - run: |
+          echo '1 == 1' | ./opengrep -l python -e '$X == $X' -

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -5,13 +5,8 @@ on:
       tag:
         description: the tag to use
         required: true
-        default: v1.0.0-alpha
+        # default: v1.0.0-alpha
         type: string
-  # push:
-  #   tags:
-  #     - 'v*'
-  #   # branches:
-  #   #   - dm/** # for testing.
 
 permissions:
   contents: write
@@ -24,12 +19,22 @@ jobs:
   build-osx-arm64:
     uses: ./.github/workflows/build-test-osx-arm64.yml
 
+  build-linux-binary-x86:
+    needs: build-linux-x86
+    uses: ./.github/workflows/build-manylinux-binary-x86.yml
+
+  build-osx-binary-arm64:
+    needs: build-osx-arm64
+    uses: ./.github/workflows/build-osx-binary-arm64.yml
+    
   release:
     runs-on: ubuntu-latest
 
     needs:
-      - build-linux-x86
-      - build-osx-arm64
+      - build-linux-x86 # redundant
+      - build-linux-binary-x86
+      - build-osx-arm64 # redundant
+      - build-osx-binary-arm64
 
     steps:
       - name: Download All Artifacts
@@ -41,12 +46,21 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R
 
-      - name: Prepare wheels
+      - name: Prepare wheels and binaries
         run: |
           pushd artifacts/
+
           unzip -j ./manylinux-x86-wheel/dist.zip "*.whl"
           unzip -j ./osx-arm64-wheel/dist.zip "*.whl"
-          ls -l *.whl
+
+          unzip ./opengrep_manylinux_binary_x86_64/opengrep.zip -d ./opengrep_manylinux_binary_x86_64
+          pushd opengrep_manylinux_binary_x86_64; mv opengrep opengrep_manylinux_x86; popd
+          ls -l opengrep_manylinux_binary_x86_64
+
+          unzip ./opengrep_osx_binary_arm64/opengrep.zip -d ./opengrep_osx_binary_arm64
+          pushd opengrep_osx_binary_arm64; mv opengrep opengrep_osx_arm64; popd
+          ls -l opengrep_osx_binary_arm64
+
           popd
 
       - name: Create or Update Rolling Release
@@ -60,6 +74,8 @@ jobs:
             This is a rolling release from `main`.
           files: |
             artifacts/*.whl
+            artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86
+            artifacts/opengrep_osx_binary_arm64/opengrep_osx_arm64
           # fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!cli/spec/opengrep.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Apex · Bash · C · C++ · C# · Clojure · Dart · Dockerfile · Elixir · HTM
 
 ## Installation
 
-binary releases coming soon
+Binaries available in the latest alpha [release](https://github.com/opengrep/opengrep/releases).
  
 ## Getting started
 

--- a/cli/spec/opengrep.spec
+++ b/cli/spec/opengrep.spec
@@ -1,0 +1,79 @@
+# -*- mode: python ; coding: utf-8 -*-
+datas = []
+datas += [("semgrepinstall/semgrep/semgrep_interfaces", "semgrep/semgrep_interfaces")]
+datas += [("semgrepinstall/semgrep/templates", "semgrep/templates")]
+
+binaries = [("semgrepinstall/semgrep/bin", "semgrep/bin")]
+
+a = Analysis(
+    ['semgrepinstall/semgrep/main.py'],
+    pathex=[],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=[
+        'jaraco',
+        'google.protobuf'
+        # 'attrs', 
+        # 'boltons', 
+        # 'click-option-group', 
+        # 'click', 
+        # 'colorama', 
+        # 'defusedxml', 
+        # 'exceptiongroup', 
+        # 'glom', 
+        # 'jsonschema', 
+        # 'opentelemetry-api', 
+        # 'opentelemetry-sdk', 
+        # 'opentelemetry-exporter-otlp-proto-http', 
+        # 'opentelemetry-instrumentation-requests', 
+        # 'packaging', 
+        # 'peewee', 
+        # 'requests', 
+        # 'rich', 
+        # 'ruamel.yaml', 
+        # 'tomli', 
+        # 'typing-extensions', 
+        # 'urllib3', 
+        # 'wcmatch'
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=2
+)
+pyz = PYZ(a.pure)
+
+# Optimised interpreter.
+options = [('O', None, 'OPTION')]
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    # [],
+    options,
+    # exclude_binaries=True,
+    name='opengrep',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False, # True is not recommended for Windows.
+    upx=False, # True is only used in Windows it seems.
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+# coll = COLLECT(
+#     exe,  # Executable
+#     a.binaries,  # Binary files
+#     a.datas,  # Data files
+#     name='opengrep',  # Name of the output directory
+# )

--- a/cli/spec/opengrep.spec
+++ b/cli/spec/opengrep.spec
@@ -1,12 +1,12 @@
 # -*- mode: python ; coding: utf-8 -*-
 datas = []
-datas += [("semgrepinstall/semgrep/semgrep_interfaces", "semgrep/semgrep_interfaces")]
-datas += [("semgrepinstall/semgrep/templates", "semgrep/templates")]
+datas += [("_opengrepinstall/semgrep/semgrep_interfaces", "semgrep/semgrep_interfaces")]
+datas += [("_opengrepinstall/semgrep/templates", "semgrep/templates")]
 
-binaries = [("semgrepinstall/semgrep/bin", "semgrep/bin")]
+binaries = [("_opengrepinstall/semgrep/bin", "semgrep/bin")]
 
 a = Analysis(
-    ['semgrepinstall/semgrep/main.py'],
+    ['_opengrepinstall/semgrep/main.py'],
     pathex=[],
     binaries=binaries,
     datas=datas,


### PR DESCRIPTION
### Changes

- Adds new workflows that create PyInstaller binaries for osx (arm64) and linux (x86, GLIBC based).
- Adapts the rolling release workflow to produce the binaries and to add them to the alpha release artifacts.
- Edits README.md to provide a link to the release page.