### PR TITLE
fix: --opengrep-ignore-pattern declared twice in python cli

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -554,11 +554,6 @@ def update_ignore_pattern(pattern: str) -> None:
     "run_secrets_flag",
     is_flag=True,
 )
-@click.option(
-    "--opengrep-ignore-pattern",
-    envvar="SEMGREP_OPENGREP_IGNORE_PATTERN",
-    default=None,
-)
 @scan_options
 @handle_command_errors
 def scan(


### PR DESCRIPTION
Because of this bug, the python cli issues a warning, but does not alter behaviour (in particular, it does not affect #259).