### PR TITLE
Fix #112: combine consecutive strings in templates

### DIFF
--- a/tests/tainting_rules/js/issue_112.js
+++ b/tests/tainting_rules/js/issue_112.js
@@ -1,0 +1,5 @@
+v = (taint) => {
+  // ruleid: issue_112
+  return `Text before escaped backtick, \`Between backticks\` 
+     ${taint}`
+}

--- a/tests/tainting_rules/js/issue_112.yaml
+++ b/tests/tainting_rules/js/issue_112.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: issue_112
+    message: message
+    languages:
+      - javascript
+    severity: ERROR
+    mode: taint
+    pattern-sinks:
+    - patterns:
+        - pattern: |
+           `$FIRST${$EXPR}...`
+        - metavariable-regex:
+            metavariable: $FIRST
+            regex: ^Text before escaped backtick,\s.*
+    pattern-sources:
+    - patterns:
+        - pattern-inside: |
+            (..., $INPUT, ...) => {
+              ...
+            }
+        - pattern: $INPUT

--- a/tests/tainting_rules/js/issue_112_b.js
+++ b/tests/tainting_rules/js/issue_112_b.js
@@ -1,0 +1,5 @@
+v = (some_var, taint) => {
+  // ruleid: issue_112_b
+  return `Text before escaped backtick, \`Between backticks\` ${some_var == true} other text \`other text inside backticks\` ${taint} \`more text inside backticks\``
+}
+

--- a/tests/tainting_rules/js/issue_112_b.yaml
+++ b/tests/tainting_rules/js/issue_112_b.yaml
@@ -1,0 +1,22 @@
+rules:
+  - id: issue_112_b
+    message: message
+    languages:
+      - javascript
+    severity: ERROR
+    mode: taint
+    pattern-sinks:
+    - patterns:
+        - pattern: |
+           `$FIRST${$_}$SECOND${$EXPR}...`
+        - metavariable-regex:
+            metavariable: $SECOND
+            regex:  \sother text \\`other text inside backticks\\`\s
+    pattern-sources:
+    - patterns:
+        - pattern-inside: |
+            ($IGNORE, $INPUT, ...) => {
+              ...
+            }
+        - pattern: $INPUT
+


### PR DESCRIPTION
## Changes

- Improve parsing: combine consecutive strings in template strings, which where previously parsed as separate structures, so that we can match on each combined string fragment.

### Details

Consider this code fragment: 
```js
v = (taint) => {
        return `Text A \`Text B\`  ${taint} \`Text C\``
      }
```

If we run: 

```bash
❯ opengrep-core -lang js -dump_tree_sitter_cst code_example.js
...
Temp_str (
          (
            "`"
            [
              Temp_chars "Text A "
              Esc_seq "\\`"
              Temp_chars "Text B"
              Esc_seq "\\`"
              Temp_chars "  "
              Temp_subs (
                (
                  "${"
                  Exp (
                    Prim_exp (
                      Choice_choice_subs_exp (
                        Choice_subs_exp (
                          Choice_unde (
                            Id "taint"
                          )
                        )
                      )
                    )
                  )
                  "}"
                )
              )
              Temp_chars " "
              Esc_seq "\\`"
              Temp_chars "Text C"
              Esc_seq "\\`"
            ]
            "`"
          )
        )
...
```

Then on `main`: 

```bash
❯ opengrep-core -lang js -dump_ast code_example.js
[00.04][INFO]: Executed as: opengrep-core -lang js -dump_ast code_example.js
[00.04][INFO]: Version: 1.2.1
Pr(
  [ExprStmt(
     Assign(
       N(
         Id(("v", ()),
           {id_info_id=2; id_flags=Ref(0); id_resolved_alternative=Ref(
            []); id_resolved=Ref(None); id_type=Ref(None);
            id_svalue=Ref(None); })), (),
       Lambda(
         {fkind=(Arrow, ());
          fparams=[Param(
                     {pname=Some(("taint", ())); pdefault=None; ptype=None;
                      pattrs=[];
                      pinfo={id_info_id=3; id_flags=Ref(0);
                             id_resolved_alternative=Ref([]);
                             id_resolved=Ref(None); id_type=Ref(None);
                             id_svalue=Ref(None); };
                      })];
          frettype=None;
          fbody=FBStmt(
                  Block(
                    [Return((),
                       Some(Call(
                              IdSpecial(
                                (ConcatString(InterpolatedConcat), ())),
                              [Arg(L(String(("Text A ", ()))));
                               Arg(L(String(("\`", ()))));
                               Arg(L(String(("Text B", ()))));
                               Arg(L(String(("\`", ()))));
                               Arg(L(String(("  ", ()))));
                               Arg(
                                 N(
                                   Id(("taint", ()),
                                     {id_info_id=4; id_flags=Ref(0);
                                      id_resolved_alternative=Ref([]);
                                      id_resolved=Ref(None);
                                      id_type=Ref(None); id_svalue=Ref(
                                      None); }))); Arg(L(String((" ", ()))));
                               Arg(L(String(("\`", ()))));
                               Arg(L(String(("Text C", ()))));
                               Arg(L(String(("\`", ()))))])), ())]));
          })), ())])
```

So we see that the `String` fragments are maintained, even though they could have been combined. This is why we cannot match the whole substring before `${taint}` in #112.

With the current version we get the expected, combined strings: 

```bash
❯ opengrep-core -lang js -dump_ast code_example.js
[00.05][INFO]: Executed as: opengrep-core -lang js -dump_ast code_example.js
[00.05][INFO]: Version: 1.2.1
Pr(
  [ExprStmt(
     Assign(
       N(
         Id(("v", ()),
           {id_info_id=2; id_flags=Ref(0); id_resolved_alternative=Ref(
            []); id_resolved=Ref(None); id_type=Ref(None);
            id_svalue=Ref(None); })), (),
       Lambda(
         {fkind=(Arrow, ());
          fparams=[Param(
                     {pname=Some(("taint", ())); pdefault=None; ptype=None;
                      pattrs=[];
                      pinfo={id_info_id=3; id_flags=Ref(0);
                             id_resolved_alternative=Ref([]);
                             id_resolved=Ref(None); id_type=Ref(None);
                             id_svalue=Ref(None); };
                      })];
          frettype=None;
          fbody=FBStmt(
                  Block(
                    [Return((),
                       Some(Call(
                              IdSpecial(
                                (ConcatString(InterpolatedConcat), ())),
                              [Arg(L(String(("Text A \`Text B\`  ", ()))));
                               Arg(
                                 N(
                                   Id(("taint", ()),
                                     {id_info_id=4; id_flags=Ref(0);
                                      id_resolved_alternative=Ref([]);
                                      id_resolved=Ref(None);
                                      id_type=Ref(None); id_svalue=Ref(
                                      None); })));
                               Arg(L(String((" \`Text C\`", ()))))])), ())]));
          })), ())])
```