### PR TITLE
Pass jobs parameter to scan with --test

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -718,6 +718,7 @@ def scan(
             json=output_format == OutputFormat.JSON,
             optimizations=optimizations,
             engine_type=engine_type,
+            jobs=jobs,
         )
 
     filtered_matches_by_rule: RuleMatchMap = {}


### PR DESCRIPTION
This parameter was previously ignored. 
Closes #86.

Here's how it works now on a 11 core machine (print has been removed):

- If `-j` is not passed, it works as before with all cores;
- If `-j` is passed, it is restricted to be <= num cpus, and is used;
- Special case: `-j 0` will use all cpus.

Sample invocations below:

```bash
❯ time opengrep scan -c python/ python/ --test
Running with 11 jobs
24/24: ✓ All tests passed
No tests for fixes found.
opengrep scan -c python/ python/ --test  13.31s user 7.03s system 454% cpu 4.474 total

❯ time opengrep scan -j 0 -c python/ python/ --test
Running with 11 jobs
24/24: ✓ All tests passed
No tests for fixes found.
opengrep scan -j 0 -c python/ python/ --test  13.21s user 6.91s system 697% cpu 2.883 total

❯ time opengrep scan -j 1 -c python/ python/ --test
Running with 1 jobs
24/24: ✓ All tests passed
No tests for fixes found.
opengrep scan -j 1 -c python/ python/ --test  6.04s user 3.14s system 98% cpu 9.294 total

❯ time opengrep scan -j 6 -c python/ python/ --test
Running with 6 jobs
24/24: ✓ All tests passed
No tests for fixes found.
opengrep scan -j 6 -c python/ python/ --test  8.99s user 5.05s system 476% cpu 2.947 total

❯ time opengrep scan -j 60 -c python/ python/ --test
Running with 11 jobs
24/24: ✓ All tests passed
No tests for fixes found.
opengrep scan -j 60 -c python/ python/ --test  13.20s user 6.89s system 690% cpu 2.908 total
```