### PR TITLE
[WIP] Add support for reporting enclosure of matches

### DIFF
--- a/libs/ast_generic/Enclosure.ml
+++ b/libs/ast_generic/Enclosure.ml
@@ -1,0 +1,51 @@
+module AST = AST_generic
+
+type delimiter_kind = Module | Class | Func
+[@@deriving show, eq]
+
+(* delimiter_info values are included in Core_match.t, which is why we
+ * don't include the relevant AST nodes here, not to block the GC from
+ * cleaning up the AST of targets that have been already processed.
+ *)
+type delimiter_info = {
+  kind : delimiter_kind;
+  name : string;
+  range : (Tok.location * Tok.location) option
+}
+[@@deriving show, eq]
+
+type t = delimiter_info list
+[@@deriving show, eq]
+
+let human_readable_entity_name (name : AST.entity_name) : string =
+  match name with
+  | AST.EN (Id ((i, _tok), _)) -> i
+  | AST.EN (IdQualified {name_last = ((i, _tok), _type_args); _}) -> i
+  | _ -> failwith "impossible"
+
+let delimiter_kind_of_definition_kind (kind : AST.definition_kind) : delimiter_kind =
+  match kind with
+  | AST.FuncDef _ -> Func
+  | AST.ClassDef _ -> Class
+  | AST.ModuleDef _ -> Module
+  | _ -> failwith "impossible"
+
+let delimiter_info_of_stmt (stmt : AST.stmt) : delimiter_info =
+  match stmt.s with
+  | AST.DefStmt (entity, kind) ->
+      { kind = delimiter_kind_of_definition_kind kind;
+        name = human_readable_entity_name entity.name;
+        range = AST_generic_helpers.range_of_any_opt (S stmt) }
+  | _ -> failwith "impossible"
+
+let is_stmt_named_delimiter (stmt : AST.stmt) : bool =
+  match stmt.s with
+  | AST.DefStmt ({name = EN _; _},
+      (AST.FuncDef _ | AST.ClassDef _ | AST.ModuleDef _)) -> true
+  | _ -> false
+
+let delimiter_kind_for_output (k : delimiter_kind) : string =
+  match k with
+  | Module -> "module"
+  | Class -> "class"
+  | Func -> "function"

--- a/libs/ast_generic/Enclosure.mli
+++ b/libs/ast_generic/Enclosure.mli
@@ -1,0 +1,21 @@
+(* This module defines functions that help track enclosure of a match.
+ * By "enclosure" we mean named delimiters that the match resides in,
+ * e.g. a method foo within a class C.
+*)
+
+type delimiter_kind = Module | Class | Func
+[@@deriving show, eq]
+
+type delimiter_info = {
+  kind : delimiter_kind;
+  name : string;
+  range : (Tok.location * Tok.location) option
+}
+[@@deriving show, eq]
+
+type t = delimiter_info list
+[@@deriving show, eq]
+
+val is_stmt_named_delimiter : AST_generic.stmt -> bool
+val delimiter_info_of_stmt : AST_generic.stmt -> delimiter_info
+val delimiter_kind_for_output : delimiter_kind -> string

--- a/src/core/Core_match.ml
+++ b/src/core/Core_match.ml
@@ -42,7 +42,6 @@
  * even if it returns the same match than a similar match coming
  * from a pattern:, we should not merge them!
  *)
