### PR TITLE
Warn if --output-enclosing-context without --json

### DIFF
--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -191,6 +191,10 @@ let scan_subset_cmdline_term : Scan_CLI.conf Term.t =
       scan_unknown_extensions secrets text text_outputs timeout
       _timeout_interfileTODO timeout_threshold (* trace trace_endpoint *) use_git
       version_check vim vim_outputs =
+    if output_enclosing_context && not json then
+      Logs.warn (fun m ->
+          m
+            "The --output-enclosing-context option has no effect without --json.");
     let output_format : Output_format.t =
       Scan_CLI.output_format_conf ~text ~files_with_matches ~json ~emacs ~vim
         ~sarif ~gitlab_sast ~gitlab_secrets ~junit_xml

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -1317,6 +1317,10 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
             "!!! You're using one or more options starting with '--x-'. These \
              options are not part of the opengrep API. They will change or will \
              be removed without notice !!! ");
+    if output_enclosing_context && not json then
+      Logs.warn (fun m ->
+          m
+            "The --output-enclosing-context option has no effect without --json.");
     let target_roots, imply_always_select_explicit_targets =
       replace_target_roots_by_regular_files_where_needed caps
         ~experimental:(common.CLI_common.maturity =*= Maturity.Experimental)


### PR DESCRIPTION
At the moment, the enclosing context captured when run with `--output-enclosing-context` shows up only in the `--json` output. So, if the user specifies the former but not the latter, we emit a warning that the former will have no effect.

NB. Adding enclosing context in other outputs should be easy and can be added to opengrep on-demand

