### PR TITLE
Workflow: create PyInstaller win64 binary

### DIFF
--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -15,6 +15,10 @@ on:
   workflow_call: null
   workflow_dispatch: null
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-core:

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -17,7 +17,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
 

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -15,9 +15,9 @@ on:
   workflow_call: null
   workflow_dispatch: null
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
 

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -22,6 +22,10 @@ on:
         required: true
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-core:

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -24,7 +24,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
 

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -22,9 +22,9 @@ on:
         required: true
         type: boolean
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
 

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: ocaml/setup-ocaml@v3
+      - uses: ocaml/setup-ocaml@v3.2.4 # This is not super cool, but c'est la vie.
         with:
           ocaml-compiler: 5.2.1
           opam-local-packages: dont_install_local_packages.opam

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -212,5 +212,4 @@ jobs:
       - name: test package
         run: opengrep --version
       - name: e2e opengrep-core test
-        # TODO: This fails only on the Windows workflow, investigate.
-        run: echo '1 == 1' | opengrep -l python -e '$X == $X' -
+        run: echo '1 == 1' | opengrep -v -l python -e '$X == $X' -

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Add extra cygwin packages
         shell: pwsh
         # NOTE: The openssl install is a hack but it's needed... for now.
-        run: C:\hostedtoolcache\windows\cygwin\3.5.5\x86_64\setup-x86_64.exe --packages=mingw64-x86_64-curl,mingw64-x86_64-gmp,mingw64-x86_64-pcre,mingw64-x86_64-pcre2,mingw64-x86_64-openssl=1.0.2u+za-1 --quiet-mode --root=D:\cygwin --site=https://mirrors.kernel.org/sourceware/cygwin/ --symlink-type=sys
+        run: C:\hostedtoolcache\windows\cygwin\3.5.6\x86_64\setup-x86_64.exe --packages=mingw64-x86_64-curl,mingw64-x86_64-gmp,mingw64-x86_64-pcre,mingw64-x86_64-pcre2,mingw64-x86_64-openssl=1.0.2u+za-1 --quiet-mode --root=D:\cygwin --site=https://mirrors.kernel.org/sourceware/cygwin/ --symlink-type=sys
 
       # FIXME: This fails when the extra _opam cache is restored.
       # - name: Restore GHA cache for OPAM in _opam

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -26,6 +26,10 @@ on:
         required: true
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build-core:

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -26,9 +26,9 @@ on:
         required: true
         type: boolean
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'push' }}
+# concurrency:
+#   group: ${{ github.workflow }}-${{ github.ref }}
+#   cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
 

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -28,7 +28,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'push' }}
 
 jobs:
 

