### PR TITLE
Remove --assume-depexts flag in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,17 +260,11 @@ install-deps-for-semgrep-core:
 # version conflicts.
 # OPAMSOLVERTIMEOUT default is 60 but seems not enough
 #
-# TODO: We use `--assume-depexts` because as of 2024-11-13 brew
-# has moved off `pkg-config`. When you install `pkg-config` you
-# get `pkgconf` instead, which OCaml doesn't recognize as satisfying
-# the dependency though it contains the same elements. This has been
-# reported to brew via https://github.com/ocaml/opam-repository/issues/26876.
-# We can remove it if that issue is resolved.
 # Per the note above install-deps-ALPINE-for-semgrep-core, we may want
 # to keep it and add `--no-cache`
 install-opam-deps:
 	opam update -y
-	OPAMSOLVERTIMEOUT=1200 opam install -y --assume-depexts --deps-only $(REQUIRED_DEPS)
+	OPAMSOLVERTIMEOUT=1200 opam install -y --deps-only $(REQUIRED_DEPS)
 
 # This will fail if semgrep.opam isn't up-to-date (in git),
 # and dune isn't installed yet. You can always install dune with


### PR DESCRIPTION

The issue that has been mentioned in TODO comment has been resolved.

I tested removing the flag and successfully built on Mac M3 docker with the following Dockerfile:

```Dockerfile
FROM ocaml/opam:latest

ADD opengrep /opengrep
RUN sudo chown -R opam:opam /opengrep
WORKDIR /opengrep
RUN opam install dune -y
RUN sudo apt-get update
RUN sudo apt-get install -y libcurl4-gnutls-dev \
python3-dev \
libev-dev \
libgmp-dev \
libpcre3-dev \
libpcre2-dev \
pkg-config
RUN eval $(opam config env) && make setup
RUN eval $(opam config env) && make
```