### PR TITLE
Add --opengrepignore-file flag 

### DIFF
--- a/scripts/lint-ocaml
+++ b/scripts/lint-ocaml
@@ -18,7 +18,7 @@ set -eu
 # Note however that the pre-commit CI action may loop forever if
 # you leave those commands uncommented (no idea why, go figure again).
 
-if [[ -v SKIP_OCAMLFORMAT ]]; then
+if [ -n "${SKIP_OCAMLFORMAT:-}" ]; then
   echo "*** SKIP_OCAMLFORMAT is set. Skipping ocamlformat step!"
   exit 0
 fi

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -263,6 +263,7 @@ let scan_subset_cmdline_term : Scan_CLI.conf Term.t =
         respect_gitignore = use_git;
         respect_semgrepignore_files = not ignore_semgrepignore_files;
         exclude_minified_files;
+        semgrepignore_filename = None;
       }
     in
     let rule_filtering_conf =
@@ -315,6 +316,7 @@ let scan_subset_cmdline_term : Scan_CLI.conf Term.t =
         allow_local_builds;
         ls = false;
         ls_format = Ls_subcommand.default_format;
+        semgrepignore_filename = None;
       }
   in
   (* Term defines 'const' but also the '$' operator *)
@@ -378,13 +380,13 @@ let cmdline_term : conf Term.t =
     }
   in
   Term.(
-    const combine $ scan_subset_cmdline_term $ o_audit_on 
+    const combine $ scan_subset_cmdline_term $ o_audit_on
     $ o_dry_run $ o_internal_ci_scan_results
     $ o_x_dump_n_rule_partitions $ o_x_dump_rule_partitions_dir
     $ o_x_merge_partial_results_dir $ o_x_merge_partial_results_output
     $ o_x_partial_config $ o_x_partial_output
     $ o_x_validate_partial_results_actual
-    $ o_x_validate_partial_results_expected $ o_subdir 
+    $ o_x_validate_partial_results_expected $ o_subdir
     $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env)
 
 let doc = "the recommended way to run opengrep in CI"

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -186,15 +186,16 @@ let scan_subset_cmdline_term : Scan_CLI.conf Term.t =
       json json_outputs junit_xml junit_xml_outputs matching_explanations
       max_chars_per_line max_lines_per_finding max_log_list_entries
       max_memory_mb max_target_bytes metrics num_jobs no_secrets_validation
-      nosem optimizations oss output output_enclosing_context pro pro_intrafile pro_lang
-      pro_path_sensitive rewrite_rule_ids sarif sarif_outputs
+      nosem optimizations oss output output_enclosing_context pro pro_intrafile
+      pro_lang pro_path_sensitive rewrite_rule_ids sarif sarif_outputs
       scan_unknown_extensions secrets text text_outputs timeout
-      _timeout_interfileTODO timeout_threshold (* trace trace_endpoint *) use_git
-      version_check vim vim_outputs =
+      _timeout_interfileTODO timeout_threshold
+      (* trace trace_endpoint *) use_git version_check vim vim_outputs =
     if output_enclosing_context && not json then
       Logs.warn (fun m ->
           m
-            "The --output-enclosing-context option has no effect without --json.");
+            "The --output-enclosing-context option has no effect without \
+             --json.");
     let output_format : Output_format.t =
       Scan_CLI.output_format_conf ~text ~files_with_matches ~json ~emacs ~vim
         ~sarif ~gitlab_sast ~gitlab_secrets ~junit_xml
@@ -275,7 +276,7 @@ let scan_subset_cmdline_term : Scan_CLI.conf Term.t =
       }
     in
     let matching_conf =
