### PR TITLE
Start memprof-limits

### DIFF
--- a/src/main/Main.ml
+++ b/src/main/Main.ml
@@ -134,6 +134,7 @@ let check_experimental_flags (argv : string array) : unit =
  * semgrep-core or osemgrep (or semgrep) behavior.
  *)
 let () =
+  Memprof_limits.start_memprof_limits ();
   Cap.main (fun (caps : Cap.all_caps) ->
       let argv = CapSys.argv caps#argv in
       let argv0 =


### PR DESCRIPTION
In order to safely use memprof-limits in the program, you need to start the memprof-limits engine

https://ocaml.org/p/memprof-limits/0.2.1/doc/Memprof_limits/index.html#val-start_memprof_limits
