### PR TITLE
Add cosign signature

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -130,8 +130,6 @@ jobs:
         uses: sigstore/cosign-installer@v3
 
       - name: Sign all binaries in artifacts
-        env:
-          COSIGN_EXPERIMENTAL: "1"
         run: |
           files_to_sign=(
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # for Cosign keyless
 
 jobs:
 
@@ -124,7 +125,32 @@ jobs:
           pushd opengrep_windows_binary_x86; mv opengrep.exe opengrep_windows_x86.exe; popd
 
           popd
+      
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
 
+      - name: Sign all binaries in artifacts
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+        run: |
+          files_to_sign=(
+            artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86
+            artifacts/opengrep_manylinux_binary_aarch64/opengrep_manylinux_aarch64
+            artifacts/opengrep_musllinux_binary_x86_64/opengrep_musllinux_x86
+            artifacts/opengrep_musllinux_binary_aarch64/opengrep_musllinux_aarch64
+            artifacts/opengrep_osx_binary_arm64/opengrep_osx_arm64
+            artifacts/opengrep_osx_binary_x86/opengrep_osx_x86
+            artifacts/opengrep_windows_binary_x86/opengrep_windows_x86.exe)
+            for bin in "${files_to_sign[@]}"; do
+            echo "Signing $bin..."
+            cosign sign-blob \
+              --yes \
+              --output-signature "$bin.sig" \
+              --output-certificate "$bin.cert" \
+              "$bin"
+          done
+
+          
       - name: Create or Update Rolling Release
         uses: softprops/action-gh-release@c95fe1489396fe8a9eb87c0abf8aa5b2ef267fda # v2
         with:
@@ -136,11 +162,25 @@ jobs:
             This is a rolling release from `main`.
           files: |
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86
+            artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86.cert
+            artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86.sig
             artifacts/opengrep_manylinux_binary_aarch64/opengrep_manylinux_aarch64
+            artifacts/opengrep_manylinux_binary_aarch64/opengrep_manylinux_aarch64.cert
+            artifacts/opengrep_manylinux_binary_aarch64/opengrep_manylinux_aarch64.sig
             artifacts/opengrep_musllinux_binary_x86_64/opengrep_musllinux_x86
+            artifacts/opengrep_musllinux_binary_x86_64/opengrep_musllinux_x86.cert
+            artifacts/opengrep_musllinux_binary_x86_64/opengrep_musllinux_x86.sig
             artifacts/opengrep_musllinux_binary_aarch64/opengrep_musllinux_aarch64
+            artifacts/opengrep_musllinux_binary_aarch64/opengrep_musllinux_aarch64.cert
+            artifacts/opengrep_musllinux_binary_aarch64/opengrep_musllinux_aarch64.sig
             artifacts/opengrep_osx_binary_arm64/opengrep_osx_arm64
+            artifacts/opengrep_osx_binary_arm64/opengrep_osx_arm64.cert
+            artifacts/opengrep_osx_binary_arm64/opengrep_osx_arm64.sig
             artifacts/opengrep_osx_binary_x86/opengrep_osx_x86
-            artifacts/opengrep_windows_binary_x86/opengrep_windows_x86.exe
+            artifacts/opengrep_osx_binary_x86/opengrep_osx_x86.cert
+            artifacts/opengrep_osx_binary_x86/opengrep_osx_x86.sig
+            artifacts/opengrep_windows_binary_x86/opengrep_windows_x86.exe 
+            artifacts/opengrep_windows_binary_x86/opengrep_windows_x86.exe.cert 
+            artifacts/opengrep_windows_binary_x86/opengrep_windows_x86.exe.sig 
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/install.sh
+++ b/install.sh
@@ -1,37 +1,69 @@
-#!/usr/bin/env bash -e
-# Opengrep installation script 
+#!/usr/bin/env bash 
+set -euo pipefail
+# Opengrep installation script
 
 print_usage() {
-    echo "Usage: $0 [-v version] [-l] [-h]"
-    echo "  -v    Specify version to install (optional, default: latest)"
-    echo "  -l    List available versions (latest 3)"
-    echo "  -h    Show this help message"
+
+    echo "Usage:"
+    echo "install.sh  -v version   Specify version to install (optional, default: latest) warns if you cannot verify signatures"
+    echo "install.sh  -v version --verify-signatures   Specify version to install (optional, default: latest) failing if you cannot verify signatures "
+    echo "install.sh  -l    List available versions (latest 3)"
+    echo "install.sh  -h    Show this help message"
 }
 
 # Function to get available versions - already checked when running main
 get_available_versions() {
-    command -v curl >/dev/null 2>&1 || { echo >&2 "Required tool curl could not be found. Aborting."; exit 1; }
+    command -v curl > /dev/null 2>&1 || {
+        echo >&2 "Required tool curl could not be found. Aborting."
+        exit 1
+    }
     curl -s https://api.github.com/repos/opengrep/opengrep/releases | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/'
 }
 
 # Function to validate version
 validate_version() {
-    local version="$1"
-    local available_versions
-    available_versions=$(get_available_versions)
-    if echo "$available_versions" | grep -q "^$version$"; then
+    local VERSION="$1"
+    local AVAILABLE_VERSIONS
+    AVAILABLE_VERSIONS=$(get_available_versions)
+    if echo "$AVAILABLE_VERSIONS" | grep -q "^$VERSION$"; then
         return 0
     else
-        echo "Error: Version $version not found"
+        echo "Error: Version $VERSION not found"
         echo "Available versions (latest 3):"
-        echo "$available_versions" | head -3
+        echo "$AVAILABLE_VERSIONS" | head -3
         exit 1
     fi
 }
+validate_signature() {
+    local P="$1"
+    if $HAS_COSIGN; then
 
-main () {
+        echo "Verifying signatures for ${P}/opengrep.cert"
+        if cosign verify-blob \
+            --cert "$P/opengrep.cert" \
+            --signature "${P}/opengrep.sig" \
+            --certificate-identity-regexp "https://github.com/opengrep/opengrep.+" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            "${P}/opengrep"; then
+            echo "Signature valid."
+            exit 0
+        else
+            if [[ "$VERIFY_SIGNATURES" == true ]]; then
+                echo "Error: Signature validation error. Deleting downloaded package"
+                rm -rf "${P}"
+                exit 1
+            else
+                echo "Warning  Signature validation error; the package is still installed."
+                echo "If this was not intended, delete and rerun with --verify-signatures"
+                exit 0
+            fi
+        fi
+    fi
+}
+
+main() {
     local VERSION="$1"
-
+    local VERIFY_SIGNATURES="$2"
     PREFIX="${HOME}/.opengrep/cli"
     INST="${PREFIX}/${VERSION}"
     LATEST="${PREFIX}/latest"
@@ -40,7 +72,10 @@ main () {
     ARCH="${ARCH:-$(uname -m)}"
     DIST=""
 
-    command -v curl >/dev/null 2>&1 || { echo >&2 "Required tool curl could not be found. Aborting."; exit 1; }
+    command -v curl > /dev/null 2>&1 || {
+        echo >&2 "Required tool curl could not be found. Aborting."
+        exit 1
+    }
 
     # check and set "os_arch"
     if [ "$OS" = "Linux" ]; then
@@ -73,7 +108,7 @@ main () {
     URL="https://github.com/opengrep/opengrep/releases/download/${VERSION}/${DIST}"
     echo
     echo "*** Installing Opengrep ${VERSION} for ${OS} (${ARCH}) ***"
-    echo
+    
 
     # check if binary already exists
     if [ -f "${INST}/opengrep" ]; then
@@ -86,6 +121,12 @@ main () {
         fi
 
         curl --fail --location --progress-bar "${URL}" > "${INST}/opengrep"
+        curl --fail --location --progress-bar "${URL}.cert" > "${INST}/opengrep.cert"
+        curl --fail --location --progress-bar "${URL}.sig" > "${INST}/opengrep.sig"
+
+        # check signature
+
+        validate_signature "${INST}"
 
         # make executable by all users
         chmod a+x "${INST}/opengrep" || exit 1
@@ -96,7 +137,7 @@ main () {
         fi
 
         # Test by calling --version on the downloaded binary
-        TEST=$("${INST}/opengrep" --version 2>/dev/null || true)
+        TEST=$("${INST}/opengrep" --version 2> /dev/null || true)
         if [ -z "$TEST" ]; then
             echo "Failed to execute installed binary: ${INST}/opengrep." 1>&2
             exit 1
@@ -104,14 +145,14 @@ main () {
 
         echo
         echo "Successfully installed Opengrep binary at ${INST}/opengrep"
-        
+
         rm -f "${LATEST}" || exit 1
         ln -s "${INST}" "${LATEST}" || exit 1
         echo "with a symlink from ${LATEST}/opengrep"
     fi
 
     LOCALBIN="${HOME}/.local/bin"
-    
+
     # Only need to create the symlink from .local/bin once if not created before.
     # For all subsequent installations, the ./local/bin symlink will still point
     # to the updated symlink (created above).
@@ -126,7 +167,7 @@ main () {
         echo "To launch Opengrep now, type:"
         # Do not assume that ~/.local/bin is in the PATH even if it exists,
         # as it is not always the case.
-        if echo "$PATH" | tr ':' '\n' | grep -Fxq "$HOME/.local/bin" ; then
+        if echo "$PATH" | tr ':' '\n' | grep -Fxq "$HOME/.local/bin"; then
             echo "opengrep"
         else
             echo "${LOCALBIN}/opengrep"
@@ -144,40 +185,77 @@ main () {
 }
 
 # Argument parsing
-VERSION=""
-SHOW_HELP=0
-SHOW_LIST=0
+if command -v cosign &> /dev/null; then
+    HAS_COSIGN=true
+else
+    HAS_COSIGN=false
+fi
 
-while getopts "v:hl" opt; do
-    case $opt in
-        v)
-            VERSION="$OPTARG"
+HELP=false
+LIST=false
+VERIFY_SIGNATURES=false
+VERSION=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h)
+            HELP=true
+            shift
             ;;
-        h)
-            SHOW_HELP=1
+        -l)
+            LIST=true
+            shift
             ;;
-        l)
-            SHOW_LIST=1
+        --verify-signatures)
+            VERIFY_SIGNATURES=true
+            shift
             ;;
-        \?)
+        -v)
+            if [[ -n "$2" && "$2" != -* ]]; then
+                VERSION="$2"
+                shift 2
+            else
+                echo "Error: -v requires a version argument"
+                exit 1
+            fi
+            ;;
+        *)
+            echo "Error: Unknown option: $1"
             print_usage
             exit 1
             ;;
     esac
 done
 