-      {Match_patterns.track_enclosing_context = output_enclosing_context}
+      { Match_patterns.track_enclosing_context = output_enclosing_context }
     in
     (* warnings.
      * ugly: TODO: remove the Default guard once we get the warning message
@@ -337,12 +338,14 @@ let scan_subset_cmdline_term : Scan_CLI.conf Term.t =
     $ SC.o_max_lines_per_finding $ SC.o_max_log_list_entries
     $ SC.o_max_memory_mb $ SC.o_max_target_bytes $ SC.o_metrics $ SC.o_num_jobs
     $ SC.o_no_secrets_validation $ SC.o_nosem $ SC.o_optimizations $ SC.o_oss
-    $ SC.o_output $ SC.o_output_enclosing_context $ SC.o_pro $ SC.o_pro_intrafile $ SC.o_pro_languages
-    $ SC.o_pro_path_sensitive $ SC.o_rewrite_rule_ids $ SC.o_sarif
-    $ SC.o_sarif_outputs $ SC.o_scan_unknown_extensions $ SC.o_secrets
-    $ SC.o_text $ SC.o_text_outputs $ SC.o_timeout $ SC.o_timeout_interfile
-    $ SC.o_timeout_threshold $ (* SC.o_trace $ SC.o_trace_endpoint $ *) SC.o_use_git
-    $ SC.o_version_check $ SC.o_vim $ SC.o_vim_outputs)
+    $ SC.o_output $ SC.o_output_enclosing_context $ SC.o_pro
+    $ SC.o_pro_intrafile $ SC.o_pro_languages $ SC.o_pro_path_sensitive
+    $ SC.o_rewrite_rule_ids $ SC.o_sarif $ SC.o_sarif_outputs
+    $ SC.o_scan_unknown_extensions $ SC.o_secrets $ SC.o_text
+    $ SC.o_text_outputs $ SC.o_timeout $ SC.o_timeout_interfile
+    $ SC.o_timeout_threshold
+    $ (* SC.o_trace $ SC.o_trace_endpoint $ *)
+    SC.o_use_git $ SC.o_version_check $ SC.o_vim $ SC.o_vim_outputs)
 
 (*************************************************************************)
 (* Turn argv into conf *)
@@ -354,12 +357,12 @@ let cmdline_term : conf Term.t =
    * it below so we can get a nice man page documenting those environment
    * variables (Romain's idea).
    *)
-  let combine scan_conf audit_on (* code secrets *) dry_run _internal_ci_scan_results
-      _x_dump_n_rule_partitions _x_dump_rule_partitions_dir
-      x_merge_partial_results_dir x_merge_partial_results_output
-      _x_partial_config _x_partial_output x_validate_partial_results_actual
-      x_validate_partial_results_expected subdir (*  supply_chain *) suppress_errors
-      _git_meta _github_meta =
+  let combine scan_conf audit_on (* code secrets *) dry_run
+      _internal_ci_scan_results _x_dump_n_rule_partitions
+      _x_dump_rule_partitions_dir x_merge_partial_results_dir
+      x_merge_partial_results_output _x_partial_config _x_partial_output
+      x_validate_partial_results_actual x_validate_partial_results_expected
+      subdir (*  supply_chain *) suppress_errors _git_meta _github_meta =
     {
       scan_conf;
       audit_on;
@@ -380,14 +383,13 @@ let cmdline_term : conf Term.t =
     }
   in
   Term.(
-    const combine $ scan_subset_cmdline_term $ o_audit_on
-    $ o_dry_run $ o_internal_ci_scan_results
-    $ o_x_dump_n_rule_partitions $ o_x_dump_rule_partitions_dir
-    $ o_x_merge_partial_results_dir $ o_x_merge_partial_results_output
-    $ o_x_partial_config $ o_x_partial_output
+    const combine $ scan_subset_cmdline_term $ o_audit_on $ o_dry_run
+    $ o_internal_ci_scan_results $ o_x_dump_n_rule_partitions
+    $ o_x_dump_rule_partitions_dir $ o_x_merge_partial_results_dir
+    $ o_x_merge_partial_results_output $ o_x_partial_config $ o_x_partial_output
     $ o_x_validate_partial_results_actual
-    $ o_x_validate_partial_results_expected $ o_subdir
-    $ o_suppress_errors $ Git_metadata.env $ Github_metadata.env)
+    $ o_x_validate_partial_results_expected $ o_subdir $ o_suppress_errors
+    $ Git_metadata.env $ Github_metadata.env)
 
 let doc = "the recommended way to run opengrep in CI"
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -256,9 +256,9 @@ CHANGE OR DISAPPEAR WITHOUT NOTICE.
 let x_semgrepignore_filename : string option Term.t =
   let info =
     Arg.info
