### PR TITLE
Fix windows binary ci e2e smoke test

### DIFF
--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -87,4 +87,7 @@ jobs:
           name: opengrep_windows_binary_x86
       - run: chmod +x opengrep.exe 
       - run: time ./opengrep.exe --version
-      - run: echo '1 == 1' | ./opengrep.exe -v -j 1 -l python -e '$X == $X' -
+      - run: >-
+          chcp 65001;
+          export PYTHONIOENCODING=utf-8;
+          echo '1 == 1' | ./opengrep.exe -v -j 1 -l python -e '$X == $X' -


### PR DESCRIPTION
See commit.

The TL;DR is that it seems to fail to render ┆.