### PR TITLE
Fix: .semgrepignore not working on windows when path is not relative

### DIFF
--- a/.github/workflows/build-manylinux-binary.yml
+++ b/.github/workflows/build-manylinux-binary.yml
@@ -107,7 +107,7 @@ jobs:
 
   test-manylinux-binary:
     needs: build-self-contained-manylinux-binary
-    runs-on: ${{ inputs.arch == 'x86_64' && 'ubuntu-20.04' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ inputs.arch == 'x86_64' && 'ubuntu-22.04' || 'ubuntu-24.04-arm' }}
     steps:
       - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -243,9 +243,9 @@ jobs:
           opam env
 
           # opam pin --no-action add semgrep.dev .
-          echo "Pinning local packages..."
-          for f in opam/*.opam;
-            do opam pin --no-action add "$(basename "$f" .opam).dev" .; done;
+          # echo "Pinning local packages..."
+          # for f in opam/*.opam;
+          #   do opam pin --no-action add "$(basename "$f" .opam).dev" .; done;
 
           echo "Installing dune..."
           opam install dune

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -117,7 +117,6 @@ jobs:
           prerelease: true
           body: |
             This is a rolling release from `main`.
-            Note that the Windows version is not yet functional, but can be tested if the following parameters are passed to the `scan` command in addition to any other parameters: `-j 1 --timeout 0`.
           files: |
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86
             artifacts/opengrep_manylinux_binary_aarch64/opengrep_manylinux_aarch64

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ core-test-e2e:
 # version constraints incompatibilities.
 #
 REQUIRED_DEPS = \
- ./ \
+ ./opam/*.opam \
  ./libs/ocaml-tree-sitter-core/tree-sitter.opam \
   ./dev/required.opam \
   $(EXTRA_OPAM_DEPS)

--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ core-test-e2e:
 # version constraints incompatibilities.
 #
 REQUIRED_DEPS = \
- ./opam/*.opam \
+ ./opam/semgrep.opam \
  ./libs/ocaml-tree-sitter-core/tree-sitter.opam \
   ./dev/required.opam \
   $(EXTRA_OPAM_DEPS)

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -137,9 +137,9 @@ install_requires = [
 
 setuptools.setup(
     name="opengrep",
-    version="v1.0.0-alpha.2",
-    author="Semgrep Inc.",
-    author_email="support@semgrep.com",
+    version="v1.1.2",
+    author="Semgrep Inc., Opengrep",
+    author_email="support@opengrep.com",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",
     cmdclass=cmdclass,
     install_requires=install_requires,

--- a/cli/src/semgrep/console_scripts/entrypoint.py
+++ b/cli/src/semgrep/console_scripts/entrypoint.py
@@ -45,6 +45,7 @@ import subprocess
 # import requests
 import semgrep.main
 import semgrep.cli
+from semgrep.constants import IS_WINDOWS
 # from semgrep import tracing
 
 # alt: you can also add '-W ignore::DeprecationWarning' after the python3 above,
@@ -64,8 +65,6 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 PATH = os.environ.get("PATH", "")
 # nosem: no-env-vars-on-top-level
 os.environ["PATH"] = PATH + os.pathsep + sysconfig.get_path("scripts")
-
-IS_WINDOWS = platform.system() == "Windows"
 
 PRO_FLAGS = ["--pro", "--pro-languages", "--pro-intrafile"]
 

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -1,8 +1,11 @@
 import re
+import sys
 from enum import auto
 from enum import Enum
 
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
+
+IS_WINDOWS = sys.platform.startswith("win32") or sys.platform.startswith("cygwin")
 
 RULES_KEY = "rules"
 MISSED_KEY = "missed"  # The number of Pro rules missed out on

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -33,7 +33,7 @@ from semgrep.app import auth
 from semgrep.config_resolver import Config
 from semgrep.console import console
 from semgrep.constants import Colors
-from semgrep.constants import PLEASE_FILE_ISSUE_TEXT
+from semgrep.constants import PLEASE_FILE_ISSUE_TEXT, IS_WINDOWS
 from semgrep.core_output import core_error_to_semgrep_error
 from semgrep.core_output import core_matches_to_rule_matches
 from semgrep.core_targets_plan import Plan
@@ -71,7 +71,6 @@ INPUT_BUFFER_LIMIT: int = 1024 * 1024 * 1024
 # test/e2e/test_performance.py is one test that exercises this risk.
 LARGE_READ_SIZE: int = 1024 * 1024 * 512
 
-IS_WINDOWS = platform.system() == "Windows"
 if not IS_WINDOWS:
     import resource
 

--- a/cli/src/semgrep/env.py
+++ b/cli/src/semgrep/env.py
@@ -99,12 +99,12 @@ class Env:
 
     @version_check_timeout.default
     def version_check_timeout_default(self) -> int:
-        value = os.getenv("SEMGREP_VERSION_CHECK_TIMEOUT", "2")
+        value = os.getenv("OPENGREP_VERSION_CHECK_TIMEOUT", "2")
         return int(value)
 
     @version_check_cache_path.default
     def version_check_cache_path_default(self) -> Path:
-        value = os.getenv("SEMGREP_VERSION_CACHE_PATH")
+        value = os.getenv("OPENGREP_VERSION_CACHE_PATH")
         if value:
             return Path(value)
         return Path.home() / ".cache" / "opengrep_version"

--- a/cli/src/semgrep/formatter/sarif.py
+++ b/cli/src/semgrep/formatter/sarif.py
@@ -15,8 +15,8 @@ import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.error import SemgrepError
 from semgrep.rule import Rule
 from semgrep.rule_match import RuleMatch
+# from semgrep.constants import IS_WINDOWS
 
-IS_WINDOWS = platform.system() == "Windows"
 
 class SarifFormatter(base.BaseFormatter):
     def keep_ignores(self) -> bool:

--- a/cli/src/semgrep/ignores.py
+++ b/cli/src/semgrep/ignores.py
@@ -291,4 +291,7 @@ class Processor:
             for unescaped in self.unescape(pat)
             for pattern in self.to_fnmatch(unescaped)
         }
+        if IS_WINDOWS:
+            # This is needed for Cygwin:
+            patterns = {p.replace("/", "\\") for p in patterns}
         return patterns

--- a/cli/src/semgrep/ignores.py
+++ b/cli/src/semgrep/ignores.py
@@ -28,17 +28,6 @@ IGNORE_FILE_NAME = ".semgrepignore"
 
 logger = getLogger(__name__)
 
-
-# path.is_relative_to is only available starting with Python 3.9
-# So we just copy its implementation
-def path_is_relative_to(p1: Path, p2: Path) -> bool:
-    try:
-        p1.relative_to(p2)
-        return True
-    except ValueError:
-        return False
-
-
 @frozen
 class FileIgnore:
     # Pysemgrep supports only one '.semgrepignore' file, and it must be in the

--- a/cli/src/semgrep/ignores.py
+++ b/cli/src/semgrep/ignores.py
@@ -13,7 +13,7 @@ from attr import frozen
 from attrs import define
 from boltons.iterutils import partition
 
-from semgrep.constants import TOO_MUCH_DATA
+from semgrep.constants import TOO_MUCH_DATA, IS_WINDOWS
 from semgrep.error import SemgrepError
 from semgrep.state import get_state
 from semgrep.types import FilteredFiles

--- a/cli/src/semgrep/ignores.py
+++ b/cli/src/semgrep/ignores.py
@@ -48,15 +48,16 @@ class FileIgnore:
         # For example, the fnmatch pattern 'tests' will match the paths
         # 'tests' and 'tests/foo'.
 
-        path.is_dir()
-        path_is_relative_to_base = path_is_relative_to(path, self.base_path)
+        # path.is_dir() # NOTE (dimitris): This has no effect.
+        path_is_relative_to_base = path.is_relative_to(self.base_path)
         matchable_path = (
             str(path.relative_to(self.base_path))
             if path_is_relative_to_base
             else str(path)
         )
+        star_star_pat_prefix = "**/" if not IS_WINDOWS else "**\\"
         for pat in self.fnmatch_patterns:
