### PR TITLE
[WiP] build an executable that always run with --experimental whatever argv0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ minimal-build:
 	dune build $(BUILD)/install/default/bin/opengrep-core$(EXE)
 	dune build $(BUILD)/install/default/bin/opengrep-cli$(EXE)
 	dune build $(BUILD)/install/default/bin/opengrep$(EXE)
+	dune build $(BUILD)/install/default/bin/opengrep-exp$(EXE)
 # Remove all symbols with GNU strip. It saves 10-25% on the executable
 # size and it doesn't seem to reduce the functionality or
 # debuggability of OCaml executables.

--- a/src/main/Main_exp.ml
+++ b/src/main/Main_exp.ml
@@ -1,0 +1,41 @@
+(* An entry point for the executable that:
+ * - never falls back on python,
+ * - always runs with --experimental,
+ * - does not depend on argv[0]. *)
+
+let first_hyphen_in_argv argv =
+  Array.find_index
+    (fun arg -> String.starts_with ~prefix:"-" arg)
+    argv
+
+let position_for_experimental_flag argv =
+  match first_hyphen_in_argv argv with
+  | None -> Array.length argv - 1
+  | Some i -> i
+
+let with_experimental_flag argv =
+  let len = position_for_experimental_flag argv in
+  Array.concat [
+    Array.sub argv 0 len;
+    [| "--experimental" |];
+    Array.sub argv len (Array.length argv - len);
+  ]
+
+(*****************************************************************************)
+(* Entry point *)
+(*****************************************************************************)
+
+let () =
+  Cap.main (fun (caps : Cap.all_caps) ->
+      let argv = CapSys.argv caps#argv in
+      let exit_code =
+        CLI.main
+          (caps :> CLI.caps)
+          (with_experimental_flag argv)
+      in
+      if not (Exit_code.Equal.ok exit_code) then
+        Logs.info (fun m ->
+            m "Error: %s\nExiting with error status %i: %s\n%!"
+              exit_code.description exit_code.code
+              (String.concat " " (Array.to_list argv)));
+      CapStdlib.exit caps#exit exit_code.code)

--- a/src/main/dune
+++ b/src/main/dune
@@ -1,5 +1,5 @@
 (executables
- (names Main)
+ (names Main Main_exp)
  (flags
   (:standard
    (:include flags.sexp))
@@ -15,8 +15,6 @@
   (pps ppx_profiling))
  ; 'byte' is for ocamldebug
  (modes native byte))
-
-; use flags.sh to generate the OS specific build flags
 
 (rule
  (targets flags.sexp)
@@ -60,6 +58,8 @@
   ; in the long term (and in the short term on windows) we want to ship
   ; opengrep-cli as "opengrep"
   (Main.exe as opengrep)
+  (Main_exp.exe as opengrep-exp)
   ; useful to debug opengrep, see ../../debug and ocamldebug
   (Main.bc as opengrep-core.bc)
-  (Main.bc as opengrep.bc)))
+  (Main.bc as opengrep.bc)
+))

--- a/src/osemgrep/cli/CLI.mli
+++ b/src/osemgrep/cli/CLI.mli
@@ -24,7 +24,7 @@ type caps =
    Exceptions are caught and turned into an appropriate exit code
    (unless you used --debug).
 *)
-val main : caps -> string array -> Exit_code.t
+val main : caps -> ?allow_fallback:bool -> string array -> Exit_code.t
 
 (* set in semgrep-pro *)
 val hook_semgrep_interactive : (string array -> Exit_code.t) ref


### PR DESCRIPTION
Add a separate executable that:
- always runs with `--experimental`
- does not depend on executable name

The name of the new executable is `opengrep-exp`