### PR TITLE
fix: use trace.core instead of trace

### DIFF
--- a/libs/tracing/dune
+++ b/libs/tracing/dune
@@ -4,7 +4,7 @@
  (wrapped false)
   (libraries
     uri
-    trace
+    trace.core
     yojson
     logs
   )

--- a/libs/tracing/js/dune
+++ b/libs/tracing/js/dune
@@ -3,7 +3,7 @@
  (public_name tracing.js)
  (name tracing_js)
  (libraries
-   trace
+   trace.core
    commons
    logs
  )

--- a/libs/tracing/unix/Tracing.ml
+++ b/libs/tracing/unix/Tracing.ml
@@ -443,7 +443,7 @@ let setup_otel trace_endpoint =
   active_endpoint := Some trace_endpoint;
   (* Set the Otel Collector *)
   Otel.Collector.set_backend otel_backend;
-  if Trace.enabled () then
+  if Trace_core.enabled () then
     (* This would only happen if this function is called multiple times which is
        fine, or if someone /else/ has some Trace_core backend setup, but not
        sure when else we'd use it *)

--- a/libs/tracing/unix/dune
+++ b/libs/tracing/unix/dune
@@ -4,7 +4,7 @@
  (libraries
    unix
    commons
-   trace
+   trace.core
    opentelemetry
    opentelemetry.trace
    opentelemetry-client-ocurl


### PR DESCRIPTION
when you do `dune utop`, it bombs out with an error like

```
Error:  Duplicated implementations:
         Multiple definitions of module Trace in files $HOME/.opam/5.3.0/lib/ocaml/compiler-libs/ocamltoplevel.cma,
         $HOME/.opam/5.3.0/lib/trace/trace.cma
```

this is in fact a known issue with the `trace` library, which says to use `trace.core` as a workaroiund
https://github.com/c-cube/ocaml-trace/issues/2