### PR TITLE
Update cygwin version in workflow

### DIFF
--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           submodules: true
 
-      - uses: ocaml/setup-ocaml@v3.2.4 # This is not super cool, but c'est la vie.
+      - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: 5.2.1
           opam-local-packages: dont_install_local_packages.opam
@@ -51,7 +51,7 @@ jobs:
       - name: Add extra cygwin packages
         shell: pwsh
         # NOTE: The openssl install is a hack but it's needed... for now.
-        run: C:\hostedtoolcache\windows\cygwin\3.5.6\x86_64\setup-x86_64.exe --packages=mingw64-x86_64-curl,mingw64-x86_64-gmp,mingw64-x86_64-pcre,mingw64-x86_64-pcre2,mingw64-x86_64-openssl=1.0.2u+za-1 --quiet-mode --root=D:\cygwin --site=https://mirrors.kernel.org/sourceware/cygwin/ --symlink-type=sys
+        run: C:\hostedtoolcache\windows\cygwin\3.5.7\x86_64\setup-x86_64.exe --packages=mingw64-x86_64-curl,mingw64-x86_64-gmp,mingw64-x86_64-pcre,mingw64-x86_64-pcre2,mingw64-x86_64-openssl=1.0.2u+za-1 --quiet-mode --root=D:\cygwin --site=https://mirrors.kernel.org/sourceware/cygwin/ --symlink-type=sys
 
       # FIXME: This fails when the extra _opam cache is restored.
       # - name: Restore GHA cache for OPAM in _opam


### PR DESCRIPTION
This is a temporary fix, we will create a custom workflow without
`setup-ocaml` as soon as possible, to improve caching.