### PR TITLE
Pin actions to commit SHA

### DIFF
--- a/.github/workflows/build-manylinux-binary-x86.yml
+++ b/.github/workflows/build-manylinux-binary-x86.yml
@@ -9,7 +9,7 @@ jobs:
     # NOTE: The image below has GLIBC 2.28, but there are others for even older version.
     # See: https://github.com/pypa/manylinux
     container:
-      image: quay.io/pypa/manylinux_2_28_x86_64
+      image: quay.io/pypa/manylinux_2_28_x86_64@sha256:b4f3589f2cc037a351d8755010e4284f1593c8acad86ac27e599416d98d6b7ad # ratchet:quay.io/pypa/manylinux_2_28_x86_64
     runs-on: ubuntu-latest
     steps:
       - run: |
@@ -21,12 +21,12 @@ jobs:
       
       # - run: find / -name "libpython*" #; exit 1
       # - run: yum install -y zip
-          
-      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
-      
-      - uses: actions/download-artifact@v4
+
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: manylinux-x86-wheel
 
@@ -94,8 +94,8 @@ jobs:
 
       - name: Zip artifact
         run: zip -j opengrep.zip dist/opengrep
-      
-      - uses: actions/upload-artifact@v4
+
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: opengrep_manylinux_binary_x86_64
           path: opengrep.zip
@@ -104,7 +104,8 @@ jobs:
     needs: build-self-contained-manylinux-binary
     runs-on: ubuntu-20.04 # ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep_manylinux_binary_x86_64
       - run: unzip opengrep.zip

--- a/.github/workflows/build-musllinux-binary-x86.yml
+++ b/.github/workflows/build-musllinux-binary-x86.yml
@@ -12,13 +12,13 @@ jobs:
       - run: |
           apk update
           apk add --no-cache zip python3 py3-pip py3-virtualenv python3-dev gcc musl-dev
-          
-      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
 
       # NOTE: In fact both linux wheels should work.
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: musllinux-x86-wheel
 
@@ -82,8 +82,8 @@ jobs:
 
       - name: Zip artifact
         run: zip -j opengrep.zip dist/opengrep
-      
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
+
         with:
           name: opengrep_musllinux_binary_x86_64
           path: opengrep.zip
@@ -93,7 +93,7 @@ jobs:
     container: quay.io/pypa/musllinux_1_2_x86_64
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep_musllinux_binary_x86_64
       - run: unzip opengrep.zip

--- a/.github/workflows/build-osx-binary-arm64.yml
+++ b/.github/workflows/build-osx-binary-arm64.yml
@@ -8,7 +8,7 @@ jobs:
   build-self-contained-osx-binary:
     runs-on: macos-13-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install pipenv
@@ -19,8 +19,8 @@ jobs:
 
       - name: install some dependencies for windows (pyinstaller only)
         run: pipenv run pip install chardet charset-normalizer
-      
-      - uses: actions/download-artifact@v4
+
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: osx-arm64-wheel
 
@@ -61,7 +61,7 @@ jobs:
       - name: Zip artifact
         run: zip -j opengrep.zip dist/opengrep
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: opengrep_osx_binary_arm64
           path: opengrep.zip 
@@ -70,7 +70,7 @@ jobs:
     needs: build-self-contained-osx-binary
     runs-on: macos-13-xlarge
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep_osx_binary_arm64
       - run: unzip opengrep.zip

--- a/.github/workflows/build-test-core-x86.yml
+++ b/.github/workflows/build-test-core-x86.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Make checkout speedy
         run: git config --global fetch.parallel 50
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
 
@@ -52,8 +52,8 @@ jobs:
             libpsl-static zstd-static libidn2-static \
             libunistring-static tar zstd
 
-      - name: Set GHA cache for OPAM 
-        uses: actions/cache@v4
+      - name: Set GHA cache for OPAM
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('opam/*.opam') }}
           path: _opam
