### PR TITLE
Reduce memory footprint

### DIFF
--- a/languages/go/menhir/parsing_hacks_go.ml
+++ b/languages/go/menhir/parsing_hacks_go.ml
@@ -43,9 +43,10 @@ type env_lbody = InIfHeader | Normal
  * everything in the Tok category?
  *)
 let is_identifier horigin (info : Tok.t) =
-  match Hashtbl.find_opt horigin info with
-  | Some (T.LNAME _) -> true
+  match Hashtbl.find horigin info with
+  | T.LNAME _ -> true
   | _ -> false
+  | exception Not_found -> false
 
 (*****************************************************************************)
 (* ASI *)

--- a/languages/java/menhir/parsing_hacks_java.ml
+++ b/languages/java/menhir/parsing_hacks_java.ml
@@ -40,9 +40,10 @@ module Log = Log_parser_java.Log
  * coupling: copy-paste of Parsing_hacks_go.is_identifier
  *)
 let is_identifier horigin (info : Tok.t) =
-  match Hashtbl.find_opt horigin info with
-  | Some (IDENTIFIER _) -> true
+  match Hashtbl.find horigin info with
+  | IDENTIFIER _ -> true
   | _ -> false
+  | exception Not_found -> false
 
 (*****************************************************************************)
 (* Generic inference *)

--- a/languages/javascript/menhir/parsing_hacks_js.ml
+++ b/languages/javascript/menhir/parsing_hacks_js.ml
@@ -92,9 +92,10 @@ let rparens_of_if toks =
  * everything in the Tok category?
  *)
 let is_identifier horigin (info : Tok.t) =
-  match Hashtbl.find_opt horigin info with
-  | Some (T.T_ID _) -> true
+  match Hashtbl.find horigin info with
+  | T.T_ID _ -> true
   | _ -> false
+  | exception Not_found -> false
 
 (*****************************************************************************)
 (* Entry point *)

--- a/languages/yaml/generic/yaml_to_generic.ml
+++ b/languages/yaml/generic/yaml_to_generic.ml
@@ -207,9 +207,9 @@ let make_node f anchor args env =
 
 let make_alias anchor pos env =
   let t = mk_tok pos anchor env in