-      [ "ignore-config" ]
+      [ "opengrepignore-file" ]
       ~doc:
-        {|Specify a custom ignore configuration file instead of the default.
+        {|Specify a custom ignore file to use instead of the default '.semgrepignore'.
 This option allows using a custom file for ignoring files during scanning.
 REQUIRES --experimental|}
   in

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -47,6 +47,7 @@ type conf = {
   ls : bool;
   (* --x-ls-long: *)
   ls_format : Ls_subcommand.format;
+  semgrepignore_filename : string option;
 }
 [@@deriving show]
 
@@ -122,6 +123,7 @@ val o_rewrite_rule_ids : bool Cmdliner.Term.t
 val o_sarif : bool Cmdliner.Term.t
 val o_sarif_outputs : string list Cmdliner.Term.t
 val o_scan_unknown_extensions : bool Cmdliner.Term.t
+val o_semgrepignore_filename : string option Cmdliner.Term.t
 val o_test : bool Cmdliner.Term.t
 val o_text : bool Cmdliner.Term.t
 val o_text_outputs : string list Cmdliner.Term.t

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -123,7 +123,7 @@ val o_rewrite_rule_ids : bool Cmdliner.Term.t
 val o_sarif : bool Cmdliner.Term.t
 val o_sarif_outputs : string list Cmdliner.Term.t
 val o_scan_unknown_extensions : bool Cmdliner.Term.t
-val o_semgrepignore_filename : string option Cmdliner.Term.t
+val x_semgrepignore_filename : string option Cmdliner.Term.t
 val o_test : bool Cmdliner.Term.t
 val o_text : bool Cmdliner.Term.t
 val o_text_outputs : string list Cmdliner.Term.t
@@ -131,6 +131,7 @@ val o_time : bool Cmdliner.Term.t
 val o_timeout : float Cmdliner.Term.t
 val o_timeout_interfile : int Cmdliner.Term.t
 val o_timeout_threshold : int Cmdliner.Term.t
+
 (* val o_trace : bool Cmdliner.Term.t
    val o_trace_endpoint : string option Cmdliner.Term.t *)
 val o_use_git : bool Cmdliner.Term.t

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -212,6 +212,7 @@ type conf = {
   (* TODO? remove it? This is now done in Diff_scan.ml instead? *)
   baseline_commit : string option;
   diff_depth : int;
+  semgrepignore_filename : string option;
 }
 [@@deriving show]
 
@@ -236,6 +237,7 @@ let default_conf : conf =
     exclude_minified_files = false;
     baseline_commit = None;
     diff_depth = 2;
+    semgrepignore_filename = None;
   }
 
 (*************************************************************************)
@@ -726,6 +728,7 @@ let setup_path_filters conf (project_roots : Project.roots) :
    *)
   let semgrepignore_filter =
     Semgrepignore.create ~cli_patterns:conf.exclude
+      ~semgrepignore_filename:conf.semgrepignore_filename
       ~default_semgrepignore_patterns:Semgrep_scan_legacy ~exclusion_mechanism
       ~project_root:(Rfpath.to_fpath project_root)
       ()

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -75,6 +75,7 @@ type conf = {
   (* TODO: not used for now *)
   baseline_commit : string option;
   diff_depth : int;
+  semgrepignore_filename : string option;
 }
 [@@deriving show]
 

--- a/src/targeting/Semgrepignore.mli
+++ b/src/targeting/Semgrepignore.mli
@@ -1,8 +1,8 @@
 (*
-   Parse and interpret '.semgrepignore' files in addition to '.gitignore'
+   Parse and interpret ignore configuration files in addition to '.gitignore'
    files.
 
-   The patterns they contain specify file paths to exclude from Semgrep scans.
+   The patterns they contain specify file paths to exclude from Opengrep scans.
 
    See the ml file for compatibility issues.
 *)