@@ -94,7 +94,7 @@ jobs:
           cp bin/opengrep-core artifacts/
           tar czf artifacts.tgz artifacts
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: opengrep-core-x86
           path: artifacts.tgz
@@ -107,13 +107,13 @@ jobs:
     steps:
       - name: Make checkout speedy
         run: git config --global fetch.parallel 50
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
       - run: |
           apk update
           apk add --no-cache zip python3 py3-pip py3-virtualenv python3-dev gcc musl-dev
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep-core-x86
       - run: |
@@ -122,7 +122,7 @@ jobs:
           python3 -m venv venv
           . venv/bin/activate
           ./scripts/build-wheels.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: musllinux-x86-wheel
           path: cli/dist.zip

--- a/.github/workflows/build-test-manylinux-x86.yml
+++ b/.github/workflows/build-test-manylinux-x86.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Make checkout speedy
         run: git config --global fetch.parallel 50
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
       - run: |
@@ -34,14 +34,14 @@ jobs:
           alternatives --remove-all python3
           alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
           alternatives --auto python3
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep-core-x86
       - run: |
           tar xf artifacts.tgz
           cp artifacts/opengrep-core cli/src/semgrep/bin
           ./scripts/build-wheels.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: manylinux-x86-wheel
           path: cli/dist.zip
@@ -52,7 +52,7 @@ jobs:
       - build-wheels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: manylinux-x86-wheel
       - run: unzip dist.zip
@@ -73,7 +73,7 @@ jobs:
       - build-wheels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: manylinux-x86-wheel
       - run: unzip dist.zip
@@ -93,11 +93,11 @@ jobs:
       - build-wheels
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: manylinux-x86-wheel
       - run: unzip dist.zip
-      - uses: Vampire/setup-wsl@v3
+      - uses: Vampire/setup-wsl@6c400b755bcd0583e60c2e7aa0cdc61794355c9b # ratchet:Vampire/setup-wsl@v3
       - name: Install Python
         run: |
           sudo apt update -y

--- a/.github/workflows/build-test-osx-arm64.yml
+++ b/.github/workflows/build-test-osx-arm64.yml
@@ -34,10 +34,10 @@ jobs:
         ocaml_version: ["5.3.0"]
     runs-on: macos-13-xlarge # NOTE: For intel, we need macos-13-large it seems.
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # ratchet:actions/setup-python@v4
         with:
           python-version: "3.11"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
       - name: Debug use-cache input
@@ -47,7 +47,7 @@ jobs:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         # if: ${{ inputs.use-cache == 'true' || inputs.use-cache == '' }}
         name: Set GHA cache for OPAM in ~/.opam
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('opam/*.opam') }}
           path: ~/.opam
@@ -111,7 +111,7 @@ jobs:
 
           popd
           tar czf artifacts.tgz artifacts
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: opengrep-osx-arm64
           path: artifacts.tgz
