### PR TITLE
Relax c-sharp parser

### DIFF
--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -674,7 +674,8 @@ let literal (env : env) (x : CST.literal) : literal =
         List_.map
           (fun x ->
             match x with
-            | `Verb_str_lit_frag tok -> str env tok
+            | `Imm_tok_prec_p1_pat_98d585a tok -> str env tok
+            (* | `Verb_str_lit_frag tok -> str env tok *)
             | `DQUOTDQUOT tok -> str env tok)
           v2
       in
@@ -686,8 +687,10 @@ let literal (env : env) (x : CST.literal) : literal =
       let xs =
         List_.map
           (fun x ->
-            match x with
-            | `Raw_str_lit_frag tok -> str env tok)
+             str env x
+            (* match x with
+               | `Raw_str_lit_frag tok -> str env tok *)
+          )
           v2
       in
       let r = token env v3 in
@@ -2834,17 +2837,19 @@ and namespace_member_declaration (env : env)
 
 and compilation_unit (env : env) (xs : CST.compilation_unit) : any =
   match xs with
-  | `Rep_extern_alias_dire_rep_using_dire_rep_global_attr_list_choice_rep_global_stmt_rep_name_member_decl
+  | `Rep_extern_alias_dire_rep_using_dire_rep_global_attr_list_choice_rep_choice_global_stmt
       (v1, v2, v3, v4) ->
       let v1 = v1 |> List_.map (extern_alias_directive env) in
       let v2 = v2 |> List_.map (using_directive env) in
       let v3 = v3 |> List_.map (global_attribute_list env) in
       let v4 =
         match v4 with
-        | `Rep_global_stmt_rep_name_member_decl (v1, v2) ->
-            let v1 = v1 |> List_.map (global_statement env) in
-            let v2 = v2 |> List_.map (namespace_member_declaration env) in
-            v1 @ v2
+        | `Rep_choice_global_stmt xs ->
+            List.map
+              (function
+                | `Global_stmt x -> global_statement env x
+                | `Name_member_decl x -> namespace_member_declaration env x)
+              xs
         | `File_scoped_name_decl x -> file_scoped_namespace_declaration env x
       in
       G.Pr (List_.flatten [ v1; v2; v3; v4 ])

--- a/src/parsing_languages/Parse_target2.ml
+++ b/src/parsing_languages/Parse_target2.ml
@@ -221,10 +221,4 @@ let just_parse_with_lang lang file : Parsing_result2.t =
    *)
   | Lang.Apex -> run_external_parser file Parsing_plugin.Apex.parse_target
   | Lang.Csharp ->
-      let parse_target =
-        (* Use the proprietary parser if available *)
-        if Parsing_plugin.Csharp.is_available () then
-          Parsing_plugin.Csharp.parse_target
-        else Parse_csharp_tree_sitter.parse
-      in
-      run file [ TreeSitter parse_target ] (fun x -> x)
+      run file [ TreeSitter Parse_csharp_tree_sitter.parse ] (fun x -> x)

--- a/tests/parsing/csharp/mixed_global_stmt_namespace_decl.cs
+++ b/tests/parsing/csharp/mixed_global_stmt_namespace_decl.cs
@@ -1,0 +1,52 @@
+// ruleid: identified-parameter-in-csharp-code
+public void PrintNames(string AliceSTR, int BobINT)
+{
+    Console.WriteLine($"Names: {AliceSTR} {str(BobINT)}");
+}
+
+// ruleid: identified-parameter-in-csharp-code
+public void GreetStringName(string AliceSTR = "John", int BobINT = 12)
+{
+    Console.WriteLine($"Hello, {AliceSTR}");
+}
+
+public class User
+{
+    // ruleid: identified-parameter-in-csharp-code
+    public string AliceUserName;
+    // ok: an int, so not counting it
+    public int AliceUserId;
+}
+
+public class Consumer
+{
+    // ruleid: identified-parameter-in-csharp-code
+    public string BobConsumerName { get; set; } = "Bob";
+    // ok: int value
+    public int BobConsumerId { get; set; } = 10;
+}
+
+// ruleid: identified-parameter-in-csharp-code
+public void GetFullName(out string BobFirstName, out int BobLastName)
+{
+    FirstName = "Alice";
+    LastName = "Brown";
+}
+
+public class Employee
+{
+    // ruleid: identified-parameter-in-csharp-code
+    public static string BobEmployee = "Default";
+    // ok: int
+    public static int BobEmbployeeId = 10;
+}
+
+// ruleid: identified-parameter-in-csharp-code
+public void IsValid(string? BobName, int? BobId)
+{
+    if (FirstName != null && LastName != null)
+    {
+       return true;
+    }
+    return false;
+}


### PR DESCRIPTION
Closes #92.

Notes: 
- We need to make sure that our ocaml-tree-sitter-semgrep is up to date. The fact is we previously changed the tree-sitter grammar which is not something we can edit upstream, and for this reason it would be better to fork https://github.com/tree-sitter/tree-sitter-c-sharp also. **Update: moved all changes to the grammar adapting to semgrep contructs.**
- I don't know if the changes are valid c-sharp because I relaxed the parser, accepting more programs. But it does not matter for our purposes.
- The c-sharp submodule now points to https://github.com/opengrep/semgrep-c-sharp/tree/dm/opengrep-issue-92-b. We should probably ensure that we point to main on each language submodule.