-
 type t = {
   (* rule (or mini rule) responsible for the pattern match found *)
   rule_id : rule_id; [@equal fun a b -> a.id = b.id]
@@ -84,6 +83,7 @@ type t = {
      `has_as_metavariable` is true of the originating rule.
      Otherwise, we leave it at `None`.
   *)
+  enclosure : Enclosure.t option;
   ast_node : AST_generic.any option;
   (* less: do we need to be lazy? *)
   tokens : Tok.t list Lazy.t; [@equal fun _a _b -> true]

--- a/src/core/Core_match.mli
+++ b/src/core/Core_match.mli
@@ -7,6 +7,7 @@ type t = {
   (* location info *)
   path : Target.path;
   range_loc : Tok.location * Tok.location;
+  enclosure : Enclosure.t option;
   ast_node : AST_generic.any option;
   tokens : Tok.t list Lazy.t;
   (* trace *)

--- a/src/engine/Match_SCA_mode.ml
+++ b/src/engine/Match_SCA_mode.ml
@@ -136,6 +136,7 @@ let check_rule (rule : Rule.t) (xtarget : Lockfile_xtarget.t)
                range_loc = dep.loc;
                (* TODO? *)
                ast_node = None;
+               enclosure = None;
                tokens = lazy dep.toks;
                env = [];
                taint_trace = None;

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -421,6 +421,7 @@ let apply_focus_on_ranges (env : env) (focus_mvars_list : R.focus_mv_list list)
                ast_node =
                  (if env.has_as_metavariable then Some (MV.mvalue_to_any mval)
                   else None);
+               enclosure = None;
                tokens = lazy (MV.ii_of_mval mval);
                env = range.mvars;
                taint_trace = None;

--- a/src/engine/Xpattern_matcher.ml
+++ b/src/engine/Xpattern_matcher.ml
@@ -92,6 +92,7 @@ let (matches_of_matcher :
                               env;
                               taint_trace = None;
                               ast_node = None;
+                              enclosure = None;
                               tokens = lazy [ info_of_token_location loc1 ];
                               engine_of_match = `OSS;
                               validation_state = `No_validator;

--- a/src/osemgrep/cli_ci/Test_is_blocking_helpers.ml
+++ b/src/osemgrep/cli_ci/Test_is_blocking_helpers.ml
@@ -65,6 +65,7 @@ let cli_match_of_finding_with_actions
         validation_state;
         historical_info = None;
         extra_extra = None;
+        enclosure = None;
       };
   }
 

--- a/src/osemgrep/language_server/Unit_LS.ml
+++ b/src/osemgrep/language_server/Unit_LS.ml
@@ -67,6 +67,7 @@ let mock_run_results (files : string list) : Core_runner.result =
         validation_state = Some `No_validator;
         historical_info = None;
         extra_extra = None;
+        enclosure = None;
       }
     in
     let (m : Out.core_match) =

--- a/src/osemgrep/reporting/Cli_json_output.ml
+++ b/src/osemgrep/reporting/Cli_json_output.ml
@@ -274,6 +274,7 @@ let cli_match_of_core_match ~fixed_lines fixed_env (hrules : Rule.hrules)
        is_ignored;
        dataflow_trace;
        sca_match;
+       enclosure
      };
   } ->
       let rule =
@@ -339,6 +340,7 @@ let cli_match_of_core_match ~fixed_lines fixed_env (hrules : Rule.hrules)
             validation_state;
             historical_info;
             extra_extra;
+            enclosure;
           };
       }
 

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -323,6 +323,17 @@ let unsafe_match_to_match
     Metavar_replacement.interpolate_metavars x.rule_id.message
       (Metavar_replacement.of_bindings x.env)
   in
+  let enclosure =
+    x.enclosure |>
+    Option.map
+      (List.map
+        (fun d ->
+          let locs = Option.map (uncurry OutUtils.position_range) d.Enclosure.range in
+          ({name = d.Enclosure.name;
+            kind = Enclosure.delimiter_kind_for_output d.Enclosure.kind;
+            start = Option.map fst locs;
+            end_ = Option.map snd locs} : Out.enclosure_elem)))
+  in
   let path, historical_info =
     match x.path.origin with
     (* We need to do this, because in Terraform, we may end up with a `file` which
@@ -383,6 +394,7 @@ let unsafe_match_to_match
         extra_extra = None;
         (* TODO: use pm.sca_match! *)
         sca_match = None;
+        enclosure;
       };
   }
 

--- a/src/reporting/Unit_core_json_output.ml
+++ b/src/reporting/Unit_core_json_output.ml
@@ -48,6 +48,7 @@ let make_core_match ?(check_id = "fake-rule-id") ?annotated_rule_id
         validation_state = None;
         historical_info = None;
         extra_extra = None;
+        enclosure = None;
       }
   in
   Out.


### PR DESCRIPTION
An "enclosure" (a tentative name) is the syntactic context in which the match resides (A function, class definition, etc.)

Issue: #103

This is a work-in-progress PR. Tasklist:
- [x] Implement logic
- [ ] Add flag to turn this feature on
- [ ] Add tests

At the moment, the enclosure information is given in the `extra` section of the result for a rule. We reveal:

- The kind of the enclosing construct (function, class, or module),
- its name,
- its location in the code.

For example, matching `x = 5` in

```csharp
class MyClass {
  public int MyFunction() {
    int x;
    x = 5;
    return x;
  }
}
```

returns the following enclosure information:

```json
[
  {
    "kind":"function",
    "name":"MyFunction",
    "start":{"line":2, "col":3, "offset":18},
    "end":{"line":6, "col":4, "offset":83}
  },
  {
    "kind":"class",
    "name":"MyClass",
    "start":{"line":1,"col":1,"offset":0},
    "end":{"line":7,"col":2,"offset":85}
  }
]
```

The list is sorted from the innermost to the outermost constructs.