@@ -121,20 +121,20 @@ jobs:
       - build-core
     runs-on: macos-13-xlarge
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # ratchet:actions/setup-python@v4
         with:
           python-version: "3.11"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep-osx-arm64
       - run: |
           tar xvfz artifacts.tgz
           cp artifacts/* cli/src/semgrep/bin
           ./scripts/build-wheels.sh --plat-name macosx_11_0_arm64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: osx-arm64-wheel
           path: cli/dist.zip
@@ -144,10 +144,10 @@ jobs:
       - build-wheels
     runs-on: macos-13-xlarge
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # ratchet:actions/setup-python@v4
         with:
           python-version: "3.11"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: osx-arm64-wheel
       - run: unzip dist.zip

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -10,7 +10,7 @@ on:
       - windows/**
       # - dm/** # branch where this change was introduced
     paths-ignore:
-    - '**.md'
+      - '**.md'
   workflow_call:
     inputs:
       use-cache:
@@ -69,14 +69,14 @@ jobs:
           git config --global core.autocrlf input;
           git config --system core.longpaths true;
           git config --global fetch.parallel 50
-      
-      - uses: actions/checkout@v4
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
 
       - name: Set-up cygwin
         # if: steps.cache.outputs.cache-hit != 'true'
-        uses: cygwin/cygwin-install-action@master
+        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # ratchet:cygwin/cygwin-install-action@master
         with:
           install-dir: D:/cygwin
           packages: curl,diffutils,m4,make,mingw64-i686-gcc-core,mingw64-i686-gcc-g++,mingw64-i686-openssl=1.0.2u+za-1,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,mingw64-x86_64-openssl=1.0.2u+za-1,patch,perl,rsync,unzip,mingw64-x86_64-libssh2,mingw64-x86_64-nghttp2,mingw64-x86_64-pcre,mingw64-x86_64-pcre2,mingw64-x86_64-win-iconv,mingw64-x86_64-zstd,mingw64-x86_64-gettext,mingw64-x86_64-libidn2,mingw64-x86_64-curl,gnupg2,mingw64-x86_64-gmp
@@ -116,7 +116,7 @@ jobs:
 
       - name: Restore Dune cache
         id: cache-dune-win32-64
-        uses: actions/cache@v4
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache@v4
         with:
           path: ${{ env.DUNE_CACHE_ROOT }}
           key: dune-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ github.run_id }}
@@ -124,14 +124,14 @@ jobs:
       
       - name: Restore _opam
         id: cache-opam-win32-64
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache/restore@v4
         with:
           path: _opam
           key: opam-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('opam/*.opam') }}
 
       - name: Restore OPAM_ROOT
         id: cache-opamroot-win32-64
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache/restore@v4
         with:
           path: ${{ env.OPAMROOT }} # C:\Users\runneradmin\AppData\Local\opam
           key: opamroot-cache-${{ runner.os }}-${{ runner.arch }}-v1-opam-${{ matrix.ocaml_version }}-${{ hashFiles('opam/*.opam') }}
@@ -298,7 +298,7 @@ jobs:
       - name: Save _opam
         if: steps.cache-opam-win32-64.outputs.cache-hit != 'true'
         id: cache-opam-win32-64-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache/save@v4
         with:
           path: _opam
           key: ${{ steps.cache-opam-win32-64.outputs.cache-primary-key }}
@@ -306,7 +306,7 @@ jobs:
       - name: Save OPAM_ROOT
         if: steps.cache-opamroot-win32-64.outputs.cache-hit != 'true'
         id: cache-opamroot-win32-64-save
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache/save@v4
         with:
           path: ${{ env.OPAMROOT }} # C:\Users\runneradmin\AppData\Local\opam
           key: ${{ steps.cache-opamroot-win32-64.outputs.cache-primary-key }}
@@ -381,7 +381,7 @@ jobs:
 
           tar czvf artifacts.tgz artifacts
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: opengrep-core-and-dependent-libs-w64-artifact
           path: artifacts.tgz
@@ -394,10 +394,10 @@ jobs:
       - build-core
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep-core-and-dependent-libs-w64-artifact
       - env:
@@ -406,7 +406,7 @@ jobs:
           tar xvfz artifacts.tgz
           cp artifacts/* cli/src/semgrep/bin
           ./scripts/build-wheels.sh --plat-name win_amd64
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # ratchet:actions/upload-artifact@v4
         with:
           name: windows-x86-wheel
           path: cli/dist.tgz
@@ -419,7 +419,7 @@ jobs:
       - build-wheels
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: windows-x86-wheel
       - run: tar xzvf dist.tgz
@@ -434,7 +434,7 @@ jobs:
           export PYTHONIOENCODING=utf-8;
           echo '1 == 1' | opengrep -l python -e '$X == $X' -
       # Test SARIF output which previously failed on Windows only:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: false
       - name: include paths test


### PR DESCRIPTION
### Changes

- Uses ratchet to pin workflow dependencies to their SHA.
- Careful: ratchet messes up yaml files to to parser issues, so there is manual work involved.

TODO: Use Aikido next time.