### PR TITLE
Bump python manylinux for nuitka build

### DIFF
--- a/.github/workflows/build-manylinux-binary.yml
+++ b/.github/workflows/build-manylinux-binary.yml
@@ -19,9 +19,9 @@ jobs:
     steps:
       - run: |
           yum update -y
-          yum install -y zip python3-pip python3.9 python39-devel ccache patchelf
+          yum install -y zip python3.12-pip python3.12 python3.12-devel ccache patchelf
           alternatives --remove-all python3
-          alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+          alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
           alternatives --auto python3
       
       # - run: find / -name "libpython*" #; exit 1
@@ -118,6 +118,7 @@ jobs:
           # install some dependencies for windows (pyinstaller only)
           python3 -m pip install chardet charset-normalizer
 
+          PYTHON_BIN=python3 \
           ./scripts/build-nuitka.sh "v$(opengrep --version)" true $SRC_SEMGREP_DIR
 
       - name: Zip artifact

--- a/.github/workflows/build-test-osx.yml
+++ b/.github/workflows/build-test-osx.yml
@@ -45,9 +45,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # ratchet:actions/checkout@v4
         with:
           submodules: true
-      - name: Debug use-cache input
-        run: |
-          echo "use-cache value: ${{ inputs.use-cache }}"
       - env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
         # if: ${{ inputs.use-cache == 'true' || inputs.use-cache == '' }}


### PR DESCRIPTION
Closes #316.

Tested on Fedora 42, and in the workflow also on Ubuntu 22.04.

Maybe we should add more distros to the workflow steps that test the binary...