-if [ "$SHOW_HELP" -eq 1 ]; then
+if { { $VERIFY_SIGNATURES || [[ -n "$VERSION" ]] || $LIST; } && $HELP; } || { { $VERIFY_SIGNATURES || [[ -n "$VERSION" ]] || $HELP; } && $LIST; }; then
+    echo "Error: incorrect arguments:"
+    print_usage
+    exit 1
+
+fi
+
+if $VERIFY_SIGNATURES && ! $HAS_COSIGN; then
+    echo "Error: cosign is required for --verify-signatures but not installed."
+    echo "Go to https://github.com/sigstore/cosign to install or run without the --verify-signatures flag to install without verifying."
+    exit 1
+elif ! $HAS_COSIGN; then
+    echo "Warning: cosign is required for --verify-signatures but not installed. Skipping signature validation"
+    echo "Go to https:/github.com/sigstore/cosign to install."
+fi
+
+
+if "$HELP"; then
     print_usage
     exit 0
 fi
 
-if [ "$SHOW_LIST" -eq 1 ]; then
+if $LIST; then
     echo "Available versions (latest 3):"
     get_available_versions | head -3
     exit 0
 fi
 
-shift $((OPTIND -1))
+shift $((OPTIND - 1))
 
 if [ -z "$VERSION" ]; then
     VERSION=$(get_available_versions | head -1)
@@ -185,5 +263,4 @@ else
     validate_version "$VERSION"
 fi
 
-
-main "$VERSION"
+main "$VERSION" "$VERIFY_SIGNATURES"


### PR DESCRIPTION
Fixes #87
The PR has two additions:
1. changes in the `rolling-release` action to sign and add signatures to each image
2. changes to the `install` script to include signature verification:
from now on the way to run it is:
`./install (-v version)` this install the file and the sigs (if present) verifies the signatures and warns on signature error 
`./install.sh (-v version) --verify-signatures` this installs the file and the signs (if present), verifies the signatures and in the case of signature errors it deletes the installed files and  fails.

Note:
it is not obvious how to test the install script before having a relesea with signatures. However one can test it locally:
1. download the three files for your os from https://github.com/opengrep/opengrep/releases/tag/untagged-d11b21f8c54255d9cadb
2. move them to $HOME/.opengrep/cli/test and rename them removing the reference to the OS (i.e opengrep, opengrep.sig opengrep.cert)
3. point the $HOME/.opengrep/cli/latest to $HOME/.opengrep/cli/test
4. run the install.sh test with and without --verify-signatures

You can also directly run install.sh with and without --verify-signatures to see it failing



