### PR TITLE
Align --profile table output

### DIFF
--- a/libs/profiling/Profiling.ml
+++ b/libs/profiling/Profiling.ml
@@ -119,6 +119,9 @@ let profile_diagnostic () : string =
       Hashtbl.fold (fun k v acc -> (k, v) :: acc) !_profile_table []
       |> List.sort (fun (_k1, (t1, _n1)) (_k2, (t2, _n2)) -> compare t2 t1)
     in
+    let max_key_len =
+      List.fold_left (fun acc (k, _) -> max acc (String.length k)) 0 xs
+    in
     Buffer_.with_buffer_to_string (fun buf ->
         let prf fmt = Printf.bprintf buf fmt in
         prf "\n";
@@ -127,7 +130,7 @@ let profile_diagnostic () : string =
         prf "---------------------\n";
         xs
         |> List.iter (fun (k, (t, n)) ->
-               prf "%-40s : %10.3f sec %10d count\n" k !t !n))
+            prf "%-*s : %10.3f sec %10d count\n" max_key_len k !t !n))
 
 let warn_if_take_time timethreshold s f =
   let t = Unix.gettimeofday () in


### PR DESCRIPTION
When passing `--profile`: improved the output, ensuring that columns are aligned. 
We now pad the first column according to the longest value instead of fixing it to 40.