### PR TITLE
Improve aarch64 build: ensure compiler is fixed to 5.3.0

### DIFF
--- a/.github/workflows/build-test-core-aarch64.yml
+++ b/.github/workflows/build-test-core-aarch64.yml
@@ -45,6 +45,7 @@ jobs:
           docker run --rm \
             --volume ${{ github.workspace }}:/workspace \
             --env SHOULD_INIT_OPAM=${{ env.SHOULD_INIT_OPAM }} \
+            --env OCAML_VERSION=${{ matrix.ocaml_version }} \
             --workdir /workspace \
             alpine:3.21.3 \
             sh -c \

--- a/scripts/workflow-build-inside-alpine-container.sh
+++ b/scripts/workflow-build-inside-alpine-container.sh
@@ -8,7 +8,7 @@ export OPAMCONFIRMLEVEL=unsafe-yes
 export OPAMCOLOR=always
 
 # OPAM_VERSION="2.3.0"
-# OCAML_VERSION="5.3.0"
+OCAML_VERSION=${OCAML_VERSION:-"5.3.0"}
 SHOULD_INIT_OPAM=${SHOULD_INIT_OPAM:-true}
 
 # Install opam and other dependencies.


### PR DESCRIPTION
This was 5.3.0 but only because this is the latest compiler, as the env variable was commented out.