### PR TITLE
Ensure that paths use '/' in glob matching

### DIFF
--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -437,5 +437,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
+      - name: include paths test
+        # NOTE: Add `SEMGREP_LOG_SRCS="semgrep.targeting"` and `--debug` for debugging.
+        run: PYTHONIOENCODING=utf-8 opengrep scan -j 1 -f tests/windows/rules.yml tests/windows/test.py
       - name: sarif output test
-        run: opengrep scan -j 1 --sarif -f tests/windows/rules.yml tests/windows/test.py
+        run: PYTHONIOENCODING=utf-8 opengrep scan -j 1 --sarif -f tests/windows/rules.yml tests/windows/test.py

--- a/cli/src/semgrep/console_scripts/entrypoint.py
+++ b/cli/src/semgrep/console_scripts/entrypoint.py
@@ -194,9 +194,6 @@ def main():
 
     if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):  # PyInstaller
         os.environ["_OPENGREP_BINARY"] = sys.executable
-        # NOTE: Not needed because we now use `subprocess.run` and we wait for completion.
-        # if IS_WINDOWS: # Because `execvp` on windows does not replace the current process.
-        #     os.environ["PYINSTALLER_RESET_ENVIRONMENT"] = "1"
     
     # escape hatch for users to pysemgrep in case of problems (they
     # can also call directly 'pysemgrep').

--- a/libs/glob/Match.mli
+++ b/libs/glob/Match.mli
@@ -1,6 +1,6 @@
 (*
    Matching of a glob pattern against a path.
-   This is purely syntaxic: the file system is not accessed.
+   This is purely syntactic: the file system is not accessed.
 *)
 
 (* A compiled pattern matcher. *)

--- a/libs/paths/Ppath.ml
+++ b/libs/paths/Ppath.ml
@@ -294,7 +294,7 @@ let remove_prefix root path =
 let make_absolute path =
   if Fpath.is_rel path then Fpath.(v (Unix.getcwd ()) // path)
   else
-    (* Here, we must make a syscall, bceause we are making an unnormalized path absolute
+    (* Here, we must make a syscall, because we are making an unnormalized path absolute
        so that we can compare it to a normalized path.
        However, in the presence of symlinks, certain relationships like prefixes and
        naive string operations do not work properly, because they are not cognizant of

--- a/libs/paths/Project.ml
+++ b/libs/paths/Project.ml
@@ -52,7 +52,7 @@ type scanning_root_info = { project_root : Rfpath.t; inproject_path : Ppath.t }
      scanning root: a.py -> foo/a.py
      project root: /path/to/foo  (not '.')
 
-   To avoid relying on this nonobvious behavior, we recommend that users
+   To avoid relying on this non-obvious behavior, we recommend that users
    run semgrep on the current folder '.'.
 
    This function assumes that the path exists.

--- a/src/targeting/Filter_target.ml
+++ b/src/targeting/Filter_target.ml
@@ -84,15 +84,16 @@ let filter_paths (paths : Rule.paths) (path : Fpath.t) : bool =
     let pat2 =
       Glob.Pattern.(append [ Any_subpath ] (append (snd pat) [ Any_subpath ]))
     in
-
     let cpat1 =
       Glob.Match.(compile ~source:(string_loc ~source_kind:None (fst pat)) pat1)
     in
     let cpat2 =
       Glob.Match.(compile ~source:(string_loc ~source_kind:None (fst pat)) pat2)
     in
-    Glob.Match.run cpat1 (Fpath.to_string path)
-    || Glob.Match.run cpat2 (Fpath.to_string path)
+    let path_str = Fpath.to_string path
+    in
+    Glob.Match.run cpat1 path_str
+    || Glob.Match.run cpat2 path_str
   in
 
   let { Rule.require; exclude } = paths in

--- a/tests/windows/rules.yml
+++ b/tests/windows/rules.yml
@@ -4,3 +4,6 @@ rules:
     message: Basic test
     severity: ERROR
     languages: [python]
+    paths:
+      include:
+        - test.py


### PR DESCRIPTION
In Windows, we try to match with paths that contain '\' in a couple of places, and this results in a no-match and consequently in no results.

Closes #78.