### PR TITLE
Fix autofix in javascript template strings

### DIFF
--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -1495,10 +1495,10 @@ and template_string (env : env) ((v1, v2, v3) : CST.template_string) :
 
 and template_substitution (env : env) ((v1, v2, v3) : CST.template_substitution)
     : expr =
-  let _v1 = token env v1 (* "${" *) in
-  let v2 = expressions env v2 in
-  let _v3 = token env v3 (* "}" *) in
-  v2
+  let l = token env v1 (* "${" *) in
+  let e = expressions env v2 in
+  let r = token env v3 (* "}" *) in
+  ParenExpr (l, e, r)
 
 and map_template_literal_type (env : env)
     ((v1, v2, v3) : CST.template_literal_type) : type_ =

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -107,7 +107,7 @@ type tin = {
    * modified, so maybe we should split tin in two and have tout use only one
    * part of this new tin?
    * alt: use globals or have an another 'env' parameter in the matcher in
-   * additionto tin instead of passing them through tin (but that's maybe a big
+   * addition to tin instead of passing them through tin (but that's maybe a big
    * refactoring of Generic_vs_generic).
    *)
   lang : Lang.t;

--- a/src/tainting/Taint.ml
+++ b/src/tainting/Taint.ml
@@ -369,7 +369,7 @@ module Taint_set = struct
    *
    * Why not just 'Set.Make(...)' using `compare_taint`? If we did this, then
    * given two taints that we consider "the same", we would pick one arbitrarily.
-   * While we consider then _essentially_ "the same", there are deatils such as
+   * While we consider them _essentially_ "the same", there are details such as
    * the call trace or the precondition (for labeled taint) that may differ, and
    * we want to pick "the best". This is what this data structure is for, the
    * key functions are 'add' and 'pick_best_taint'.

--- a/tests/autofix/js/tagged_template_string_pattern.fix
+++ b/tests/autofix/js/tagged_template_string_pattern.fix
@@ -1,0 +1,1 @@
+console.log($MSG, "hello");

--- a/tests/autofix/js/tagged_template_string_pattern.fixed
+++ b/tests/autofix/js/tagged_template_string_pattern.fixed
@@ -1,0 +1,2 @@
+console.log(tag`this is a test ${id}`, "hello");
+

--- a/tests/autofix/js/tagged_template_string_pattern.js
+++ b/tests/autofix/js/tagged_template_string_pattern.js
@@ -1,0 +1,1 @@
+console.log(tag`this is a test ${id}`)

--- a/tests/autofix/js/tagged_template_string_pattern.sgrep
+++ b/tests/autofix/js/tagged_template_string_pattern.sgrep
@@ -1,0 +1,1 @@
+console.log($MSG)

--- a/tests/autofix/js/template_string_pattern.fix
+++ b/tests/autofix/js/template_string_pattern.fix
@@ -1,0 +1,1 @@
+console.log($MSG, "hello");

--- a/tests/autofix/js/template_string_pattern.fixed
+++ b/tests/autofix/js/template_string_pattern.fixed
@@ -1,0 +1,2 @@
+console.log(`this is a test ${id}`, "hello");
+

--- a/tests/autofix/js/template_string_pattern.js
+++ b/tests/autofix/js/template_string_pattern.js
@@ -1,0 +1,1 @@
+console.log(`this is a test ${id}`)

--- a/tests/autofix/js/template_string_pattern.sgrep
+++ b/tests/autofix/js/template_string_pattern.sgrep
@@ -1,0 +1,1 @@
+console.log($MSG)


### PR DESCRIPTION
### Changes

- Ensures that ranges are correct in template (and tagged template) literals.
- Ensures, as a consequence of the above, that autofix works as expected in such cases.
- Adds some tests.

Closes #111.