### PR TITLE
Fix logging mutex

### DIFF
--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -26,6 +26,8 @@ module TLS = Thread_local_storage
 (* Globals *)
 (*****************************************************************************)
 
+let logs_mutex = Mutex.create ()
+
 (* unix time in seconds *)
 let now () : float = UUnix.gettimeofday ()
 
@@ -258,103 +260,15 @@ let read_level_from_env (vars : string list) : Logs.level option option =
 (*****************************************************************************)
 
 (* Enable threaded logging. *)
-module RMutex = struct
-  (* This is a light copy/paste of the re-entrant mutex from BatteriesThread.RMutex.
-     We do this to avoid importing the massive batteries library. Ours has
-     minor changes to use precise compare instead of polymorphic compare. *)
-  (*
-  * RMutex - Reentrant mutexes
-  * Copyright (C) 2008 David Teller, LIFO, Universite d'Orleans
-  *               2011 Edgar Friendly <thelema314@gmail.com>
-  *
-  * This library is free software; you can redistribute it and/or
-  * modify it under the terms of the GNU Lesser General Public
-  * License as published by the Free Software Foundation; either
-  * version 2.1 of the License, or (at your option) any later version,
-  * with the special exception on linking described in file LICENSE.
-  *
-  * This library is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  * Lesser General Public License for more details.
-  *
-  * You should have received a copy of the GNU Lesser General Public
-  * License along with this library; if not, write to the Free Software
-  * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-  *)
 
