### PR TITLE
Binary install script for Mac OSX and Linux

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,3 +1,23 @@
+# Installing Opengrep (for users)
+
+Install the Opengrep CLI is with our install script:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install_opengrep.sh | bash
+```
+
+- This will install Opengrep to `~/.opengrep/cli/<version>` and set up a `latest` symlink.
+- To install a specific version, use:
+  ```sh
+  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install_opengrep.sh | bash -s -- -v v1.0.0
+  ```
+- To list available versions:
+  ```sh
+  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install_opengrep.sh | bash -s -- -l
+  ```
+
+---
+
 # Build instructions for developers
 
 ## Manual development

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,19 +1,17 @@
-# Installing Opengrep (for users)
-
-Install the Opengrep CLI is with our install script:
+# Install the Opengrep CLI with our install script:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install_opengrep.sh | bash
+curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
 ```
 
 - This will install Opengrep to `~/.opengrep/cli/<version>` and set up a `latest` symlink.
 - To install a specific version, use:
   ```sh
-  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install_opengrep.sh | bash -s -- -v v1.0.0
+  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash -s -- -v v1.0.0
   ```
 - To list available versions:
   ```sh
-  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install_opengrep.sh | bash -s -- -l
+  curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash -s -- -l
   ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Apex · Bash · C · C++ · C# · Clojure · Dart · Dockerfile · Elixir · HTM
 
 ## Installation
 
-You can install Opengrep via our official install script.
+You can install Opengrep using our official install script.
 
 ### Quick Install (Recommended)
 ```sh
@@ -45,7 +45,7 @@ If you've cloned the repo and `install.sh` is in the root directory, you can run
 Which will install the latest version of Opengrep.
 
 You can also install manually:
