### PR TITLE
Fix baseline scan when using --experimental

### DIFF
--- a/src/osemgrep/cli_scan/Diff_scan.ml
+++ b/src/osemgrep/cli_scan/Diff_scan.ml
@@ -58,7 +58,7 @@ let remove_matches_in_baseline caps (commit : string) (baseline : Core_result.t)
       !!(m.path.internal_path_to_content) |> fun p ->
       Option.bind renamed
         (List_.find_some_opt (fun (before, after) ->
-             if after = p then Some before else None))
+             if String.equal after p then Some before else None))
       |> Option.value ~default:p
     in
     let start_range, end_range = m.range_loc in

--- a/src/osemgrep/cli_scan/Diff_scan.ml
+++ b/src/osemgrep/cli_scan/Diff_scan.ml
@@ -215,7 +215,7 @@ let scan_baseline (caps : < Cap.chdir ; Cap.tmp >) (conf : Scan_CLI.conf)
     in
     match conf.engine_type with
     | PRO Engine_type.{ analysis = Interfile; _ } -> (targets, added_or_modified)
-    | _ -> (targets, added_or_modified)
+    | _ -> (targets, [])
   in
   let (head_scan_result : Core_result.result_or_exn) =
     Profiler.record profiler ~name:"head_core_time" (fun () ->

--- a/src/osemgrep/cli_scan/Diff_scan.ml
+++ b/src/osemgrep/cli_scan/Diff_scan.ml
@@ -171,6 +171,8 @@ let scan_baseline_and_remove_duplicates (caps : < Cap.chdir ; Cap.tmp >)
               let baseline_targets, baseline_diff_targets =
                 match conf.engine_type with
                 | PRO Engine_type.{ analysis = Interprocedural; _ } ->
+                    (* Keeping all the PRO stuff since we will probably need
+                     * these code paths. *)
                     let all_in_baseline, _ =
                       Find_targets.get_target_fpaths conf.targeting_conf
                         conf.target_roots

--- a/src/osemgrep/cli_scan/Diff_scan.ml
+++ b/src/osemgrep/cli_scan/Diff_scan.ml
@@ -215,7 +215,14 @@ let scan_baseline (caps : < Cap.chdir ; Cap.tmp >) (conf : Scan_CLI.conf)
     in
     match conf.engine_type with
     | PRO Engine_type.{ analysis = Interfile; _ } -> (targets, added_or_modified)
-    | _ -> (targets, [])
+    | _ ->
+      let targets_modified_or_added =
+        let added_or_modified_set = Fpath.Set.of_list added_or_modified in
+        List.filter
+          (fun p -> Fpath.Set.mem p added_or_modified_set)
+          targets
+      in
+      (targets_modified_or_added, [])
   in
   let (head_scan_result : Core_result.result_or_exn) =
     Profiler.record profiler ~name:"head_core_time" (fun () ->

--- a/src/osemgrep/cli_scan/Diff_scan.ml
+++ b/src/osemgrep/cli_scan/Diff_scan.ml
@@ -215,7 +215,7 @@ let scan_baseline (caps : < Cap.chdir ; Cap.tmp >) (conf : Scan_CLI.conf)
     in
     match conf.engine_type with
     | PRO Engine_type.{ analysis = Interfile; _ } -> (targets, added_or_modified)
-    | _ -> (added_or_modified, [])
+    | _ -> (targets, added_or_modified)
   in
   let (head_scan_result : Core_result.result_or_exn) =
     Profiler.record profiler ~name:"head_core_time" (fun () ->


### PR DESCRIPTION
### Changes 

Closes #301: the head scan needs to be on the passed targets, which have been selected accordingly (also including semgrep ignore etc).

The git diff information is used on the baseline scan, for example to detect renamed files (removing matches as if the renaming has not taken place).

Out of all the normal targets we would scan, we restrict to the ones actually added or modified from the baseline.
Else, semgrepignore is not applied, and we end up scanning targets that should be ignored.