### PR TITLE
Pick changes in Filename_.readable from semgrep

### DIFF
--- a/libs/commons/Filename_.mli
+++ b/libs/commons/Filename_.mli
@@ -1,8 +1,8 @@
 (* Deprecated: use the Ppath module instead! *)
-val filename_without_leading_path :
-  string -> string (* filename *) -> string (* filename *)
 
-val readable : root:string -> string (* filename *) -> string (* filename *)
+val readable : root:Fpath.t -> Fpath.t -> Fpath.t
+(** [readable ~root p] finds a "readable" path to [p] relative to
+    the [root] (this is generally the root of a project). * *)
 
 (* stuff that was in common2.mli *)
 

--- a/libs/commons/Fpath_.ml
+++ b/libs/commons/Fpath_.ml
@@ -46,7 +46,7 @@ module Operators = struct
   let ( !! ) = ( !! )
 end
 
-let readable ~root path = Filename_.readable ~root:!!root !!path |> Fpath.v
+let readable = Filename_.readable
 let current_dir = Fpath.v "."
 
 (* TODO: get rid of! *)

--- a/libs/commons/tests/Unit_commons.ml
+++ b/libs/commons/tests/Unit_commons.ml
@@ -85,21 +85,25 @@ let test_cat () =
       assert false
 
 let test_readable () =
-  Alcotest.(check string)
-    "same string" "Bar.java"
-    (Filename_.readable ~root:"." "./Bar.java");
-  Alcotest.(check string)
-    "same string" "Bar.java"
-    (Filename_.readable ~root:"." "Bar.java");
-  Alcotest.(check string)
-    "same string" "a/b/Bar.java"
-    (Filename_.readable ~root:"." "a/b/Bar.java");
-  Alcotest.(check string)
-    "same string" "Bar.java"
-    (Filename_.readable ~root:"/a/b/" "/a/b/Bar.java");
-  Alcotest.(check string)
-    "same string" "Bar.java"
-    (Filename_.readable ~root:"/a/b/" "/a/b//Bar.java");
+  let readable ~root p =
+    Filename_.readable ~root:(Fpath.v root) (Fpath.v p)
+  in
+  let fpath = Alcotest.testable Fpath.pp Fpath.equal in
+  Alcotest.(check fpath)
+    "same string" (Fpath.v "Bar.java")
+    (readable ~root:"." "./Bar.java");
+  Alcotest.(check fpath)
+    "same string" (Fpath.v "Bar.java")
+    (readable ~root:"." "Bar.java");
+  Alcotest.(check fpath)
+    "same string" (Fpath.v "a/b/Bar.java")
+    (readable ~root:"." "a/b/Bar.java");
+  Alcotest.(check fpath)
+    "same string" (Fpath.v "Bar.java")
+    (readable ~root:"/a/b/" "/a/b/Bar.java");
+  Alcotest.(check fpath)
+    "same string" (Fpath.v "Bar.java")
+    (readable ~root:"/a/b/" "/a/b//Bar.java");
   ()
 
 let with_file contents f =


### PR DESCRIPTION
Old version uses regexps, new version uses Fpath.

Investigation needed if this function is meaningfully used in opengrep.

Closes #136