### PR TITLE
Performance improvements

### DIFF
--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -180,6 +180,16 @@ let memoized ?(use_cache = true) h k f =
         Kcas_data.Hashtbl.replace h k v;
         v
 
+let memoized_not_thread_safe ?(use_cache = true) h k f =
+  if not use_cache then f ()
+  else
+    match Hashtbl.find_opt h k with
+    | Some v -> v
+    | None ->
+        let v = f () in
+        Hashtbl.replace h k v;
+        v
+
 exception Todo
 exception Impossible
 exception Multi_found (* to be consistent with Not_found *)

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -180,6 +180,8 @@ let memoized ?(use_cache = true) h k f =
         Kcas_data.Hashtbl.replace h k v;
         v
 
+(* Because memoize does not create the hashtable itself, but uses an existing one,
+ * when we have a domain-local hashtable, it will be safe to use in parallel. *)
 let memoized_not_thread_safe ?(use_cache = true) h k f =
   if not use_cache then f ()
   else

--- a/libs/commons/Common.ml
+++ b/libs/commons/Common.ml
@@ -326,14 +326,16 @@ let matched7 s =
     matched 6 s,
     matched 7 s )
 
-let _memo_compiled_regexp = Kcas_data.Hashtbl.create () (* 101 *)
+module DLS = Domain.DLS
+
+let _memo_compiled_regexp = DLS.new_key (fun () -> Hashtbl.create 101)
 
 let candidate_match_func s re =
   (* old: Str.string_match (Str.regexp re) s 0 *)
   let compile_re =
     (* NOTE: The internal state of matches is in DLS, but we are sharing
      * here between domains also. Maybe make key domain local? [re ^ domain-id]. *)
-    memoized _memo_compiled_regexp
+    memoized_not_thread_safe (DLS.get _memo_compiled_regexp)
       re
       (* (re ^ "-" ^ string_of_int ((Domain.self ()) :> int)) *)
       (fun () -> Str.regexp re)

--- a/libs/commons/Common.mli
+++ b/libs/commons/Common.mli
@@ -246,6 +246,7 @@ val input_text_line : in_channel -> string
 (*****************************************************************************)
 
 val memoized : ?use_cache:bool -> ('a, 'b) Kcas_data.Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
+val memoized_not_thread_safe : ?use_cache:bool -> ('a, 'b) Hashtbl.t -> 'a -> (unit -> 'b) -> 'b
 
 (*****************************************************************************)
 (* Profiling *)

--- a/src/core_cli/Core_actions.ml
+++ b/src/core_cli/Core_actions.ml
@@ -181,7 +181,10 @@ let dump_rule (file : Fpath.t) : unit =
 (*****************************************************************************)
 
 let prefilter_of_rules file =
-  let cache = Some (Kcas_data.Hashtbl.create () (* 101 *)) in
+  (* Do we need a new DLS key every time? Don't think so.
+   * But this seems to only be called in a single invocation of opengrep-core,
+   * passing `-prefilter_of_rules`. *)
+  let cache = Some (Domain.DLS.new_key (fun () -> Hashtbl.create 101)) in
   match Parse_rule.parse file with
   | Ok rules ->
       let xs =

--- a/src/engine/tests/Unit_engine.ml
+++ b/src/engine/tests/Unit_engine.ml
@@ -550,8 +550,12 @@ let eval_regression_tests () =
 (* Analyze_rule (filter irrelevant rules) tests *)
 (*****************************************************************************)
 
+let cache = Domain.DLS.new_key (fun () -> Hashtbl.create 101)
+
 let test_irrelevant_rule rule_file target_file =
-  let cache = Some (Kcas_data.Hashtbl.create () (* 101 *)) in
+  (* Reset domain cache. *)
+  let _ = Domain.DLS.set cache (Hashtbl.create 101) in
+  let cache = Some cache in
   (* TODO: fail more gracefully for invalid rules? *)
   let rules = Parse_rule.parse rule_file |> Result.get_ok in
   rules

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -377,10 +377,11 @@ let lambdas_in_expr e =
  * huge expressions still takes some time). It would be better to
  * return a unique identifier to each expression to remove the hashing cost.
  *)
-let hmemo = Kcas_data.Hashtbl.create () (* 101 *)
+let hmemo : (expr, function_definition list) Hashtbl.t Domain.DLS.key =
+  Domain.DLS.new_key (fun () -> Hashtbl.create 101) 
 
 let lambdas_in_expr_memo a =
