### PR TITLE
Make check for bash version case insensitive

### DIFF
--- a/scripts/check-bash-version
+++ b/scripts/check-bash-version
@@ -7,7 +7,7 @@
 #
 set -eu -o pipefail
 
-if ! { bash --version | grep -q 'version [56789]'; }; then
+if ! { bash --version | grep -iq 'version [56789]'; }; then
   cat >&2 <<EOF
 Error: Bash >= 5.0 is required.
 If you're on a Mac, run:


### PR DESCRIPTION
Closes #66 

The reason the `check-bash-version` script didn't work when running `make setup` is because some bash versions have a capitalised v in the output while others don't.

Adding `-i` makes the grep case insensitive to make it worth with both.

