### PR TITLE
Use OCaml 5.3.0

### DIFF
--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - linux/**
-      # - dm/linux-static-build-workflow # branch where this change was introduced
     paths-ignore:
       - '**.md'
   pull_request:
@@ -22,8 +21,11 @@ on:
 jobs:
 
   build-core:
+    strategy:
+      matrix:
+        ocaml_version: ["5.3.0"]
     container:
-      image: ocamlpro/ocaml:5.2.1
+      image: ocamlpro/ocaml:${{ matrix.ocaml_version }}
       # NOTE: Can also match the UID between Alpine and Ubuntu users, removing `--user root`.
       # See: https://github.com/actions/checkout/issues/956.
       # But this suggest to run as root: https://docs.github.com/en/enterprise-server@3.12/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user
@@ -53,7 +55,7 @@ jobs:
       - name: Set GHA cache for OPAM 
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-${{ hashFiles('semgrep.opam') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('semgrep.opam') }}
           path: _opam
 
       - name: Create switch

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -29,6 +29,9 @@ on:
 jobs:
 
   build-core:
+    strategy:
+      matrix:
+        ocaml_version: ["5.3.0"]
     runs-on: macos-13-xlarge # NOTE: For intel, we need macos-13-large it seems.
     steps:
       - uses: actions/setup-python@v4
@@ -46,10 +49,10 @@ jobs:
         name: Set GHA cache for OPAM in ~/.opam
         uses: actions/cache@v4
         with:
-          key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-${{ hashFiles('semgrep.opam') }}
+          key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('semgrep.opam') }}
           path: ~/.opam
       - name: Install dependencies
-        run: ./scripts/osx-setup-for-release.sh "5.2.1"
+        run: ./scripts/osx-setup-for-release.sh ${{ matrix.ocaml_version }}
       - name: Compile opengrep
         run: opam exec -- make core
       - name: Test opengrep-core

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -35,12 +35,14 @@ env:
   OPAMROOT: D:/.opam
   DUNE_CACHE_ROOT: D:/dune
   OPAMCONFIRMLEVEL: unsafe-yes
-  OCAML_VERSION: "5.2.1"
   OPAM_VERSION: "2.3.0"
 
 jobs:
 
   build-core:
+    strategy:
+      matrix:
+        ocaml_version: ["5.3.0"]
     # defaults:
     #   run:
     #     shell: bash
@@ -117,22 +119,22 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.DUNE_CACHE_ROOT }}
-          key: dune-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-${{ github.run_id }}
-          restore-keys: dune-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-
+          key: dune-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ github.run_id }}
+          restore-keys: dune-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-
       
       - name: Restore _opam
         id: cache-opam-win32-64
         uses: actions/cache/restore@v4
         with:
           path: _opam
-          key: opam-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-${{ hashFiles('*.opam') }}
+          key: opam-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('*.opam') }}
 
       - name: Restore OPAM_ROOT
         id: cache-opamroot-win32-64
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.OPAMROOT }} # C:\Users\runneradmin\AppData\Local\opam
-          key: opamroot-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-5.2.1-${{ hashFiles('*.opam') }}
+          key: opamroot-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('*.opam') }}
           
       - name: Install OPAM
         env:
@@ -145,7 +147,7 @@ jobs:
         run: |
           # Define variables
           OPAM_VERSION=${{ env.OPAM_VERSION }}
-          OCAML_VERSION=${{ env.OCAML_VERSION }}
+          OCAML_VERSION=${{ matrix.ocaml_version }}
           OPAM_BIN="opam-${OPAM_VERSION}-x86_64-windows.exe"
           OPAM_SIG="${OPAM_BIN}.sig"
           DOWNLOAD_URL="https://github.com/ocaml/opam/releases/download/${OPAM_VERSION}"
@@ -213,11 +215,10 @@ jobs:
           # OPAMCONFIRMLEVEL: unsafe-yes
           OPAMSOLVERTIMEOUT: 600
           OPAMCOLOR: always
-          # OCAML_VERSION: "5.2.1"
         shell: bash
         if: steps.cache-opam-win32-64.outputs.cache-hit != 'true'
         run: |
-          export OCAML_VERSION=${{ env.OCAML_VERSION  }}
+          export OCAML_VERSION=${{ matrix.ocaml_version }}
           echo "Creating local switch with OCaml $OCAML_VERSION..."
           opam switch --no-install --packages="ocaml-base-compiler.$OCAML_VERSION" create .
 

--- a/dev/optional.opam
+++ b/dev/optional.opam
@@ -14,7 +14,7 @@ depends: [
   # - scripts/lint-ocaml
   # - .github/workflows/lint.yml and its pre-commit-ocaml job
   "feather" # used by hello_script.ml
-  "ocaml-lsp-server" {= "1.15.1-4.14"} # used by the VSCode extension
+  "ocaml-lsp-server" {= "1.22.0"} # used by the VSCode extension
   "earlybird" {= "1.2.1"} # used by the VSCode extension
   "py" "qcheck" "qcheck-alcotest" # used by libs/python-str-repr/test
 ]

--- a/dev/required.opam
+++ b/dev/required.opam
@@ -10,5 +10,5 @@ synopsis: "OCaml dependencies needed in CI"
 depends: [
   #coupling: with scripts/lint-ocaml version
   #coupling: with .github/workflows/lint.jsonnet version
-  "ocamlformat" {= "0.26.2" } # used by the pre-commit hook
+  "ocamlformat" {= "0.27.0" } # used by the pre-commit hook
 ]

--- a/dune-project
+++ b/dune-project
@@ -513,7 +513,7 @@ For more information see https://opengrep.dev.
     parmap
     semver
     (timedesc (>= 2.0.0)) ; used via git-wrapper
-    (lsp (= 1.15.1-5.0))
+    (lsp (= 1.22.0))
     git
     ; tracing
     trace
@@ -541,10 +541,10 @@ For more information see https://opengrep.dev.
     lwt_ppx
     (conf-libev (<> :os win32)) ; for lwt, to get better FD perf
     ; jsoo
-    (js_of_ocaml (= 5.8.2))
-    (js_of_ocaml-compiler (= 5.8.2))
-    (js_of_ocaml-ppx (= 5.8.2))
-    (js_of_ocaml-lwt (= 5.8.2))
+    (js_of_ocaml (= 5.9.1))
+    (js_of_ocaml-compiler (= 5.9.1))
+    (js_of_ocaml-ppx (= 5.9.1))
+    (js_of_ocaml-lwt (= 5.9.1))
     integers_stubs_js
     ;TODO: this is for secrets and should be in ../dune-project but doing so
     ; slows down a lot our CI because it pulls dependencies that seem

--- a/scripts/osx-setup-for-release.sh
+++ b/scripts/osx-setup-for-release.sh
@@ -27,7 +27,7 @@ opam init --no-setup --bare
 # brew uninstall --force semgrep
 brew uninstall --force tree-sitter
 
-SWITCH_NAME="${1:-5.2.1}"
+SWITCH_NAME="${1:-5.3.0}"
 
 #coupling: this should be the same version than in our Dockerfile
 if opam switch "${SWITCH_NAME}" 2>/dev/null; then

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -81,10 +81,10 @@ depends: [
   "lwt"
   "lwt_ppx"
   "conf-libev" {os != "win32"}
-  "js_of_ocaml" {= "5.8.2"}
-  "js_of_ocaml-compiler" {= "5.8.2"}
-  "js_of_ocaml-ppx" {= "5.8.2"}
-  "js_of_ocaml-lwt" {= "5.8.2"}
+  "js_of_ocaml" {= "5.9.1"}
+  "js_of_ocaml-compiler" {= "5.9.1"}
+  "js_of_ocaml-ppx" {= "5.9.1"}
+  "js_of_ocaml-lwt" {= "5.9.1"}
   "integers_stubs_js"
   "git-unix"
   "odoc" {with-doc}

--- a/semgrep.opam
+++ b/semgrep.opam
@@ -60,7 +60,7 @@ depends: [
   "parmap"
   "semver"
   "timedesc" {>= "2.0.0"}
-  "lsp" {= "1.15.1-5.0"}
+  "lsp" {= "1.22.0"}
   "git"
   "trace"
   "ppx_trace"

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -155,8 +155,8 @@ let trace_of_source source =
     sink_trace = convert_taint_call_trace sink_trace;
   }
 
-let pms_of_effect ~match_on (effect : Effect.t) =
-  match effect with
+let pms_of_effect ~match_on (effect_ : Effect.t) =
+  match effect_ with
   | ToLval _
   | ToReturn _
   | ToSinkInCall _ ->
@@ -259,8 +259,8 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
   in
   let record_matches new_effects =
     new_effects
-    |> Effects.iter (fun effect ->
-           let effect_pms = pms_of_effect ~match_on effect in
+    |> Effects.iter (fun effect_ ->
+           let effect_pms = pms_of_effect ~match_on effect_ in
            matches := List.rev_append effect_pms !matches)
   in
   let {

--- a/src/osemgrep/cli_lsp/Lsp_subcommand.ml
+++ b/src/osemgrep/cli_lsp/Lsp_subcommand.ml
@@ -18,6 +18,8 @@ module Io : RPC_server.LSIO = struct
       (struct
         include Lwt
 
+        type 'a t = 'a Lwt.t
+
         module O = struct
           let ( let* ) x f = Lwt.bind x f
           let ( let+ ) x f = Lwt.map f x
@@ -30,7 +32,9 @@ module Io : RPC_server.LSIO = struct
         type output = Lwt_io.output_channel
 
         let read_line = Lwt_io.read_line_opt
-        let write = Lwt_io.write
+        (* XXX: I'm not 100% sure about this... but tests pass and it seems to be
+         * the reasonable thing to do. *)
+        let write = (fun o s_list -> Lwt_list.iter_s (fun s -> Lwt_io.write o s) s_list)
 
         (* LWT doesn't implement this in a nice way *)
         let read_exactly inc n =

--- a/src/osemgrep/language_server/scan_helpers/Diagnostics.ml
+++ b/src/osemgrep/language_server/scan_helpers/Diagnostics.ml
@@ -37,7 +37,7 @@ let diagnostic_of_match is_intellij (m : OutJ.cli_match) =
   let diagnostic =
     Diagnostic.create
       ~range:(Conv.range_of_cli_match m)
-      ~code ~severity ~source:"Semgrep" ~message
+      ~code ~severity ~source:"Semgrep" ~message:(`String message)
   in
   match codeDescription with
   | None -> diagnostic ()

--- a/src/osemgrep/language_server/server/Lsp_.ml
+++ b/src/osemgrep/language_server/server/Lsp_.ml
@@ -29,6 +29,7 @@ open Lsp
 open Types
 module SR = Server_request
 module SN = Server_notification
+module PR = Progress
 module CR = Client_request
 module CN = Client_notification
 
@@ -130,7 +131,7 @@ let create_progress title message =
   in
   let request, _id = request progress in
   let start =
-    SN.Progress.Begin (WorkDoneProgressBegin.create ~message ~title ())
+    Progress.Begin (WorkDoneProgressBegin.create ~message ~title ())
   in
   let progress = SN.WorkDoneProgress (ProgressParams.create token start) in
   ([ request; notify progress ], token)
@@ -140,7 +141,7 @@ let end_progress token =
   Logs.debug (fun m ->
       m "Ending progress token %s"
         (token |> ProgressToken.yojson_of_t |> Yojson.Safe.pretty_to_string));
-  let end_ = SN.Progress.End (WorkDoneProgressEnd.create ()) in
+  let end_ = Progress.End (WorkDoneProgressEnd.create ()) in
   let progress = SN.WorkDoneProgress (ProgressParams.create token end_) in
   notify progress
 


### PR DESCRIPTION
### Changes

- Bump some dependencies so we can compile with OCaml 5.3.0 
- Apply fixes for (minor) breaking API changes in order to compile.
- Update all workflows to use OCaml 5.3.0.

There are important reasons for this upgrade, as discussed internally. 