### PR TITLE
Allow multiple files with test command

### DIFF
--- a/src/osemgrep/cli_test/Test_CLI.mli
+++ b/src/osemgrep/cli_test/Test_CLI.mli
@@ -23,7 +23,7 @@ type conf = {
 
 and target_kind =
   | Dir of Fpath.t * Rules_config.config_string option (* optional --config *)
-  | File of Fpath.t * Rules_config.config_string (* mandatory --config *)
+  | Files of Fpath.t list * Rules_config.config_string (* mandatory --config *)
 [@@deriving show]
 
 (*

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -176,9 +176,9 @@ let rules_and_targets (kind : Test_CLI.target_kind) (errors : error list ref) :
                      m "found targets for %s: %s" !!rule_file
                        (xs |> List_.map Fpath.to_string |> String.concat ", "));
                  Some (rule_file, xs))
-  | Test_CLI.File (target, config_str) -> (
+  | Test_CLI.Files (targets, config_str) -> (
       match Rules_config.parse_config_string ~in_docker:false config_str with
-      | File rule_file -> [ (rule_file, [ target ]) ]
+      | File rule_file -> [ (rule_file, targets) ]
       | Dir _
       | URL _
       | R _


### PR DESCRIPTION
All correct previous commands work the same

New option is to specify multiple files:

```
opengrep test -c path/to/rules.yaml file1.py file2.py
```

Or (when run as a shell command):

```
opengrep test -c path/ro/rules.ysml file*.py
```

Closes #237