@@ -24,9 +24,9 @@ type exclusion_mechanism = {
 (*
    Initialize the data used to filter paths.
    The project_root path must exist. It is used to
-   locate .gitignore and .semgrepignore files.
+   locate .gitignore and ignore configuration files.
 
-   This is an instantiation of Gitignore_filter.t specific to Semgrep.
+   This is an instantiation of Gitignore_filter.t specific to Opengrep.
 
    Use Git_project.find_project_root to determine the root of the
    git project.

--- a/src/targeting/Semgrepignore.mli
+++ b/src/targeting/Semgrepignore.mli
@@ -33,6 +33,7 @@ type exclusion_mechanism = {
 *)
 val create :
   ?cli_patterns:string list ->
+  ?semgrepignore_filename:string option ->
   default_semgrepignore_patterns:default_semgrepignore_patterns ->
   exclusion_mechanism:exclusion_mechanism ->
   project_root:Fpath.t ->

--- a/src/targeting/Unit_semgrepignore.ml
+++ b/src/targeting/Unit_semgrepignore.ml
@@ -137,12 +137,12 @@ let tests =
            ]);
       t "custom ignore file"
         (test_filter ~semgrepignore_filename:(Some ".customignore")
-           [ 
+           [
              (* Create a custom ignore file instead of .semgrepignore *)
              File (".customignore", "*.json\ndocs/");
              (* Create a regular .semgrepignore that should be ignored *)
              File (".semgrepignore", "*.ml");
-             file "config.json"; 
+             file "config.json";
              file "main.ml";
              dir "docs" [ file "readme.md"; ];
              dir "src" [ file "data.json"; file "util.ml"; ];
@@ -152,7 +152,7 @@ let tests =
              ("/config.json", false);
              ("/docs/readme.md", false);
              ("/src/data.json", false);
-             
+
              (* These should NOT be ignored since .semgrepignore is not used *)
              ("/main.ml", true);
              ("/src/util.ml", true);
@@ -162,13 +162,13 @@ let tests =
            [
              (* Regular gitignore file that should still be used *)
              File (".gitignore", "*.txt");
-             
+
              (* Custom ignore file instead of .semgrepignore *)
              File (".opengrep-ignore", "*.json");
-             
+
              (* Regular .semgrepignore that should be ignored *)
              File (".semgrepignore", "*.ml");
-             
+
              file "notes.txt";
              file "config.json";
              file "main.ml";
@@ -176,10 +176,10 @@ let tests =
            [
              (* Ignored by gitignore *)
              ("/notes.txt", false);
-             
+
              (* Ignored by custom ignore *)
              ("/config.json", false);
-             
+
              (* Should NOT be ignored since .semgrepignore is not used *)
              ("/main.ml", true);
            ]);


### PR DESCRIPTION
# Add `--opengrepignore-file` flag for custom ignore file configuration

## Summary
This PR introduces a new CLI flag `--opengrepignore-file` that allows users to specify a custom file for ignoring files during scanning, rather than relying on the default `.semgrepignore` file.

## Motivation
Currently, Opengrep uses `.semgrepignore` files to determine which files to exclude from scanning. However, users may want to:
- Use a differently named ignore file that better fits their project conventions (e.g., `.myignore`)
- Share ignore configurations between different tools
- Maintain multiple ignore configurations for different scanning purposes
- Use a global ignore file outside the project directory

## Implementation Details
- Added a new `--opengrepignore-file`  flag that accepts a path to a custom ignore file
- Updated the `Semgrepignore.ml` implementation to use the provided custom file instead of defaulting to `.semgrepignore`
- Updated documentation to use more general terminology for ignore files
- Modified the configuration processing to ensure the custom ignore file path is properly passed to the targeting system

## Usage Examples
```bash
# Use a custom ignore file
opengrep scan --config p/javascript --opengrepignore-file=.myignore .
```