### PR TITLE
Fix: pin memprof-limits

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -4,7 +4,7 @@
 ;; to autogenerate the semgrep.opam for 'opam'.
 
 (pin
- (url "git+https://gitlab.com/dimitris-m/memprof-limits.git#dm/ocaml-5.3.0")
+ (url "git+https://gitlab.com/dimitris-m/memprof-limits.git#dm/ocaml-5.3.0-opengrep")
  (package (name memprof-limits)))
 
 ;; classic dune-project settings

--- a/scripts/install-memprof-limits-dev.sh
+++ b/scripts/install-memprof-limits-dev.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 opam pin -y add memprof-limits.dev \
-    https://gitlab.com/dimitris-m/memprof-limits.git\#dm/ocaml-5.3.0
+    https://gitlab.com/dimitris-m/memprof-limits.git\#dm/ocaml-5.3.0-opengrep


### PR DESCRIPTION
The branch we were using had some changes made by the upstream author, which in some cases led to this error: 

```
[00.45][ERROR](process_limits): exn while in set_timeout
[00.45][ERROR]: exception on src/code.ml (Failure: Gc.Memprof.start: already started.)
```

Not sure why yet, but it indicates a concurrency bug.

I restored my original solution in a new branch which is tested and does not have this regression.
This is the branch used in this PR.

Please ensure you adapt your switch with: 

```bash
opam pin add memprof-limits.dev https://gitlab.com/dimitris-m/memprof-limits.git\#dm/ocaml-5.3.0-opengrep -y
```