-            if path_is_relative_to_base or pat.startswith("**/"):
+            if path_is_relative_to_base or pat.startswith(star_star_pat_prefix):
                 if fnmatch.fnmatch(matchable_path, pat):
                     return False
         return True

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -139,6 +139,10 @@ def get_file_ignore(max_log_list_entries: int) -> FileIgnore:
                 raise FilesNotFoundError(
                     f"Could not find {IGNORE_FILE_NAME} in {TEMPLATES_DIR}"
                 )
+            else:
+                logger.verbose(
+                    f"Using default .semgrepignore rules from {semgrepignore_path}"
+                )
         else:
             logger.verbose("using path ignore rules from user provided .semgrepignore")
 

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -106,7 +106,12 @@ logger = getLogger(__name__)
 
 
 def get_file_ignore(max_log_list_entries: int) -> FileIgnore:
-    TEMPLATES_DIR = Path(__file__).parent / "templates"
+    if getattr(sys, 'frozen', False) and hasattr(sys, '_MEIPASS'):
+        # Running in pyinstaller bundle:
+        base_path = Path(sys._MEIPASS) / "semgrep"
+    else:
+        base_path = Path(__file__).parent
+    TEMPLATES_DIR = base_path / "templates"
     try:
         workdir = Path.cwd()
     except FileNotFoundError:

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -133,6 +133,12 @@ def get_file_ignore(max_log_list_entries: int) -> FileIgnore:
                 "No .semgrepignore found. Using default .semgrepignore rules. See the docs for the list of default ignores: https://semgrep.dev/docs/cli-usage/#ignore-files"
             )
             semgrepignore_path = TEMPLATES_DIR / IGNORE_FILE_NAME
