### PR TITLE
Ruby local global bug

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -635,7 +635,7 @@ and expr_aux env ?(void = false) g_expr =
                 tok,
                 G.FN
                   (G.Id
-                    (("concat", _), { G.id_resolved = { contents = None }; _ }))
+                     (("concat", _), { G.id_resolved = { contents = None }; _ }))
               );
           _;
         },
@@ -721,8 +721,9 @@ and expr_aux env ?(void = false) g_expr =
          * if a function with the same name as the identifier exists, specifically
          * for Ruby. *)
         match lval with
-        | { base = Var { ident; _ }; _ }
+        | { base = Var { ident; id_info; _ }; _ }
           when env.lang =*= Lang.Ruby
+               && Option.is_none !(id_info.id_resolved)
                && IdentSet.mem (H.str_of_ident ident) env.ctx.entity_names ->
             let tok = G.fake "call" in
             add_call env tok eorig ~void (fun res -> Call (res, exp, []))
@@ -943,7 +944,7 @@ and expr_lazy_op env op tok arg0 args eorig =
   let arg0' = argument env arg0 in
   let args' : exp argument list =
     (* Consider A && B && C, side-effects in B must only take effect `if A`,
-       * and side-effects in C must only take effect `if A && B`. *)
+     * and side-effects in C must only take effect `if A && B`. *)
     args
     |> List.fold_left_map
          (fun cond argi ->
@@ -1567,7 +1568,7 @@ and mk_class_construction env obj origin_exp ty cons_id_info args :
         (Fetch { lval with rev_offset = [ { o = Dot cons'; oorig = NoOrig } ] })
         (SameAs (G.N cons |> G.e))
       (* THINK: ^^^^^ We need to construct a `SameAs` eorig here because Pro
-         * looks at the eorig, but maybe it shouldn't? *)
+       * looks at the eorig, but maybe it shouldn't? *)
     in
     Some cons_exp
   in
@@ -1806,8 +1807,8 @@ and for_each env tok (pat, tok2, e) st =
             (related_tok tok2)))
   in
   (* same semantic? or need to take Ref? or pass lval
-     * directly in next_call instead of using intermediate next_lval?
-  *)
+   * directly in next_call instead of using intermediate next_lval?
+   *)
   let assign_st =
     pattern_assign_statements env
       (mk_e (Fetch next_lval) (related_tok tok2))

--- a/tests/rules/ruby_local_global.rb
+++ b/tests/rules/ruby_local_global.rb
@@ -1,0 +1,7 @@
+def opts(data) = Array(data).join(" ") # process options
+
+def test_calls4(user_input)
+    opts = [user_input, "-c"] # local var
+    # ruleid: test
+    system("ls #{opts}")
+end

--- a/tests/rules/ruby_local_global.yaml
+++ b/tests/rules/ruby_local_global.yaml
@@ -1,0 +1,24 @@
+rules:
+  - id: test
+    message: Possible command injection via exec()-type functions
+    languages:
+      - ruby
+    severity: ERROR
+    mode: taint
+    options:
+      symbolic_propagation: true
+    pattern-sources:
+      - pattern-either:
+          - patterns:
+              - focus-metavariable: $SOURCE
+              - pattern-inside: def $METHOD(..., $SOURCE, ...) ...
+    pattern-sinks:
+      - patterns:
+          - pattern-either:
+              - patterns:
+                  - metavariable-regex:
+                      regex: (system)$
+                      metavariable: $METHOD
+                  - focus-metavariable: $SOURCE
+                  - pattern-either:
+                      - pattern: $METHOD($SOURCE, ...)


### PR DESCRIPTION
fixes #323 

 In the AS_to_IL there was a short hack to allow for ruby calling function without brackets and without arguments. The issue was that it did not consider local variable.