### PR TITLE
Remove references to Semgrep in CLI output

### DIFF
--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -494,12 +494,11 @@ class OutputHandler:
                     missed_rule_count
                     and state.get_cli_ux_flavor() != DesignTreatment.LEGACY
                 ):
-                    missed_count_line = f"💎 Missed out on {unit_str(missed_rule_count, 'pro rule')} since you aren't logged in!"
                     learn_more_url = with_color(
                         Colors.cyan, "https://github.com/opengrep/opengrep", underline=True
                     )
                     learn_more_line = f"⚡ Contribute to Opengrep at {learn_more_url}."
-                    stats_line = f"{stats_line}\n{missed_count_line}\n{learn_more_line}"
+                    stats_line = f"{stats_line}\n{learn_more_line}"
             if ignore_log is not None:
                 too_many_entries = self.settings.max_log_list_entries
                 logger.verbose(ignore_log.verbose_output(too_many_entries))

--- a/cli/src/semgrep/scan_report.py
+++ b/cli/src/semgrep/scan_report.py
@@ -41,7 +41,7 @@ def _print_product_status(sast_enabled: bool = True, sca_enabled: bool = False) 
     (Simple) print the statuses of enabled products to stdout when the user
     is given the product-focused CLI UX treatment.
     """
-    learn_more_url = with_color(Colors.cyan, "https://sg.run/cloud", underline=True)
+    learn_more_url = with_color(Colors.cyan, "https://opengrep.dev", underline=True)
     login_command = with_color(Colors.gray, "`semgrep login`")
     is_logged_in = auth.is_logged_in_weak()
     all_enabled = True  # assume all enabled until we find a disabled product
@@ -52,20 +52,6 @@ def _print_product_status(sast_enabled: bool = True, sca_enabled: bool = False) 
             sast_enabled,
             [
                 "Basic security coverage for first-party code vulnerabilities.",
-            ],
-        ),
-        (
-            "Semgrep Code (SAST)",
-            is_logged_in and sast_enabled,
-            [
-                "Find and fix vulnerabilities in the code you write with advanced scanning and expert security rules.",
-            ],
-        ),
-        (
-            "Semgrep Supply Chain (SCA)",
-            sca_enabled,
-            [
-                "Find and fix the reachable vulnerabilities in your OSS dependencies.",
             ],
         ),
     ]
@@ -79,20 +65,9 @@ def _print_product_status(sast_enabled: bool = True, sca_enabled: bool = False) 
             console.print(f"  {with_feature_status(enabled=enabled)} {feature}")
 
     if not is_logged_in:
-        message = "\n".join(
-            wrap(
-                f"💎 Get started with all Semgrep products via {login_command}.",
-                width=80,
-            )
-            + [f"✨ Learn more at {learn_more_url}."]
-        )
+        message = f"✨ Learn more at {learn_more_url}."
         console.print(f"\n{message}\n")
     elif not all_enabled:
-        # TODO: Handle cases where SAST / SCA are not enabled (GROW-53)
-        # We should suggest a resolution such as enabling supply chain in SCP settings, and
-        # run then `semgrep ci`. However, there are some additional edge cases to consider
-        # such as feature availability / required plan upgrades, and thus we will punt showing
-        # a resolution for now.
         console.print(" ")  # space intentional for progress bar padding
     else:
         console.print(" ")  # space intentional for progress bar padding

--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -54,9 +54,10 @@ For more information about Opengrep, visit @{<cyan;ul>https://opengrep.dev@}
 
 @{<ul>Help@}:
   @{<cyan>opengrep COMMAND --help@}      For more information on each command
-
-For the CLI docs visit @{<cyan;ul>https://opengrep.dev/docs/cli-reference@}
 |}
+(* TODO: Add back when fixed, this was the last line above:
+ * For the CLI docs visit @{<cyan;ul>https://opengrep.dev/docs/cli-reference@}
+ *)
 
 (* coupling: see above *)
 let print_semgrep_dashdash_help (stdout : Cap.Console.stdout) =


### PR DESCRIPTION
Closes #120.

- An issue was opened to remove Metrics, which will be done later as it's more substantial. See https://github.com/opengrep/opengrep/issues/158.
- An issue was opened relating to a broken link, now hidden: https://github.com/opengrep/opengrep/issues/159