-  Common.memoized hmemo a (fun () -> lambdas_in_expr a)
+  Common.memoized_not_thread_safe ~use_cache:false (Domain.DLS.get hmemo) a (fun () -> lambdas_in_expr a)
 [@@profiling]
 
 (*****************************************************************************)

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -380,9 +380,19 @@ let lambdas_in_expr e =
 let hmemo : (expr, function_definition list) Hashtbl.t Domain.DLS.key =
   Domain.DLS.new_key (fun () -> Hashtbl.create 101) 
 
-let lambdas_in_expr_memo a =
-  Common.memoized_not_thread_safe ~use_cache:false (Domain.DLS.get hmemo) a (fun () -> lambdas_in_expr a)
+let _dummy_hmemo = Hashtbl.create 1 (* Not to be used. *)
+
+(* NOT USED for now, see below. *)
+let _lambdas_in_expr_memo a =
+  Common.memoized_not_thread_safe
+    ~use_cache:false (* [true] makes it much slower. *)
+    (Domain.DLS.get hmemo)
+    a
+    (fun () -> lambdas_in_expr a)
 [@@profiling]
+
+(* XXX: Shortcut, because we don't use the cache due to performance degradation. *)
+let lambdas_in_expr_memo = lambdas_in_expr
 
 (*****************************************************************************)
 (* Really substmts_of_stmts *)

--- a/src/matching/SubAST_generic.ml
+++ b/src/matching/SubAST_generic.ml
@@ -380,13 +380,11 @@ let lambdas_in_expr e =
 let hmemo : (expr, function_definition list) Hashtbl.t Domain.DLS.key =
   Domain.DLS.new_key (fun () -> Hashtbl.create 101) 
 
-let _dummy_hmemo = Hashtbl.create 1 (* Not to be used. *)
-
 (* NOT USED for now, see below. *)
 let _lambdas_in_expr_memo a =
   Common.memoized_not_thread_safe
     ~use_cache:false (* [true] makes it much slower. *)
-    (Domain.DLS.get hmemo)
+    (Domain.DLS.get hmemo) (* perf: use a dummy, constant hashtable if above is [false]. *)
     a
     (fun () -> lambdas_in_expr a)
 [@@profiling]

--- a/src/metachecking/Check_rule.ml
+++ b/src/metachecking/Check_rule.ml
@@ -354,6 +354,7 @@ let check_files
       CapConsole.print caps#stdout (SJ.string_of_core_output json)
 
 (* for semgrep-core -stat_rules *)
+let cache = Domain.DLS.new_key (fun () -> Hashtbl.create 101)
 let stat_files (caps : < Cap.stdout >) xs =
   let fullxs, _skipped_paths =
     xs
@@ -364,7 +365,9 @@ let stat_files (caps : < Cap.stdout >) xs =
   in
   let good = ref 0 in
   let bad = ref 0 in
-  let cache = Some (Kcas_data.Hashtbl.create () (* 101 *)) in
+  (* Reset cache. *)
+  let _ = Domain.DLS.set cache (Hashtbl.create 101) in
+  let cache = Some cache in 
   fullxs
   |> List.iter (fun file ->
          Logs.info (fun m -> m "stat_files: processing rule file %s" !!file);

--- a/src/optimizing/Analyze_rule.mli
+++ b/src/optimizing/Analyze_rule.mli
@@ -13,7 +13,7 @@ type prefilter = Semgrep_prefilter_t.formula * (string -> bool)
       confusing to debug. To prevent that from happening again, the table is
       now passed to this function. For convenience you can also choose not to
        memoize. *)
-type prefilter_cache = (Rule_ID.t, prefilter option) Kcas_data.Hashtbl.t
+type prefilter_cache = (Rule_ID.t, prefilter option) Hashtbl.t Domain.DLS.key
 
 (* This function analyzes a rule and returns optionaly a prefilter.
  *

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -448,7 +448,7 @@ let run_rules_against_targets_for_engine caps (env : env) (rules : Rule.t list)
     (targets : Target.t list) : Core_result.t =
   (* old:
    * let xtarget = Test_engine.xtarget_of_file xlang target in
-   * let xconf = { Match_env.default_xconfig with matching_explanations = true}in
+   * let xconf = { Match_env.default_xconfig with matching_explanations = true} in
    * Match_rules.check ~match_hook:(fun _ ->()) ~timeout:None xconf rules xtarget
    *)
   let config = core_scan_config env.conf rules targets in


### PR DESCRIPTION
This has been tested with a large repo (17,000 files+) and over 2,000 rules, and now it's as fast as Semgrep on the same invocation.

Co-author @maciejpirog.