### PR TITLE
fix: tools/languages_dumper builds again

### DIFF
--- a/tools/languages_dumper/Main.ml
+++ b/tools/languages_dumper/Main.ml
@@ -108,7 +108,7 @@ let options () =
       spf " <str> choose language (default = %s)" !lang );
     (*x: [[Main.options]] main cases *)
     ( "-sgrep_mode",
-      Arg.Set Flag_parsing.sgrep_mode,
+      Arg.Unit (fun () -> Domain.DLS.set Flag_parsing.sgrep_mode true),
       " enable sgrep mode parsing (to debug)" )
     (*e: [[Main.options]] main cases *);
   ]

--- a/tools/languages_dumper/dune
+++ b/tools/languages_dumper/dune
@@ -11,7 +11,6 @@
     parser_javascript.menhir
     parser_json.menhir
     parser_cpp.menhir
-    parser_c.menhir
     parser_ocaml.menhir
     parser_java.menhir
     parser_go.menhir


### PR DESCRIPTION
tools/languages_dumper broke because
* `parser_c.menhir` is now gone
* the `Flag_parsing.sgrep_mode` flag changed to a DLS key

fixed both

Not sure this tool is actually used, but it was stopping `dune build @check -w` in the top-level of the tree from succeeding