### PR TITLE
Fix: remove global state from C parser

### DIFF
--- a/languages/cpp/menhir/parse_cpp.ml
+++ b/languages/cpp/menhir/parse_cpp.ml
@@ -206,7 +206,7 @@ let create_defs (lang: Flag_cpp.language) =
            failwith (spf "Could not find %s, have you set PFFF_HOME correctly?" !!file); *)
       Log.info (fun m -> m "Using %s macro file" !!file);
       let xs = extract_macros file in
-      xs |> List.iter (fun (k, v) -> Hashtbl.add defs k v);
+      xs |> List.iter (fun (k, v) -> Hashtbl.replace defs k v);
       Atomic.set defs_cached (Some defs);
       defs
     | _ -> Hashtbl.create 101

--- a/languages/cpp/menhir/parse_cpp.mli
+++ b/languages/cpp/menhir/parse_cpp.mli
@@ -17,9 +17,8 @@ val parse_fuzzy :
   Fpath.t -> Ast_fuzzy.trees * (Lib_ast_fuzzy.token_kind * Tok.t) list
 
 (* usually correspond to what is inside your macros.h *)
-val _defs : (string, Pp_token.define_body) Hashtbl.t
-val init_defs : Fpath.t -> unit
-val add_defs : Fpath.t -> unit
+val create_defs :
+  Flag_parsing_cpp.language -> (string, Pp_token.define_body) Hashtbl.t
 
 (* used to extract macros from standard.h, but also now used on C files
  * in -extract_macros to assist in building a macros.h

--- a/src/parsing_languages/Parse_target2.ml
+++ b/src/parsing_languages/Parse_target2.ml
@@ -42,8 +42,6 @@ let lang_to_python_parsing_mode = function
 (*****************************************************************************)
 
 let just_parse_with_lang lang file : Parsing_result2.t =
-  if lang =*= Lang.C && Sys.file_exists !!(!Flag_parsing_cpp.macros_h) then
-    Parse_cpp.init_defs !Flag_parsing_cpp.macros_h;
 
   match lang with
   (* Neither Menhir nor tree-sitter *)


### PR DESCRIPTION
There was a global hashtable in the C parser in `languages/cpp/menhir/parse_cpp.ml`. In our multicore context, this would be populated (and accessed) concurrently, which is not thread-safe.

Now we create it in a safe way, without races, and cache it in an atomic reference to avoid repeating the work as it also involves IO.