-* Binaries available in the latest alpha [release](https://github.com/opengrep/opengrep/releases).
+* Binaries available in the [release page](https://github.com/opengrep/opengrep/releases).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,26 @@ Apex · Bash · C · C++ · C# · Clojure · Dart · Dockerfile · Elixir · HTM
 
 ## Installation
 
-Binaries available in the latest alpha [release](https://github.com/opengrep/opengrep/releases).
- 
+You can install Opengrep via our official install script.
+
+### Quick Install (Recommended)
+```sh
+curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
+```
+
+If you've cloned the repo and `install.sh` is in the root directory, you can run:
+
+```sh
+./install.sh
+```
+
+Which will install the latest version of Opengrep.
+
+You can also install manually:
+* Binaries available in the latest alpha [release](https://github.com/opengrep/opengrep/releases).
+
+---
+
 ## Getting started
 
 Create `rules/demo-rust-unwrap.yaml` with the following content:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,191 @@
+#!/bin/bash -e
+# Opengrep installation script 
+
+print_usage() {
+    echo "Usage: $0 [-v version] [-l] [-h]"
+    echo "  -v    Specify version to install (optional, default: latest)"
+    echo "  -l    List available versions (latest 3)"
+    echo "  -h    Show this help message"
+}
+
+# Function to get available versions - already checked when running main
+get_available_versions() {
+    command -v curl >/dev/null 2>&1 || { echo >&2 "Required tool curl could not be found. Aborting."; exit 1; }
+    curl -s https://api.github.com/repos/opengrep/opengrep/releases | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+# Function to get latest release version
+get_latest_version() {
+    command -v curl >/dev/null 2>&1 || { echo >&2 "Required tool curl could not be found. Aborting."; exit 1; }
+    curl -s https://api.github.com/repos/opengrep/opengrep/releases | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
+}
+
+# Function to validate version
+validate_version() {
+    local version="$1"
+    local available_versions
+    available_versions=$(get_available_versions)
+    if echo "$available_versions" | grep -q "^$version$"; then
+        return 0
+    else
+        echo "Error: Version $version not found"
+        echo "Available versions (latest 3):"
+        echo "$available_versions" | head -3
+        exit 1
+    fi
+}
+
+
+main () {
+    local VERSION="$1"
+
+    PREFIX="${HOME}/.opengrep/cli"
+    INST="${PREFIX}/${VERSION}"
+    LATEST="${PREFIX}/latest"
+
+    OS="${OS:-$(uname -s)}"
+    ARCH="${ARCH:-$(uname -m)}"
+    DIST=""
+
+    command -v curl >/dev/null 2>&1 || { echo >&2 "Required tool curl could not be found. Aborting."; exit 1; }
+
+    # check and set "os_arch"
+    if [ "$OS" = "Linux" ]; then
+        if ldd --version 2>&1 | grep -qi musl; then
+            if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
+                DIST="opengrep_musllinux_x86"
+            elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+                DIST="opengrep_musllinux_aarch64"
+            fi
+        else
+            if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
+                DIST="opengrep_manylinux_x86"
+            elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+                DIST="opengrep_manylinux_aarch64"
+            fi
+        fi
+    elif [ "$OS" = "Darwin" ]; then
+        if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
+            DIST="opengrep_osx_x86"
+        elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+            DIST="opengrep_osx_arm64"
+        fi
+    fi
+
+    if [ -z "${DIST}" ]; then
+        echo "Operating system '${OS}' / architecture '${ARCH}' is unsupported." 1>&2
+        exit 1
+    fi
+
+    URL="https://github.com/opengrep/opengrep/releases/download/${VERSION}/${DIST}"
+    echo
+    echo "*** Installing Opengrep version ${VERSION} for ${DIST} ***"
+    echo
+
+    # check if binary already exists
+    if [ -f "${INST}/opengrep" ]; then
+        echo "Destination binary ${INST}/opengrep already exists."
+    else
+        mkdir -p "${INST}"
+        if [ ! -d "${INST}" ]; then
+            echo "Failed to create install directory ${INST}." 1>&2
+            exit 1
+        fi
+
+        curl --fail --location --progress-bar "${URL}" > "${INST}/opengrep"
+
+        # make executable by all users
+        chmod a+x "${INST}/opengrep" || exit 1
+
+        if [ ! -f "${INST}/opengrep" ]; then
+            echo "Failed to download binary at ${INST}/opengrep" 1>&2
+            exit 1
+        fi
+
+        # Test by calling --version on the downloaded binary
+        TEST=$("${INST}/opengrep" --version 2>/dev/null || true)
+        if [ -z "$TEST" ]; then
+            echo "Failed to execute installed binary: ${INST}/opengrep." 1>&2
+            exit 1
+        fi
+
+        echo
+        echo "Successfully installed Opengrep binary to ${INST}/opengrep"
+        
+        ln -s "${INST}" "${LATEST}" || exit 1
+        echo "with a symlink from ${LATEST}/opengrep"
+    fi
+
+    LOCALBIN="${HOME}/.local/bin"
+    SYMLINK_CREATED=0
+
+    if [ -d "${LOCALBIN}" ] && [ -w "${LOCALBIN}" ] && [ ! -f "${LOCALBIN}/opengrep" ]; then
+        ln -s "${LATEST}/opengrep" "${LOCALBIN}/opengrep" && SYMLINK_CREATED=1
+        if [ $SYMLINK_CREATED -eq 1 ]; then
+            echo "Created a symlink: ${LOCALBIN}/opengrep → ${LATEST}/opengrep"
+        fi
+    fi
+
+    if [ $SYMLINK_CREATED -eq 0 ]; then
+        echo
+        echo "Hint: Append the following line to your shell profile:"
+        echo "export PATH='${LATEST}':\$PATH"
+        echo
+    fi
+
+    if [ $SYMLINK_CREATED -eq 1 ]; then
+        echo
+        echo "To launch Opengrep now, type"
+        echo "opengrep"
+    else
+        echo
+        echo "To launch Opengrep now, type"
+        echo "${LATEST}/opengrep"
+    fi
+
+}
+
+# Argument parsing
+VERSION=""
+SHOW_HELP=0
+SHOW_LIST=0
+
+while getopts "v:hl" opt; do
+    case $opt in
+        v)
+            VERSION="$OPTARG"
+            ;;
+        h)
+            SHOW_HELP=1
+            ;;
+        l)
+            SHOW_LIST=1
+            ;;
+        \?)
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$SHOW_HELP" -eq 1 ]; then
+    print_usage
+    exit 0
+fi
+
+if [ "$SHOW_LIST" -eq 1 ]; then
+    echo "Available versions (latest 3):"
+    get_available_versions | head -3
+    exit 0
+fi
+
+shift $((OPTIND -1))
+
+if [ -z "$VERSION" ]; then
+    VERSION=$(get_latest_version)
+else
+    validate_version "$VERSION"
+fi
+
+
+main "$VERSION"

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ get_available_versions() {
 # Function to get latest release version
 get_latest_version() {
     command -v curl >/dev/null 2>&1 || { echo >&2 "Required tool curl could not be found. Aborting."; exit 1; }
-    curl -s https://api.github.com/repos/opengrep/opengrep/releases | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
+    curl -s https://api.github.com/repos/opengrep/opengrep/releases/latest | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 # Function to validate version

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 # Opengrep installation script 
 
 print_usage() {

--- a/install.sh
+++ b/install.sh
@@ -14,12 +14,6 @@ get_available_versions() {
     curl -s https://api.github.com/repos/opengrep/opengrep/releases | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
-# Function to get latest release version
-get_latest_version() {
-    command -v curl >/dev/null 2>&1 || { echo >&2 "Required tool curl could not be found. Aborting."; exit 1; }
-    curl -s https://api.github.com/repos/opengrep/opengrep/releases/latest | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/'
-}
-
 # Function to validate version
 validate_version() {
     local version="$1"
@@ -182,7 +176,7 @@ fi
 shift $((OPTIND -1))
 
 if [ -z "$VERSION" ]; then
-    VERSION=$(get_latest_version)
+    VERSION=$(get_available_versions | head -1)
 else
     validate_version "$VERSION"
 fi

--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,7 @@ main () {
 
     URL="https://github.com/opengrep/opengrep/releases/download/${VERSION}/${DIST}"
     echo
-    echo "*** Installing Opengrep version ${VERSION} for ${DIST} ***"
+    echo "*** Installing Opengrep ${VERSION} for ${OS} (${ARCH}) ***"
     echo
 
     # check if binary already exists
@@ -106,37 +106,34 @@ main () {
         echo
         echo "Successfully installed Opengrep binary to ${INST}/opengrep"
         
+        rm -f "${LATEST}" || exit 1
         ln -s "${INST}" "${LATEST}" || exit 1
         echo "with a symlink from ${LATEST}/opengrep"
     fi
 
     LOCALBIN="${HOME}/.local/bin"
-    SYMLINK_CREATED=0
-
-    if [ -d "${LOCALBIN}" ] && [ -w "${LOCALBIN}" ] && [ ! -f "${LOCALBIN}/opengrep" ]; then
-        ln -s "${LATEST}/opengrep" "${LOCALBIN}/opengrep" && SYMLINK_CREATED=1
-        if [ $SYMLINK_CREATED -eq 1 ]; then
-            echo "Created a symlink: ${LOCALBIN}/opengrep → ${LATEST}/opengrep"
+    
+    # only need create the symlink from .local/bin once if not created before
+    # for all subsequent installations, the ./local/bin symlink will still point to the updated symlink (created above)
+    if [ -d "${LOCALBIN}" ] && [ -w "${LOCALBIN}" ]; then
+        # Only create the symlink if it doesn't already exist
+        if [ ! -f "${LOCALBIN}/opengrep" ]; then
+            ln -s "${LATEST}/opengrep" "${LOCALBIN}/opengrep"
+            echo "Created symlink from ${LATEST}/opengrep to ${LOCALBIN}/opengrep"
         fi
-    fi
-
-    if [ $SYMLINK_CREATED -eq 0 ]; then
+        echo
+        echo "To launch Opengrep now, type:"
+        echo "opengrep"
+        echo
+        echo "To check Opengrep version, type:"
+        echo "opengrep --version"
+        echo
+    else
         echo
         echo "Hint: Append the following line to your shell profile:"
         echo "export PATH='${LATEST}':\$PATH"
         echo
     fi
-
-    if [ $SYMLINK_CREATED -eq 1 ]; then
-        echo
-        echo "To launch Opengrep now, type"
-        echo "opengrep"
-    else
-        echo
-        echo "To launch Opengrep now, type"
-        echo "${LATEST}/opengrep"
-    fi
-
 }
 
 # Argument parsing


### PR DESCRIPTION
### Description:
Add a install shell script for easy binary installation of Opengrep.

### Includes:
- install.sh: Downloads and installs the correct prebuilt binary for Linux and macOS (x86_64 and arm64/aarch64), with automatic detection.

- Versioned installs in ~/.opengrep/cli/$VERSION and a symlink to latest.

- Attempts to symlink to ~/.local/bin/opengrep for user-wide CLI access (falls back to a hint for the user to do it manually)


- Handles argument parsing:

    `-v` install specific version
    
    `-l` list available versions
    
    `-h` help/usage

### Why?
Simplifies Opengrep setup for end users (no manual downloads or system-wide installs required), no need for sudo permissions for script to run successfully.

### Docs:
Updated README and install instructions for end users.

### Issue:
Resolves Enchancement Issue #82 

