### PR TITLE
Add `--force-exclude` flag: apply `--exclude` uniformly

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -271,7 +271,8 @@ def ci(
     dump_rule_partitions_dir: Optional[Path],
     partial_config: Optional[Path],
     partial_output: Optional[Path],
-    opengrep_ignore_pattern: Optional[str]
+    opengrep_ignore_pattern: Optional[str],
+    bypass_includes_excludes_for_files: bool = True
 ) -> None:
     state = get_state()
 
@@ -291,6 +292,14 @@ def ci(
         logger.info(
             "WARNING: --opengrep-ignore-pattern is set but will be ignored: "
             "all results are returned by the ci command"
+        )
+
+    # Maybe move this and the above to the scan-only params, since they are not
+    # needed here.
+    if bypass_includes_excludes_for_files:
+        logger.info(
+            "WARNING: --force-exclude is set but will be ignored: "
+            "no explicit targets are passed to the ci command"
         )
 
     state.metrics.configure(metrics)

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -121,6 +121,18 @@ _scan_options: List[Callable] = [
         multiple=True,
         default=[],
     ),
+    # When this flag is added, the bypass that happens by default for files is disabled,
+    # and as a result even targets that are files are processed with the include/exclude
+    # filters.
+    # Note that this flag is sent back by the OCaml CLI, when falling back to python.
+    optgroup.option(
+        "--force-exclude",
+        "bypass_includes_excludes_for_files",
+        is_flag=True,
+        flag_value=False,
+        default=True,
+        help="Apply include and exclude filters also to TARGETs that are files, not only folders.",
+    ),
     optgroup.option(
         "--max-target-bytes",
         type=bytesize.ByteSizeType(),
@@ -583,6 +595,7 @@ def scan(
     path_sensitive: bool,
     allow_local_builds: bool,
     opengrep_ignore_pattern: Optional[str],
+    bypass_includes_excludes_for_files: bool = True
 ) -> Optional[Tuple[RuleMatchMap, List[SemgrepError], List[Rule], Set[Path]]]:
     if version:
         print(__VERSION__)
@@ -857,6 +870,7 @@ def scan(
                     capture_core_stderr=capture_core_stderr,
                     allow_local_builds=allow_local_builds,
                     opengrep_ignore_pattern=opengrep_ignore_pattern,
+                    bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
                 )
             except SemgrepError as e:
                 output_handler.handle_semgrep_errors([e])

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -667,7 +667,7 @@ def scan(
         logger.warning(
             with_color(
                 Colors.yellow,
-                "Paths that match both --include and --exclude will be skipped by Semgrep.",
+                "Paths that match both --include and --exclude will be skipped by Opengrep.",
             )
         )
 

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -714,6 +714,7 @@ class CoreRunner:
         *,
         all_targets: Optional[Set[Path]] = None,
         product: Optional[out.Product] = None,
+        bypass_includes_excludes_for_files: bool = True
     ) -> Plan:
         """
         Gets the targets to run for each rule
@@ -739,7 +740,8 @@ class CoreRunner:
             for language in rule.languages:
                 targets = list(
                     target_manager.get_files_for_rule(
-                        language, rule.includes, rule.excludes, rule.id, rule.product
+                        language, rule.includes, rule.excludes, rule.id, rule.product,
+                        bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
                     )
                 )
                 any_target = any_target or len(targets) > 0
@@ -786,6 +788,7 @@ class CoreRunner:
         target_mode_config: TargetModeConfig,
         sca_subprojects: Dict[out.Ecosystem, List[ResolvedSubproject]],
         opengrep_ignore_pattern: Optional[str],
+        bypass_includes_excludes_for_files: bool = True
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
         state = get_state()
         logger.debug(f"Passing whole rules directly to semgrep_core")
@@ -891,6 +894,7 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                     evolve(target_manager, baseline_handler=None),
                     all_targets=all_targets,
                     sca_subprojects=sca_subprojects,
+                    bypass_includes_excludes_for_files=bypass_includes_excludes_for_files
                 )
 
             else:
@@ -899,6 +903,7 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                     target_manager,
                     all_targets=all_targets,
                     sca_subprojects=sca_subprojects,
+                    bypass_includes_excludes_for_files=bypass_includes_excludes_for_files
                 )
 
             plan.record_metrics()
@@ -1098,6 +1103,7 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
         target_mode_config: TargetModeConfig,
         sca_subprojects: Dict[out.Ecosystem, List[ResolvedSubproject]],
         opengrep_ignore_pattern: Optional[str] = None,
+        bypass_includes_excludes_for_files: bool = True
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
         """
         Sometimes we may run into synchronicity issues with the latest DeepSemgrep binary.
@@ -1121,6 +1127,7 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                 target_mode_config,
                 sca_subprojects,
                 opengrep_ignore_pattern=opengrep_ignore_pattern,
+                bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
             )
         except SemgrepError as e:
             # Handle Semgrep errors normally
@@ -1162,6 +1169,7 @@ Exception raised: `{e}`
         target_mode_config: TargetModeConfig,
         sca_subprojects: Dict[out.Ecosystem, List[ResolvedSubproject]],
         opengrep_ignore_pattern: Optional[str] = None,
+        bypass_includes_excludes_for_files: bool = True
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
         """
         Takes in rules and targets and returns object with findings
@@ -1185,6 +1193,7 @@ Exception raised: `{e}`
             target_mode_config,
             sca_subprojects,
             opengrep_ignore_pattern=opengrep_ignore_pattern,
+            bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
         )
 
         logger.debug(

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -261,6 +261,7 @@ def run_rules(
     allow_local_builds: bool = False,
     prioritize_dependency_graph_generation: bool = False,
     opengrep_ignore_pattern: Optional[str] = None,
+    bypass_includes_excludes_for_files: bool = True
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -360,6 +361,7 @@ def run_rules(
         target_mode_config,
         resolved_subprojects,
         opengrep_ignore_pattern=opengrep_ignore_pattern,
+        bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
     )
 
     if join_rules:
@@ -542,6 +544,7 @@ def run_scan(
     dump_rule_partitions_dir: Optional[Path] = None,
     prioritize_dependency_graph_generation: bool = False,
     opengrep_ignore_pattern: Optional[str] = None,
+    bypass_includes_excludes_for_files: bool = True
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -818,6 +821,7 @@ def run_scan(
         allow_local_builds=allow_local_builds,
         prioritize_dependency_graph_generation=prioritize_dependency_graph_generation,
         opengrep_ignore_pattern=opengrep_ignore_pattern,
+        bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
     )
     profiler.save("core_time", core_start_time)
     semgrep_errors: List[SemgrepError] = config_errors + scan_errors

--- a/cli/src/semgrep/scan_report.py
+++ b/cli/src/semgrep/scan_report.py
@@ -298,6 +298,7 @@ def print_scan_status(
     # TODO: Use an array of semgrep_output_v1.Product instead of booleans flags for secrets, code, and supply chain
     with_code_rules: bool = True,
     with_supply_chain: bool = False,
+    bypass_includes_excludes_for_files: bool = True
 ) -> List[Plan]:
     """
     Prints the scan status and returns the plans
@@ -328,6 +329,7 @@ def print_scan_status(
             out.SAST()
         ),  # code-smell since secrets and sast are within the same plan
         sca_subprojects=sca_subprojects,
+        bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
     )
 
     sca_plan = CoreRunner.plan_core_run(
@@ -343,6 +345,7 @@ def print_scan_status(
         target_manager,
         product=out.Product(out.SCA()),
         sca_subprojects=sca_subprojects,
+        bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
     )
 
     plans = [sast_plan, sca_plan]

--- a/src/osemgrep/cli_ci/Ci_CLI.ml
+++ b/src/osemgrep/cli_ci/Ci_CLI.ml
@@ -256,6 +256,7 @@ let scan_subset_cmdline_term : Scan_CLI.conf Term.t =
         force_novcs_project = false;
         exclude = exclude_;
         include_;
+        apply_includes_excludes_to_file_targets = false; (* no explicit targets anyway *)
         baseline_commit;
         diff_depth;
         max_target_bytes;

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -182,6 +182,15 @@ https://git-scm.com/docs/gitignore#_pattern_format
   in
   Arg.value (Arg.opt_all Arg.string [] info)
 
+let o_apply_includes_excludes_to_files : bool Term.t =
+  let info =
+    Arg.info [ "force-exclude" ]
+      ~doc:
+        {|Apply the --include and --exclude options to files specified on the
+command line. By default, these options are only applied to files found in the directory trees scanned|}
+  in
+  Arg.value (Arg.flag info)
+
 let o_include : string list Term.t =
   let info =
     Arg.info [ "include" ] ~docv:"PATTERN"
@@ -1302,8 +1311,8 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
   (* !The parameters must be in alphabetic orders to match the order
      of the corresponding '$ o_xx $' further below!
   *)
-  let combine allow_local_builds allow_untrusted_validators autofix
-      baseline_commit common config dataflow_traces diff_depth dryrun dump_ast
+  let combine allow_local_builds allow_untrusted_validators apply_includes_excludes_to_files
+      autofix baseline_commit common config dataflow_traces diff_depth dryrun dump_ast
       dump_command_for_core dump_engine_path emacs emacs_outputs error exclude_
       exclude_minified_files exclude_rule_ids files_with_matches force_color
       gitlab_sast gitlab_sast_outputs gitlab_secrets gitlab_secrets_outputs
@@ -1426,6 +1435,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
         force_novcs_project;
         exclude = exclude_;
         include_;
+        apply_includes_excludes_to_file_targets = apply_includes_excludes_to_files;
         baseline_commit;
         diff_depth;
         max_target_bytes;
@@ -1499,7 +1509,8 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       else if x_ls then (true, Ls_subcommand.default_format)
       else (false, Ls_subcommand.default_format)
     in
-    let matching_conf = {Match_patterns.track_enclosing_context = output_enclosing_context} in
+    let matching_conf = {Match_patterns.track_enclosing_context = output_enclosing_context}
+    in
     {
       rules_source;
       target_roots;
@@ -1534,6 +1545,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     (* !the o_xxx must be in alphabetic orders to match the parameters of
      * combine above! *)
     const combine $ o_allow_local_builds $ o_allow_untrusted_validators
+    $ o_apply_includes_excludes_to_files
     $ o_autofix $ o_baseline_commit $ CLI_common.o_common $ o_config
     $ o_dataflow_traces $ o_diff_depth $ o_dryrun $ o_dump_ast
     $ o_dump_command_for_core $ o_dump_engine_path $ o_emacs $ o_emacs_outputs

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -1579,7 +1579,7 @@ let man : Cmdliner.Manpage.block list =
     `P "To get started quickly, run";
     `Pre "opengrep --config auto .";
     `P
-      "This will automatically fetch rules for your project from the Opengrep \
+      "This will automatically fetch rules for your project from the Semgrep \
        Registry.";
     `P "For more information about Opengrep, go to https://opengrep.dev.";
   ]

--- a/src/targeting/Find_targets.mli
+++ b/src/targeting/Find_targets.mli
@@ -34,6 +34,7 @@ type conf = {
    * Those are flags copied from grep (and ripgrep).
    *)
   include_ : string list option;
+  apply_includes_excludes_to_file_targets: bool;
   max_target_bytes : int;
   (* Whether to respect what is specified in the '.gitignore' files
      found in the project and extended by optional '.semgrepignore' files.


### PR DESCRIPTION
### Changes

- Adds `--force-exclude` flag, which makes Opengrep apply the `--include` and `--exclude` filters even on passed targets that are not directories.

Closes #264.