### PR TITLE
Making it so that the URLs dont get normalised

### DIFF
--- a/libs/commons/Uri_.ml
+++ b/libs/commons/Uri_.ml
@@ -26,3 +26,8 @@
 let of_string_opt (str : string) : Uri.t option =
   let uri = Uri.of_string str in
   if Uri.equal uri Uri.empty then None else Some uri
+
+
+let url_regex = Pcre2_.regexp "^https?://"
+let is_url config_path = 
+  Pcre2_.pmatch_noerr ~rex:url_regex config_path

--- a/libs/commons/Uri_.mli
+++ b/libs/commons/Uri_.mli
@@ -2,3 +2,9 @@
  * empty uri in case of error, we return None here.
  *)
 val of_string_opt : string -> Uri.t option
+
+(* Checks if the string starts with 'http://' or 'https://'
+ * Returns true only for valid HTTP(S) URL prefixes.
+ * Note: This only validates the scheme prefix, not the full URL structure.
+ *)
+val is_url : string -> bool

--- a/src/osemgrep/language_server/server/Session.ml
+++ b/src/osemgrep/language_server/server/Session.ml
@@ -279,12 +279,15 @@ let fetch_rules session =
   in
   let home = !Semgrep_envvars.v.user_home_dir in
   let rules_source =
-    session.user_settings.configuration |> List_.map Fpath.v
-    |> List_.map Fpath.normalize
-    |> List_.map (fun f ->
-           let p = Fpath.rem_prefix (Fpath.v "~/") f in
-           Option.bind p (fun f -> Some (home // f)) |> Option.value ~default:f)
-    |> List_.map Fpath.to_string
+    session.user_settings.configuration
+    |> List_.map (fun config_path ->
+      if Uri_.is_url config_path then
+        config_path
+      else
+        let f = Fpath.v config_path |> Fpath.normalize in
+        let p = Fpath.rem_prefix (Fpath.v "~/") f in
+        Option.value ~default:f (Option.map (fun f -> home // f) p)
+        |> Fpath.to_string)
   in
   let rules_source =
     if rules_source = [] && ci_rules = None then (


### PR DESCRIPTION
Same as https://github.com/semgrep/semgrep/pull/10798 

Currently, there exists an issue in the Language Server that when a URL is used for configuration it is normalised and as such
// is normalised to / which results in errors.

As can be seen here: https://github.com/semgrep/semgrep-vscode/issues/181