### PR TITLE
fix: detect musl in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,7 @@ main() {
 
     # check and set "os_arch"
     if [ "$OS" = "Linux" ]; then
-        if ldd --version 2> /dev/null | grep -qi musl || [ -f /lib/ld-musl-*.so.* ]; then
+        if ldd /bin/sh 2>&1 | grep -qi musl; then
             if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
                 DIST="opengrep_musllinux_x86"
             elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then

--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,7 @@ main() {
 
     # check and set "os_arch"
     if [ "$OS" = "Linux" ]; then
-        if ldd --version 2>&1 | grep -qi musl; then
+        if ldd --version 2> /dev/null | grep -qi musl || [ -f /lib/ld-musl-*.so.* ]; then
             if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then
                 DIST="opengrep_musllinux_x86"
             elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
@@ -151,7 +151,7 @@ main() {
         fi
     else
         echo
-        echo "*** Installing Opengrep ${VERSION} for ${OS} (${ARCH}) ***"
+        echo "*** Installing ${DIST} ${VERSION} for ${OS} (${ARCH}) ***"
 
         # cleanup on error
         trap '[ "$?" -eq 0 ] || cleanup_on_failure $INST' EXIT

--- a/install.sh
+++ b/install.sh
@@ -151,7 +151,7 @@ main() {
         fi
     else
         echo
-        echo "*** Installing ${DIST} ${VERSION} for ${OS} (${ARCH}) ***"
+        echo "*** Installing Opengrep ${VERSION} for ${OS} (${ARCH}) ***"
 
         # cleanup on error
         trap '[ "$?" -eq 0 ] || cleanup_on_failure $INST' EXIT


### PR DESCRIPTION
Issue: 
The ldd --version check failed to reliably detect musl on Alpine.

Change:
 A direct verification for `/lib/ld-musl-*.so.*`. The path based check for musl presence when ldd --version output is ambiguous.

Validate:
Create a test.Dockerfile for testing
```
FROM alpine:latest
RUN apk add cosign curl
COPY install.sh .
RUN sh ./install.sh
```
Run
`Docker build . -f test.Dockerfile --no-cache --progress=plain`