### PR TITLE
Set `PYTHONIOENCODING` to `utf-8` in win binary test

### DIFF
--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -88,6 +88,5 @@ jobs:
       - run: chmod +x opengrep.exe 
       - run: time ./opengrep.exe --version
       - run: >-
-          chcp 65001;
           export PYTHONIOENCODING=utf-8;
           echo '1 == 1' | ./opengrep.exe -v -j 1 -l python -e '$X == $X' -


### PR DESCRIPTION
Try to fix Windows binary workflow that now fails in the final check