### PR TITLE
fix: FromAsCasing in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@
 # semgrep-core. This is done in a multi-stage build so that the final COPY
 # happens in a single layer.
 
-FROM busybox:stable as semgrep-core-files
+FROM busybox:stable AS semgrep-core-files
 WORKDIR /src/semgrep
 
 # copy over the entire semgrep repository
@@ -98,7 +98,7 @@ COPY cli/src/semgrep/semgrep_interfaces cli/src/semgrep/semgrep_interfaces
 #    add a package or we wanted to switch to a different OCaml version.
 #    Being able to control everything from a single Dockerfile is simpler.
 
-FROM alpine:3.19 as semgrep-core-container
+FROM alpine:3.19 AS semgrep-core-container
 
 # Install opam and basic build tools
 RUN apk add --no-cache bash build-base git make opam

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,22 @@
 # Build instructions for developers
 
-## Manual development
+First, clone the repository and fetch the submodules:
 
-Developers should consult the makefiles, which are documented.
+```sh
+$ git clone --recursive https://github.com/opengrep/opengrep 
+```
+if you've already cloned the repository, you can fetch the submodules with:
+```sh
+$ git submodule update --init --recursive
+```
+
+
+## Local development
+
+Developers should consult the `Makefile`s, which are documented.
 The steps to set up and build everything are normally:
 
 ```
-$ git submodule update --init --recursive
 $ make setup       # meant to be run infrequently, may not be sufficient
 $ make             # routine build
 $ make test        # test everything
@@ -46,7 +56,7 @@ The Semgrep project has two main parts:
 
 The main [`Dockerfile`](Dockerfile) serves as a reference on how to
 build Opengrep for Linux. The usual instructions for building a Docker
-image apply. It should be:
+image apply. Once you've cloned the repository and fetched the submodules(see above), it should be:
 
 ```
 $ docker build -t opengrep .


### PR DESCRIPTION
Update Dockerfile's casing to be uppercase so docker build won't crash on newer
docker engine versions
