### PR TITLE
Fix: replace pcre with pcre2 in Eval_generic

### DIFF
--- a/src/engine/Eval_generic.ml
+++ b/src/engine/Eval_generic.ml
@@ -226,9 +226,9 @@ let eval_regexp_matches ?(base_offset = 0) ~file ~regexp:re str =
      * alt: let s = value_to_string v in
      * to convert anything in a string before using regexps on it
   *)
-  let regexp = Pcre_.regexp ~flags:[ `ANCHORED ] re in
+  let regexp = Pcre2_.regexp ~flags:[ `ANCHORED ] re in
   Xpattern_match_regexp.regexp_matcher ~base_offset
-    Xpattern_match_regexp.pcre_regex_functions str file regexp
+    Xpattern_match_regexp.pcre2_regex_functions str file regexp
 [@@alert "-deprecated"]
 
 let rec eval env code =


### PR DESCRIPTION
We observed occasional segfaults that we traced to specific PCRE versions, specifically in Linux things work with 8.39 but we get segfaults with 8.44+.

The solution here is to simply switch to PCRE2 at the exact place that caused the segfault, as discovered using GDB.

Co-authors: @corneliuhoffman @maciejpirog @dimitris-m 