--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -1,0 +1,89 @@
+
+name: build-windows-binary-x86
+on:
+  workflow_call: null
+  workflow_dispatch: null
+
+jobs:
+
+  build-self-contained-windows-binary:
+    defaults:
+      run:
+        shell: bash
+    runs-on: windows-latest
+    steps:
+      - name: Create BASH_ENV configuration
+        shell: bash
+        run: >-
+          echo "set -o igncr" >> bash_env.sh;
+          echo "set -eo pipefail" >> bash_env.sh
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install setuptools with --upgrade
+        run: pip3 install --upgrade setuptools
+      - name: Install pyinstaller
+        run: pip3 install pyinstaller protobuf
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: windows-x86-wheel
+
+      # - name: Authenticate GitHub CLI
+      #   run: |
+      #     gh auth login --with-token <<< "${{ secrets.GITHUB_TOKEN }}"
+
+      # - name: Get Latest Successful Run ID
+      #   id: get-run-id
+      #   run: |
+      #     # Fetch the latest successful run ID for the workflow
+      #     RUN_ID=$(gh run list --repo opengrep/opengrep --workflow build-test-windows-x86 --status success --limit 1 --json databaseId --jq '.[0].databaseId')
+      #     echo "run_id=$RUN_ID" >> $GITHUB_OUTPUT
+
+      # - name: Output Run ID
+      #   run: |
+      #     echo "The latest successful run ID is: ${{ steps.get-run-id.outputs.run_id }}"
+
+      # - name: Download Artifact
+      #   run: |
+      #     gh run download ${{ steps.get-run-id.outputs.run_id }} \
+      #       -R opengrep/opengrep -n windows-x86-wheel
+          
+      - run: tar -xvzf dist.tgz
+
+      - name: Install package
+        run: pip3 install dist/*.whl --target ./_opengrepinstall
+      - name: Rename file 
+        run: |
+          { echo '#!/usr/bin/env python3'; cat ./_opengrepinstall/semgrep/main.py; echo 'sys.exit(main())';} > tempfile
+          mv tempfile ./_opengrepinstall/semgrep/main.py
+          cp ./_opengrepinstall/semgrep/main.py ./_opengrepinstall/semgrep/__main__.py
+          cat ./_opengrepinstall/semgrep/main.py
+
+      - name: Build executable
+        run: |
+          cp cli/spec/opengrep.spec .
+          pyinstaller opengrep.spec
+
+      - run: cp dist/opengrep opengrep.exe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: opengrep_windows_binary_x86
+          path: opengrep.exe 
+
+  test-windows-binary:
+    defaults:
+      run:
+        shell: bash
+    needs: build-self-contained-windows-binary
+    runs-on: windows-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: opengrep_windows_binary_x86
+      - run: chmod +x opengrep.exe 
+      - run: time ./opengrep.exe --version
+      - run: echo '1 == 1' | ./opengrep.exe -v -j 1 -l python -e '$X == $X' -

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -5,7 +5,6 @@ on:
       tag:
         description: the tag to use
         required: true
-        # default: v1.0.0-alpha
         type: string
 
 permissions:
@@ -19,6 +18,9 @@ jobs:
   build-osx-arm64:
     uses: ./.github/workflows/build-test-osx-arm64.yml
 
+  build-windows-x86:
+    uses: ./.github/workflows/build-test-windows-x86.yml
+
   build-linux-binary-x86:
     needs: build-linux-x86
     uses: ./.github/workflows/build-manylinux-binary-x86.yml
@@ -26,6 +28,10 @@ jobs:
   build-osx-binary-arm64:
     needs: build-osx-arm64
     uses: ./.github/workflows/build-osx-binary-arm64.yml
+
+  build-windows-binary-x86:
+    needs: build-windows-x86
+    uses: ./.github/workflows/build-windows-binary-x86.yml
     
   release:
     runs-on: ubuntu-latest
@@ -35,6 +41,8 @@ jobs:
       - build-linux-binary-x86
       - build-osx-arm64 # redundant
       - build-osx-binary-arm64
+      - build-windows-x86 # redundant
+      - build-windows-binary-x86
 
     steps:
       - name: Download All Artifacts
@@ -61,6 +69,8 @@ jobs:
           pushd opengrep_osx_binary_arm64; mv opengrep opengrep_osx_arm64; popd
           ls -l opengrep_osx_binary_arm64
 
+          pushd opengrep_windows_binary_x86; mv opengrep.exe opengrep_windows_x86.exe; popd
+
           popd
 
       - name: Create or Update Rolling Release
@@ -72,10 +82,11 @@ jobs:
           prerelease: true
           body: |
             This is a rolling release from `main`.
+            Note that the Windows version is not yet functional.
           files: |
             artifacts/*.whl
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86
             artifacts/opengrep_osx_binary_arm64/opengrep_osx_arm64
-          # fail_on_unmatched_files: true
+            artifacts/opengrep_windows_binary_x86/opengrep_windows_x86.exe
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes

- New workflow that creates PyInstaller onefile Windows binary from wheel. 
- Adaptations to rolling release workflow to also publish that binary.

Note: the Windows binary is not ready for general use yet, because of unresolved issues.