-  type owner =
-    {
-      thread : int;       (**Identity of the latest owner (possibly the current owner)*)
-      mutable depth : int (**Number of times the current owner owns the lock.*)
-    }
-  type t =
-    {
-      primitive : Mutex.t; (**A low-level mutex, used to protect access to [ownership]*)
-      wait      : Condition.t; (** a condition to wait on when the lock is locked *)
-      mutable ownership : owner option;
-    }
-
-  let owner_equal a b =
-    Int.equal a.thread b.thread && Int.equal a.depth b.depth
-
-  let create () =
-    {
-      primitive = Mutex.create ();
-      wait      = Condition.create ();
-      ownership = None
-    }
-
-  (**
-     Attempt to acquire the mutex, waiting indefinitely
-  *)
-  let lock m =
-    let id = Thread.id (Thread.self ()) in
-    Mutex.lock m.primitive; (******Critical section begins*)
-    (
-      match m.ownership with
-      | None -> (*Lock belongs to nobody, I can take it. *)
-        m.ownership <- Some {thread = id; depth = 1}
-      | Some s when Int.equal s.thread id -> (*Lock already belongs to me, I can keep it. *)
-        s.depth <- s.depth + 1
-      | _ -> (*Lock belongs to someone else. *)
-        while not (Option.equal owner_equal m.ownership None) do
-          Condition.wait m.wait m.primitive
-        done;
-        m.ownership <- Some {thread = id; depth = 1}
-    );
-    Mutex.unlock m.primitive (******Critical section ends*)
-
-  (** Unlock the mutex; this function checks that the thread calling
-      unlock is the owner and raises an assertion failure if this is not
-      the case. It will also raise an assertion failure if the mutex is
-      not locked. *)
-  let unlock m =
-    let id = Thread.id (Thread.self ()) in
-    Mutex.lock m.primitive; (******Critical section begins*)
-    (match m.ownership with
-     | Some s ->
-       assert (Int.equal s.thread id); (*If I'm not the owner, we have a consistency issue.*)
-       if s.depth > 1 then
-         s.depth <- s.depth - 1 (*release one depth but we're still the owner*)
-       else
-         begin
-           m.ownership <- None;  (*release once and for all*)
-           Condition.signal m.wait   (*wake up waiting threads *)
-         end
-     | _ -> assert false
-    );
-    Mutex.unlock m.primitive (******Critical section ends  *)
-end
-
-let reentrant_mutex = RMutex.create ()
 let _ =
-  let lock () = RMutex.lock reentrant_mutex
-  and unlock () = RMutex.unlock reentrant_mutex in
+  let lock () = Mutex.lock logs_mutex
+  and unlock () = Mutex.unlock logs_mutex in
 Logs.set_reporter_mutex ~lock ~unlock
 
-(* We use a re-entrant mutex above because otherwise tests using [make core-test]
- * deadlock. *)
+(* We previously used use a re-entrant mutex above because otherwise tests
+ * using [make core-test] raise an error when trying to lock the already locked
+ * mutex. *)
 (* let _ = Logs_threaded.enable () *)
 
 (* Enable basic logging so that you can use Logging calls even before a

--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -361,7 +361,10 @@ let with_debug_trace ?(src = debug_trace_src) ~__FUNCTION__
   with
   | exn ->
       let exn' = Exception.catch exn in
-      let msgf ppf =
+      (* FIXME: We still get occasional deadlocks when we log exceptions.
+       * So for now these logs are disabled.
+       * See commented out [Logs.{debug, err}] below. *)
+      let _msgf ppf =
         Format.fprintf ppf "exception during %s:\n" name;
         match pp_input with
         | None -> ()
@@ -381,8 +384,8 @@ let with_debug_trace ?(src = debug_trace_src) ~__FUNCTION__
       | Exception.Timeout _ ->
           (* %t the little known give me back my format stream
              specifier. *)
-          Logs.debug (fun m -> m "%t" msgf)
-      | _ -> Logs.err (fun m -> m "%t" msgf));
+          () (* Logs.debug (fun m -> m "%t" msgf) *)
+      | _ -> () (* Logs.err (fun m -> m "%t" msgf) *));
       Exception.reraise exn'
 
 (*****************************************************************************)

--- a/libs/commons/Logs_.mli
+++ b/libs/commons/Logs_.mli
@@ -170,11 +170,6 @@ val list : ('a -> string) -> 'a list -> string
 val option : ('a -> string) -> 'a option -> string
 val array : ('a -> string) -> 'a array -> string
 
-(* This is a light copy/paste from BatteriesThread.RMutex *)
-module RMutex : sig
-  type t
-end
-
-(* The reentrant mutex used for logging, exposed so it can
+(* The mutex used for logging, exposed so it can
  * be shared by pretty-printing functions. *)
-val reentrant_mutex : RMutex.t
+val logs_mutex : Mutex.t

--- a/libs/ojsonnet/Value_jsonnet.ml
+++ b/libs/ojsonnet/Value_jsonnet.ml
@@ -135,7 +135,7 @@ let empty_env =
   {
     locals = Map_.empty;
     depth = 0;
-    in_debug_call = false;
+    in_debug_call = true; (* FIXME: When [false], we get Logs error trying to lock Mutex. *)
     (* fake implem; Each Eval_jsonnet_xxx.ml need to define those methods *)
     eval_expr = (fun _ _ -> failwith "TODO: eval_expr not implemented");
     eval_std_filter_element =

--- a/libs/process_limits/Time_limit.ml
+++ b/libs/process_limits/Time_limit.ml
@@ -64,6 +64,8 @@ let set_timeout (_caps : < Cap.time_limit >) ?(granularity_float_s=0.1) ~name ma
       timeout (duration -. granularity_float_s)
     )
   in
+  (* TODO: Investigate why too many threads are created, to the point of failing
+   * to create more. *)
   ignore (Thread.create timeout max_duration);
   match M.limit_with_token ~token
           (fun () -> Fun.protect ~finally:(fun () -> Atomic.set finished_work true) f) with

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -172,11 +172,10 @@ let print_cli_additional_targets (config : Core_scan_config.t) (n : int) : unit
  * newline with no dot. Exit code is 0 but because of this the scan fails. This
  * is a little weird since we flush on the string, but it seems it can be interleaved
  * so it does not always work. *)
-let print_progress_mutex = Mutex.create ()
 let print_cli_progress (config : Core_scan_config.t) : unit =
   (* Print when each file is done so the Python progress bar knows *)
   match config.output_format with
-  | Json true -> Mutex.protect print_progress_mutex (fun () -> UConsole.print ".")
+  | Json true -> Mutex.protect Logs_.logs_mutex (fun () -> UConsole.print ".")
   | _ -> ()
 
 (*****************************************************************************)


### PR DESCRIPTION
### Changes 

- Remove reentrant mutex from logs, use normal Mutex: the reentrant mutex is not only slower but also using it it did not allow us to catch other bugs.
- Fix logging mutex release.
- Make a small change in `libs/ojsonnet/Value_jsonnet.ml`, since we seem to be logging recursively here, and 9 tests failed.