### PR TITLE
Share some stateless visitor instances

### DIFF
--- a/src/experiments/misc/Function_range.ml
+++ b/src/experiments/misc/Function_range.ml
@@ -16,6 +16,8 @@ type ranges = function_info list [@@deriving show]
 (* Entry point *)
 (*****************************************************************************)
 
+(* This is not used, but if it is to be used, we should create a class and
+ * then a common shared object. *)
 let ranges (prog : AST_generic.program) : ranges =
   let visitor =
     object (_self : 'self)

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -357,16 +357,17 @@ let do_visit_with_ref visitor any =
   visitor#visit_any res any;
   List.rev !res
 
-let lambdas_in_expr e =
-  let visitor =
-    object (_self : 'self)
-      inherit [_] AST_generic.iter_no_id_info
+class ['self] lambdas_in_expr_visitor =
+  object (_self : 'self)
+    inherit [_] AST_generic.iter_no_id_info
 
-      (* TODO Should we recurse into the Lambda? *)
-      method! visit_Lambda aref def = Stack_.push def aref
-    end
-  in
-  do_visit_with_ref visitor (E e)
+    (* TODO Should we recurse into the Lambda? *)
+    method! visit_Lambda aref def = Stack_.push def aref
+  end
+
+let lambdas_in_expr_visitor_instance = new lambdas_in_expr_visitor
+let lambdas_in_expr e =
+  do_visit_with_ref lambdas_in_expr_visitor_instance (E e)
 [@@profiling]
 
 (* opti: using memoization speed things up a bit too

--- a/src/parsing/Check_pattern.ml
+++ b/src/parsing/Check_pattern.ml
@@ -68,9 +68,10 @@ class ['self] metavar_checker =
       super#visit_ident (error, lang) id
   end
 
+let metavar_checker_instance = new metavar_checker
 let check_pattern_metavars error lang ast =
   if lang_has_no_dollar_ids lang then
-    (new metavar_checker)#visit_any (error, lang) ast
+    metavar_checker_instance#visit_any (error, lang) ast
 
 exception CheckFailure of string
 


### PR DESCRIPTION
We do this to reduce allocations, although in this case the effect is not as pronounced as it was in PR #154.

