### PR TITLE
Show enclosing context when focusing on a metavar (partial solution)

### DIFF
--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -423,7 +423,7 @@ let apply_focus_on_ranges (env : env) (focus_mvars_list : R.focus_mv_list list)
                ast_node =
                  (if env.has_as_metavariable then Some (MV.mvalue_to_any mval)
                   else None);
-               enclosure = None;
+               enclosure = range.origin.enclosure;
                tokens = lazy (MV.ii_of_mval mval);
                env = range.mvars;
                taint_trace = None;


### PR DESCRIPTION
**PARTIAL** solution for #229 

The solution is partial because when we focus on a metavariable, but the rule captures, for example, an entire function, we do not include this function in the context. Consider the following:

rule:
```
- pattern: foo() { ... $VAR = 5; ...}
- focus-metavariable: $VAR
```

code:
```
class C {
  foo() { x = 5; }
}
```

In the above, the rule matches the entire definition of `foo`, but we focus on `x` only because of `focus-metavariable`. In such a case, I think we want to say that the enclosing context is `class C` and `function foo`, but the reported enclosing context consists only of `class C`. This is because currently the enclosing context is reported for the match of the rule, not of the (post-factum) focus.

Technical reason: At the moment, the enclosing context is constructed in the visitor for mtching in the module `Match_patterns`. If the match that happens in the module `Generic_vs_generic` captures, say, a function, but later the result is focused on a metavariable inside that function, we do not add it to the enclosing context, because we do not gather enclosing context when going deeper in the structure in `Generic_vs_generic`. So, when we focus on the metavariable in the example above, we strip the result from `foo() { ... = 5; }` and only report `x` at a given range with the enclosing context only `class C`, which can be misleading in edge cases. To fix this, we can, for example:

- change the algorithm of matching in `Generic_vs_generic` to keep the enclosing context at all times (could be expensive),
- recalculate the enclosing context from the original AST after we found a rule with a match (more sensible, but quite a bit of coding, because this requires a new visitor).

TBD