+            # This should never fail, so it could even be an assertion, but this
+            # is more informative in the event it does happen.
+            if not semgrepignore_path.is_file():
+                raise FilesNotFoundError(
+                    f"Could not find {IGNORE_FILE_NAME} in {TEMPLATES_DIR}"
+                )
         else:
             logger.verbose("using path ignore rules from user provided .semgrepignore")
 

--- a/cli/src/semgrep/semgrep_core.py
+++ b/cli/src/semgrep/semgrep_core.py
@@ -5,14 +5,13 @@ import shutil
 import sys
 from pathlib import Path
 from typing import Optional
+from semgrep.constants import IS_WINDOWS
 
 from semgrep.verbose_logging import getLogger
 
 logger = getLogger(__name__)
 
 VERSION_STAMP_FILENAME = "pro-installed-by.txt"
-
-IS_WINDOWS = platform.system() == "Windows"
 
 
 def compute_executable_path(exec_name: str) -> Optional[str]:

--- a/dune-project
+++ b/dune-project
@@ -27,7 +27,7 @@
 (opam_file_location inside_opam_directory)
 
 ;; set here so the semgrep package below can use it and we can easily bump it
-(version 1.100.0) ; TODO (dimitris): Eventually move to Opengrep versioning.
+(version 1.100.0) ; TODO: Bump as per our version, but this ruins caching.
 
 ;; Default attributes of opam packages
 (source (github opengrep/opengrep))
@@ -467,7 +467,7 @@ For more information see https://opengrep.dev.
     ; (is it, though?), we need a version that doesn't register
     ; rogue exception printers.
     ; See https://github.com/janestreet/base/issues/146
-    (base (>= v0.15.1))
+    (base (>= v0.17.1))
     fpath
     bos
     fileutils
@@ -501,7 +501,7 @@ For more information see https://opengrep.dev.
     ppx_deriving_yojson
     ppx_hash
     ppx_inline_test
-    (ppx_sexp_conv ( = v0.16.0))
+    (ppx_sexp_conv (>= v0.16.0))
     ppx_expect
     (visitors (= 20250212))
     ; regexps

--- a/opam/semgrep.opam
+++ b/opam/semgrep.opam
@@ -24,7 +24,7 @@ depends: [
   "ocaml" {>= "5.2.1"}
   "dune" {>= "3.8" & >= "3.7"}
   "menhir" {= "20230608"}
-  "base" {>= "v0.15.1"}
+  "base" {>= "v0.17.1"}
   "fpath"
   "bos"
   "fileutils"
@@ -50,7 +50,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_hash"
   "ppx_inline_test"
-  "ppx_sexp_conv" {= "v0.16.0"}
+  "ppx_sexp_conv" {>= "v0.16.0"}
   "ppx_expect"
   "visitors" {= "20250212"}
   "re"

--- a/src/targeting/Semgrepignore.mli
+++ b/src/targeting/Semgrepignore.mli
@@ -26,7 +26,7 @@ type exclusion_mechanism = {
    The project_root path must exist. It is used to
    locate .gitignore and .semgrepignore files.
 
-   This is an instanciation of Gitignore_filter.t specific to Semgrep.
+   This is an instantiation of Gitignore_filter.t specific to Semgrep.
 
    Use Git_project.find_project_root to determine the root of the
    git project.


### PR DESCRIPTION
### Changes
- Fix fnmatch [.semgrepignore] patterns on windows, where / should become \\
- Fix dependencies (esp. base version)
- Fix Makefile, we moved the .opam files to opam/ and this was not reflected in all places
- Cleanup rolling release text
- Bump ubuntu 20.04 since CI started to fail, now we use the oldest available version when needed
- Fix a couple of env variables that we are migrating to have `OPENGREP_` prefix

Closes #193 in 274f993dffaac510d14a49b2c22971abcb696112