### PR TITLE
Use concat_map in the definition of bind in matching

### DIFF
--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -137,7 +137,7 @@ type 'a comb_matcher = 'a -> 'a list -> 'a list comb_result
 (*****************************************************************************)
 (* Monadic operators *)
 (*****************************************************************************)
-(* The >>= combinator below allow you to configure the matching process
+(* The >>= combinator below allows you to configure the matching process
  * anyway you want. Essentially this combinator takes a matcher,
  * another matcher, and returns a matcher that combines the 2
  * matcher arguments.
@@ -160,10 +160,7 @@ let (( >>= ) : (tin -> tout) -> (unit -> tin -> tout) -> tin -> tout) =
    * the empty list when it didn't match, playing the role None
    * had before)
    *)
-  let xs = m1 tin in
-  (* try m2 on each possible returned bindings *)
-  let xxs = xs |> List_.map (fun binding -> m2 () binding) in
-  List_.flatten xxs
+  m1 tin |> List.concat_map (fun binding -> m2 () binding)
 
 (* the disjunctive combinator *)
 let (( >||> ) : (tin -> tout) -> (tin -> tout) -> tin -> tout) =


### PR DESCRIPTION
before: `map` composed with `flatten`
after: `concat_map`

We gain:
- code simplification
- tiny boost in performance:

E.g. on https://github.com/grafana/grafana (1991 rules on 15304 files):

||before|after|change|
|---|---|---|---|
|time|9:02.15|8:54.27|-1.48%|
|memory|239394M words|238213M words|-0.49%|

Tested on smaller repos as well