### PR TITLE
Restore the python version of the `ci` command

### DIFF
--- a/cli/src/semgrep/cli.py
+++ b/cli/src/semgrep/cli.py
@@ -2,7 +2,7 @@ from typing import Dict
 
 import click
 
-# from semgrep.commands.ci import ci
+from semgrep.commands.ci import ci
 # from semgrep.commands.install import install_semgrep_pro
 # from semgrep.commands.login import login
 # from semgrep.commands.publish import publish # NOTE: May be re-activated in future.
@@ -59,7 +59,7 @@ def cli(ctx: click.Context) -> None:
     maybe_set_git_safe_directories()
 
 
-# cli.add_command(ci)
+cli.add_command(ci)
 # cli.add_command(login)
 # cli.add_command(publish) # NOTE: This may be added in the future.
 cli.add_command(scan)


### PR DESCRIPTION
The OCaml version, which is used when we pass --experimental, is not usable right now. We may restore it at a later time.