-  match Hashtbl.find_opt env.anchors anchor with
-  | Some (expr, _p) -> (G.e (G.Alias ((anchor, t), expr)), pos)
-  | None -> raise (UnrecognizedAlias t)
+  match Hashtbl.find env.anchors anchor with
+  | (expr, _p) -> (G.e (G.Alias ((anchor, t), expr)), pos)
+  | exception Not_found -> raise (UnrecognizedAlias t)
 
 (*
    A tag is a sort of type annotation e.g. '!number 42' tags the value

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -489,8 +489,9 @@ class ['self] extract_info_visitor =
       | _ -> super#visit_expr globals x
   end
 
+let extract_info_visitor_instance = new extract_info_visitor
 let ii_of_any any =
-  let v = new extract_info_visitor in
+  let v = extract_info_visitor_instance in
   let globals = ref [] in
   v#visit_any globals any;
   List.rev !globals
@@ -687,8 +688,9 @@ class ['self] any_range_visitor =
     method! visit_Alias ranges id _e = self#visit_ident ranges id
   end
 
+let any_range_visitor_instance = new any_range_visitor
 let nearest_any_of_pos prog position =
-  let v = new any_range_visitor in
+  let v = any_range_visitor_instance in
   let info = { range = ref None; any = ref None; position } in
   v#visit_program info prog;
   !(info.any)

--- a/libs/commons/Pcre2_.ml
+++ b/libs/commons/Pcre2_.ml
@@ -118,6 +118,10 @@ let full_split ?iflags ?flags ~rex ?pos ?max ?callout subj =
   | Pcre2.Error err -> Error err
 
 let log_error rex subj err =
+ (* NOTE: We could move the [string_fragment] calculation into log function below,
+  * but in normal operation we print the warnings anyway, unless if `--quiet` is
+  * passed. And if we did move it in the log closure, it would be protected by a
+  * mutex which would make normal operation slower. *)
   let string_fragment =
     let len = String.length subj in
     if len < 200 then subj

--- a/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
+++ b/libs/lib_parsing_tree_sitter/Parse_tree_sitter_helpers.ml
@@ -120,6 +120,10 @@ let wrap_parser tree_sitter_parser ast_mapper =
     match res.program with
     | Some cst ->
         (if res.errors <> [] then
+           (* We could move this into the fun below, but since we emit warnings
+            * by default, this would only save some work when using `--quiet`,
+            * but would also force the code below to run in a critical section
+            * which is not necessary, in normal operation. *)
            let error_strs =
              List_.map
                (fun err -> err.Tree_sitter_run.Tree_sitter_error.msg)

--- a/libs/spacegrep/src/lib/Find_files.ml
+++ b/libs/spacegrep/src/lib/Find_files.ml
@@ -11,6 +11,9 @@ type visit_tracker = {
   mark_visited : string -> unit;
 }
 
+(* TODO: Make thread safe if needed; but for now this is not the case.
+ * The hash table is shared by all invocations of the function so it's
+ * an issue if it's called concurrently. *)
 let memoize f =
   let tbl = Hashtbl.create 100 in
   fun x ->
@@ -36,6 +39,9 @@ let stat = memoize Unix.stat
    by symbolic links.
 *)
 let create_visit_tracker () =
+  (* TODO: Make thread safe if needed; but for now this is not the case.
+   * The hash table is shared by all invocations of the function so it's
+   * an issue if it's called concurrently. *)
   let tbl = Hashtbl.create 100 in
   let get_id path =
     try Some (stat path).st_ino with

--- a/libs/spacegrep/src/lib/Find_files.ml
+++ b/libs/spacegrep/src/lib/Find_files.ml
@@ -22,7 +22,7 @@ let memoize f =
       | Some run -> run
       | None ->
           let run = lazy (f x) in
-          Hashtbl.add tbl x run;
+          Hashtbl.replace tbl x run;
           run
     in
     Lazy.force run

--- a/src/analyzing/CFG_build.ml
+++ b/src/analyzing/CFG_build.ml
@@ -104,8 +104,9 @@ let label_node state labels nodei =
 let resolve_gotos state =
   !(state.gotos)
   |> List.iter (fun (srci, label_key) ->
-         match Hashtbl.find_opt state.labels label_key with
-         | None ->
+         match Hashtbl.find state.labels label_key with
+         | dsti -> state.g |> add_arc (srci, dsti)
+         | exception Not_found ->
              (* We won't move that stuff inside the function below, because
               * warning is on by default, and logging is protected by a mutex,
               * which would slow down default operation as a result. *)
@@ -115,8 +116,7 @@ let resolve_gotos state =
                | Some tok -> spf " (%s)" (Tok.stringpos_of_tok tok)
              in
              Log.warn (fun m ->
-                 m ~tags "Could not resolve label: %s%s" (fst label_key) loc_str)
-         | Some dsti -> state.g |> add_arc (srci, dsti));
+                 m ~tags "Could not resolve label: %s%s" (fst label_key) loc_str));
   state.gotos := []
 
 (*****************************************************************************)

--- a/src/analyzing/CFG_build.ml
+++ b/src/analyzing/CFG_build.ml
@@ -106,6 +106,9 @@ let resolve_gotos state =
   |> List.iter (fun (srci, label_key) ->
          match Hashtbl.find_opt state.labels label_key with
          | None ->
+             (* We won't move that stuff inside the function below, because
+              * warning is on by default, and logging is protected by a mutex,
+              * which would slow down default operation as a result. *)
              let loc_str =
                match state.opt_tok with
                | None -> ""

--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -312,9 +312,10 @@ class ['self] stats_of_prog_visitor =
       super#visit_expr (env, ctx) x
   end
 
+let stats_of_prog_visitor_instance = new stats_of_prog_visitor
 let stats_of_prog prog : stats =
   let stats = new_stats () in
-  let visitor = new stats_of_prog_visitor 
+  let visitor = stats_of_prog_visitor_instance 
   in
   visitor#visit_program (stats, Iter_with_context.initial_context) prog;
   stats

--- a/src/core/Core_error.ml
+++ b/src/core/Core_error.ml
@@ -223,6 +223,10 @@ let known_exn_to_error ?(file : Fpath.t option) (e : Exception.t) : t option =
   | AST_generic.Error (s, tok) ->
       Some (mk_error_tok ?file tok s Out.AstBuilderError)
   | Time_limit.Timeout timeout_info ->
+      (* Maybe move [Printexc.get_backtrace ()] into the fun below?
+       * As mentioned in similar situations elsewhere, this won't really
+       * have an effect in normal operation since warnings are emitted
+       * anyway, so why force this to happen inside a critical section? *)
       let s = Printexc.get_backtrace () in
       Log.warn (fun m -> m "WEIRD Timeout converted to exn, backtrace = %s" s);
       (* This exception should always be reraised. *)

--- a/src/core/Core_match.ml
+++ b/src/core/Core_match.ml
@@ -191,7 +191,7 @@ let submatch pm1 pm2 =
   (* THINK: && "pm1.bindings = pm2.bindings" ? *)
   && Range.( $<$ ) (range pm1) (range pm2)
 
-(* Remove matches that are srictly inside another match. *)
+(* Remove matches that are strictly inside another match. *)
 let no_submatches pms =
   (* Initial hash table size based on memory profiling with memtrace. Increase
    * only with caution. *)

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -792,7 +792,6 @@ let sca_rules_filtering (target : Target.regular) (rules : Rule.t list) :
 let mk_target_handler (caps : < Cap.time_limit >) (config : Core_scan_config.t)
     (valid_rules : Rule.t list)
     (prefilter_cache_opt : Match_env.prefilter_config) : target_handler =
-  (* Note that this function runs in another process *)
   function
   | Lockfile ({ path; kind } as lockfile) ->
       (* TODO: (sca) we always pass None as the manifest target here, but this

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -80,11 +80,11 @@ let is_relevant_rule_for_xtarget r xconf xtarget =
         | None -> true
         | Some (prefilter_formula, func) ->
           (* NOTE: If [lazy_content] is shared in > 1 thread, then this is not
-           * thread-safe. However, each [Xtarget.t] is only acessed in 1 worker
+           * thread-safe. However, each [Xtarget.t] is only accessed in 1 worker
            * task, so there should be no race. *)
           let content = Lazy.force lazy_content in
-          let s = Semgrep_prefilter_j.string_of_formula prefilter_formula in
           Log.info (fun m ->
+              let s = Semgrep_prefilter_j.string_of_formula prefilter_formula in
               m "looking for %s in %s" s !!internal_path_to_content);
           func content)
   in

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -276,8 +276,9 @@ class ['self] get_facts_visitor =
       super#visit_expr (facts, is_first) expr
   end
 
+let get_facts_visitor_instance = new get_facts_visitor
 let get_facts_of_stmt stmt =
-  let fact_v = new get_facts_visitor in
+  let fact_v = get_facts_visitor_instance in
   let facts = ref [] in
   let is_first = ref true in
   fact_v#visit_stmt (facts, is_first) stmt;

--- a/src/optimizing/Analyze_pattern.ml
+++ b/src/optimizing/Analyze_pattern.ml
@@ -190,10 +190,9 @@ class ['self] extract_mvars_in_id_position_visitor =
         | _ -> super#visit_expr env x
     end
 
+let extract_mvars_in_id_position_visitor_instance = new extract_mvars_in_id_position_visitor
 let extract_mvars_in_id_position ?lang:_ any =
-  (* let mvars = ref MvarSet.empty in *)
-  let visitor = new extract_mvars_in_id_position_visitor
+  let visitor = extract_mvars_in_id_position_visitor_instance
   in
   visitor#visit_any () any;
   visitor#get_mvars
-  (* !mvars *)

--- a/src/parsing/Parse_rule.ml
+++ b/src/parsing/Parse_rule.ml
@@ -1117,6 +1117,9 @@ let parse_generic_ast ?(error_recovery = false) ?rewrite_rule_ids
              | Ok rule -> Ok (Either.Left rule)
              | Error { kind = InvalidRule ((kind, ruleid, _) as err); _ }
                when error_recovery || Rule_error.is_skippable_error kind ->
+                 (* We could move this into the closure below, but it would
+                  * slow down the default operation were warnings are emitted,
+                  * since it would be protected by a mutex. *)
                  let s = Rule_error.string_of_invalid_rule_kind kind in
                  Log.warn (fun m ->
                      m "skipping rule %s, error = %s" (Rule_ID.to_string ruleid)


### PR DESCRIPTION
### Minor changes

- Ensure that one conversion to json -- that was only relevent for an INFO log -- happens inside the log's closure, avoiding the work when the log level is "warn" which means INFO should not be emitted.
- Adds comments on Log.warn invocations, in case we decide to do the same. But this may not be a good idea, since logs are now by necessity protected by a mutex, so any work inside logging functions is now serialised. The default level is "warn" so we would not benefit under normal invocation, but rather it would become slower... Only `--quiet` could benefit but I don't think this is worth it now.

### Major changes

We obtain a large memory footprint optimisation by replacing `Hashtbl.find_opt` with `Hashtbl.find`.  To my surprise, the exception handling [`find` raises `Not_found`] is very cheap, and performance does not suffer. However, we now have significantly less allocations, as confirmed by a small benchmark. I tested using our internal Aikido rules (hundreds) on our internal test repo, and obtained a 30-35% reduction in maximum resident set size (RSS) and peak memory footprint.

This is of course worthy of a proper benchmark, but it seems very promising so let's merge it in.

```bash
$ /usr/bin/time -l -- opengrep-cli --experimental -j 8 -c <rules> <internal-repo-for-testing> --quiet

# Unoptimised below: 

       41.62 real        93.21 user        10.76 sys
           805109760  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              224014  page reclaims
                1852  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1777  voluntary context switches
             2057121  involuntary context switches
       1404328809237  instructions retired
        356680854727  cycles elapsed
           673172928  peak memory footprint

       40.12 real        92.30 user        10.43 sys
           879329280  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              218872  page reclaims
                3500  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                 323  voluntary context switches
             2036085  involuntary context switches
       1391108901263  instructions retired
        352360154902  cycles elapsed
           755846784  peak memory footprint

# Versus optimised: 

       41.52 real        92.32 user        10.65 sys
           537067520  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              214198  page reclaims
                1863  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                1822  voluntary context switches
             2055521  involuntary context switches
       1354263689652  instructions retired
        353942035593  cycles elapsed
           411651008  peak memory footprint

       40.88 real        92.36 user        10.75 sys
           579485696  maximum resident set size
                   0  average shared memory size
                   0  average unshared data size
                   0  average unshared stack size
              211174  page reclaims
                6028  page faults
                   0  swaps
                   0  block input operations
                   0  block output operations
                   0  messages sent
                   0  messages received
                   0  signals received
                2076  voluntary context switches
             2136403  involuntary context switches
       1365527971510  instructions retired
        358116535669  cycles elapsed
           455511040  peak memory footprint

```
