### PR TITLE
Make profiling thread-safe

### DIFF
--- a/libs/profiling/Profiling.ml
+++ b/libs/profiling/Profiling.ml
@@ -56,7 +56,7 @@ let adjust_profile_entry category difftime =
     | None ->
         let xtime = Loc.make 0.0 in
         let xcount = Loc.make 0 in
-        Hashtbl.Xt.add ~xt _profile_table category (xtime, xcount))}
+        Hashtbl.Xt.replace ~xt _profile_table category (xtime, xcount))}
 
 (*****************************************************************************)
 (* Entry points *)

--- a/libs/profiling/Profiling.mli
+++ b/libs/profiling/Profiling.mli
@@ -5,11 +5,9 @@ type prof = ProfAll | ProfNone | ProfSome of string list
 
 val profile : prof ref
 val show_trace_profile : bool ref
-val _profile_table : (string, float ref * int ref) Hashtbl.t ref
+val _profile_table : (string, float Kcas.Loc.t * int Kcas.Loc.t) Kcas_data.Hashtbl.t
 val profile_code : string -> (unit -> 'a) -> 'a
 val profile_diagnostic : unit -> string
-val profile_code_exclusif : string -> (unit -> 'a) -> 'a
-val profile_code_inside_exclusif_ok : string -> (unit -> 'a) -> 'a
 val warn_if_take_time : int -> string -> (unit -> 'a) -> 'a
 
 (* similar to profile_code but log some information during execution too *)

--- a/libs/profiling/dune
+++ b/libs/profiling/dune
@@ -7,5 +7,7 @@
    unix
    commons
    process_limits ; for Time_limit.Timeout special handling
+   kcas
+   kcas_data
  )
 )


### PR DESCRIPTION
When the `--profile` flag is passed, a lot of functions are profiled, and previously the data was recorded in a shared hashtable as each function executed.

This is not thread-safe, so we now replaced it with a Kcas hashtable, and we wrap the updating code in a transaction. The reason for which a transaction is needed is that we first check if a key exists, and if not then we add an initial entry. We do not want a race condition that can override a record, potentially deleting profiling information. This can happen is an entry is added after we check and find none, and if we re-initialise it by setting the values to 0s.

To experiment: 

```bash
opengrep-cli scan --experimental -c <rules> <code> --profile
```

I also improved the output, ensuring that columns are aligned. We now pad the first column according to the longest value instead of fixing it to 40.
