### PR TITLE
Fix version check url for future

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_regex/test_regex_rule__issue2465/results.json
+++ b/cli/tests/default/e2e/snapshots/test_regex/test_regex_rule__issue2465/results.json
@@ -18,7 +18,7 @@
         "engine_kind": "OSS",
         "fingerprint": "0x42",
         "is_ignored": false,
-        "lines": "Foo==1.1.1",
+        "lines": "Foo==<MASKED>",
         "message": "Found $TAG",
         "metadata": {},
         "metavars": {},

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -145,7 +145,7 @@ let o_version_check : bool Term.t =
   H.negatable_flag_with_env [ "enable-version-check" ]
     ~neg_options:[ "disable-version-check" ]
     ~default:default.version_check
-    ~env:(Cmd.Env.info "SEMGREP_ENABLE_VERSION_CHECK")
+    ~env:(Cmd.Env.info "OPENGREP_ENABLE_VERSION_CHECK")
     ~doc:
       {|Checks Opengrep servers to see if the latest version is run; disabling
  this may reduce exit time after returning results.

--- a/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -147,13 +147,13 @@ let of_current_sys_env () : t =
     (* integration_name can take a label like "funkyintegration" for custom partner integrations *)
     integration_name = env_opt "SEMGREP_INTEGRATION_NAME";
     version_check_url =
-      env_or Uri.of_string "SEMGREP_VERSION_CHECK_URL"
-        (Uri.of_string "https://semgrep.dev/api/check-version");
+      env_or Uri.of_string "OPENGREP_VERSION_CHECK_URL"
+        (Uri.of_string "https://opengrep.dev/api/check-version");
     version_check_timeout =
-      env_or int_of_string "SEMGREP_VERSION_CHECK_TIMEOUT" 2;
+      env_or int_of_string "OPENGREP_VERSION_CHECK_TIMEOUT" 2;
     version_check_cache_path =
-      env_or Fpath.v "SEMGREP_VERSION_CACHE_PATH"
-        (Fpath.v (Sys.getcwd ()) / ".cache" / "semgrep_version");
+      env_or Fpath.v "OPENGREP_VERSION_CACHE_PATH"
+        (Fpath.v (Sys.getcwd ()) / ".cache" / "opengrep_version");
     git_command_timeout = env_or int_of_string "SEMGREP_GIT_COMMAND_TIMEOUT" 300;
     src_directory = env_or Fpath.v "SEMGREP_SRC_DIRECTORY" (Fpath.v "/src");
     (* user_agent_append is a literal string like "(Docker)" for inclusion in our metrics user agent field *)

--- a/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -83,7 +83,7 @@ let env_truthy var =
  *)
 type t = {
   semgrep_url : Uri.t;
-  fail_open_url : Uri.t;
+  (* fail_open_url : Uri.t; *)
   metrics_url : Uri.t;
   app_token : Auth.token option;
   integration_name : string option;
@@ -137,9 +137,9 @@ let of_current_sys_env () : t =
              (env_opt "SEMGREP_APP_URL"
              |> Option.value ~default:"https://semgrep.dev")
       |> Uri.of_string;
-    fail_open_url =
-      env_or Uri.of_string "SEMGREP_FAIL_OPEN_URL"
-        (Uri.of_string "https://fail-open.prod.semgrep.dev/failure");
+    (* fail_open_url =
+         env_or Uri.of_string "SEMGREP_FAIL_OPEN_URL"
+           (Uri.of_string "https://fail-open.prod.semgrep.dev/failure"); *)
     metrics_url =
       env_or Uri.of_string "SEMGREP_METRICS_URL" Metrics_.metrics_url;
     app_token =

--- a/src/osemgrep/configuring/Semgrep_envvars.mli
+++ b/src/osemgrep/configuring/Semgrep_envvars.mli
@@ -12,7 +12,7 @@ type t = {
   (* $SEMGREP_URL | $SEMGREP_APP_URL *)
   semgrep_url : Uri.t;
   (* $SEMGREP_FAIL_OPEN_URL *)
-  fail_open_url : Uri.t;
+  (* fail_open_url : Uri.t; *)
   (* $SEMGREP_METRICS_URL *)
   metrics_url : Uri.t;
   app_token : Auth.token option;


### PR DESCRIPTION
### Changes

- In anticipation of re-enabling the live version check (should we want to), this replaces an env variable. Note that we have already disabled the actual call to check for the latest version anyway, and this continues to be the case.
- Removes unused `fail_open_url`.
- Fixes a python test snapshot (not sure why this happens and it was not caught before).