### PR TITLE
Fix windows: use subprocess and wait, not execvp

### DIFF
--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -425,21 +425,17 @@ jobs:
       - run: tar xzvf dist.tgz
       - name: install package
         run: pip3 install dist/*.whl
-      - name: test package
+      - name: test version output
         run: opengrep --version
       - name: test help output
         run: opengrep --help
+      - name: e2e opengrep-core test
+        run: >-
+          export PYTHONIOENCODING=utf-8;
+          echo '1 == 1' | opengrep -j 1 -l python -e '$X == $X' -
       # Test SARIF output which previously failed on Windows only:
       - uses: actions/checkout@v4
         with:
           submodules: false
       - name: sarif output test
         run: opengrep scan -j 1 --sarif -f tests/windows/rules.yml tests/windows/test.py
-      # NOTE: This fails for some strange reason, not worth too much attention at this moment
-      # because in general the wheel works, modulo known issues unrelated to this. The above
-      # sarif test is enough for the purposes of checking that the wheel can be used to invoke
-      # a scan.
-      # - name: e2e opengrep-core test
-      #   run: >-
-      #     export PYTHONIOENCODING=utf-8;
-      #     echo '1 == 1' | opengrep -v -l python -e '$X == $X' -

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -437,7 +437,7 @@ jobs:
         run: opengrep scan -j 1 --sarif -f tests/windows/rules.yml tests/windows/test.py
       # NOTE: This fails for some strange reason, not worth too much attention at this moment
       # because in general the wheel works, modulo known issues unrelated to this. The above
-      # sarif test is enougn for the purposes of checking that the wheel can be used to invoke
+      # sarif test is enough for the purposes of checking that the wheel can be used to invoke
       # a scan.
       # - name: e2e opengrep-core test
       #   run: >-

--- a/TCB/CapUnix.ml
+++ b/TCB/CapUnix.ml
@@ -1,4 +1,6 @@
 let execvp _caps = Unix.execvp
+let create_process _caps = Unix.create_process
+let waitpid _caps = Unix.waitpid
 let system _caps = Unix.system
 let fork _caps = Unix.fork
 let alarm _caps = Unix.alarm

--- a/TCB/CapUnix.mli
+++ b/TCB/CapUnix.mli
@@ -2,6 +2,10 @@
 
 (* See also libs/commons/CapExec.ml *)
 val execvp : Cap.Exec.t -> string -> string array -> 'a
+(* TODO: Better capabilities, for example [Cap.Process.create], [Cap.Process.wait]. *)
+val create_process :
+  Cap.Exec.t -> string -> string array -> Unix.file_descr -> Unix.file_descr -> Unix.file_descr -> int
+val waitpid : Cap.Exec.t -> Unix.wait_flag list -> int -> int * Unix.process_status
 
 (* You should use CapExec.ml instead *)
 val system : Cap.Exec.t -> string -> Unix.process_status

--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -36,7 +36,7 @@ def maybe_set_git_safe_directories() -> None:
         git_check_output(["git", "config", "--global", "--add", "safe.directory", "*"])
     except Exception as e:
         logger.info(
-            f"Semgrep failed to set the safe.directory Git config option. Git commands might fail: {e}"
+            f"Opengrep failed to set the safe.directory Git config option. Git commands might fail: {e}"
         )
 
 

--- a/cli/src/semgrep/console_scripts/entrypoint.py
+++ b/cli/src/semgrep/console_scripts/entrypoint.py
@@ -194,8 +194,9 @@ def main():
 
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):  # PyInstaller
         os.environ["_OPENGREP_BINARY"] = sys.executable
-        if IS_WINDOWS: # Because `execvp` on windows does not replace the current process.
-            os.environ["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
+        # NOTE: Not needed because we now use `subprocess.run` and we wait for completion.
+        # if IS_WINDOWS: # Because `execvp` on windows does not replace the current process.
+        #     os.environ["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
     
     # escape hatch for users to pysemgrep in case of problems (they
     # can also call directly 'pysemgrep').

--- a/cli/src/semgrep/console_scripts/entrypoint.py
+++ b/cli/src/semgrep/console_scripts/entrypoint.py
@@ -40,6 +40,7 @@ import platform
 import shutil
 import sysconfig
 import warnings
+import subprocess
 # import unicodedata
 # import requests
 import semgrep.main
@@ -178,11 +179,14 @@ def exec_osemgrep():
 
     # If you call opengrep-core as opengrep-cli, then we get
     # opengrep-cli behavior, see src/main/Main.ml
-    sys.argv[0] = "opengrep-cli" 
+    sys.argv[0] = "opengrep-cli"
 
-    # nosem: dangerous-os-exec-tainted-env-args
-    os.execvp(str(path), sys.argv)
-
+    if IS_WINDOWS:
+      cp = subprocess.run(sys.argv, executable=str(path), close_fds=True)
+      sys.exit(cp.returncode)
+    else:
+      # nosem: dangerous-os-exec-tainted-env-args
+      os.execvp(str(path), sys.argv)
 
 # Needed for similar reasons as in pysemgrep, but only for the legacy
 # flag to work

--- a/src/main/Main.ml
+++ b/src/main/Main.ml
@@ -121,7 +121,9 @@ let () =
                 (* adding --experimental so we don't default back to pysemgrep *)
                 CLI.main
                   (caps :> CLI.caps)
-                  (Array.append argv [| "--experimental" |])
+                  (Array.concat [[|argv.(0)|];
+                     [| "--experimental" |];
+                     Array.sub argv 1 (Array.length argv - 1)])
             | _else_ -> CLI.main (caps :> CLI.caps) argv
           in
           if not (Exit_code.Equal.ok exit_code) then

--- a/src/osemgrep/core/Pysemgrep.ml
+++ b/src/osemgrep/core/Pysemgrep.ml
@@ -16,6 +16,16 @@ exception Fallback
 (* Entry point *)
 (*************************************************************************)
 
+let exec (caps : < Cap.exec >) prog argv =
+  if Sys.os_type = "Win32" then
+    let pid = CapUnix.create_process caps#exec prog argv Unix.stdin Unix.stdout Unix.stderr in
+    let _pid, process_status = CapUnix.waitpid caps#exec [Unix.WUNTRACED] pid in
+    match process_status with
+    | Unix.WEXITED exit_code -> exit exit_code
+    | _ -> assert false (* On Windows, only WEXITED is used. *)
+  else
+    CapUnix.execvp caps#exec prog argv
+
 (* dispatch back to pysemgrep! *)
 let pysemgrep (caps : < Cap.exec >) argv =
   Logs.debug (fun m ->
@@ -26,10 +36,12 @@ let pysemgrep (caps : < Cap.exec >) argv =
   (* pysemgrep should be in the PATH, thx to the code in
      ../../../cli/bin/semgrep *)
   match Sys.getenv_opt "_OPENGREP_BINARY" with
-  | Some entrypoint ->
-    CapUnix.execvp caps#exec entrypoint
+  | Some opengrep_bin ->
+    exec
+      caps
+      opengrep_bin
       (Array.concat [[|argv.(0)|];
-                     [| "--legacy" |];
-                     Array.sub argv 1 (Array.length argv - 1)]) 
+                     [| "--legacy" |]; (* forces `pyopengrep` *)
+                     Array.sub argv 1 (Array.length argv - 1)])
   | None ->
-    CapUnix.execvp caps#exec "pyopengrep" argv
+    exec caps "pyopengrep" argv


### PR DESCRIPTION
### Changes

- The behaviour of `execvp` on Windows differs from the one in Unix systems, and it creates issues when we invoke Python to OCaml to Python ... 
- This PR ensures that on windows, we use subprocesses and we wait for completion of these subprocesses, which means the CLI behaves like on Unix, without strange spawning and killing of processes.