### PR TITLE
Create _opam in container when no GHA cache hit

### DIFF
--- a/.github/workflows/build-test-core-aarch64.yml
+++ b/.github/workflows/build-test-core-aarch64.yml
@@ -50,6 +50,7 @@ jobs:
             alpine:3.22 \
             sh -c \
             "set -e;
+             mkdir -p _opam;
              chown -R root:root /workspace/_opam;
              ./scripts/workflow-build-inside-alpine-container.sh;
              chown -R $(id -u):$(id -g) /workspace/_opam"


### PR DESCRIPTION
Fixes an undetected bug.