### PR TITLE
Use opengrep's fork of semgrep-interfaces

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -80,7 +80,7 @@ url = https://github.com/opengrep/semgrep-swift.git
 
 [submodule "OSS/cli/src/semgrep/semgrep_interfaces"]
 path = cli/src/semgrep/semgrep_interfaces
-url = https://github.com/returntocorp/semgrep-interfaces.git
+url = https://github.com/opengrep/semgrep-interfaces.git
 
 [submodule "OSS/languages/julia/tree-sitter/semgrep-julia"]
 path = languages/julia/tree-sitter/semgrep-julia


### PR DESCRIPTION
The `semgrep-interfaces` repo consists the definition of the schema of the output. We want to make custom changes to it, which make it diverge from the semgrep's version, hence we point to our fork instead of the original semgrep's repo.