### PR TITLE
Ensure fingerprint is unique

### DIFF
--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -193,7 +193,7 @@ let metavar_string_of_any any =
      Handle such cases *)
   any |> AST_generic_helpers.ii_of_any
   |> List.filter Tok.is_origintok
-  |> List.sort Tok.compare_pos
+  |> List.sort_uniq Tok.compare_pos
   |> List_.map Tok.content_of_tok
   |> Core_text_output.join_with_space_if_needed
 


### PR DESCRIPTION
Closes #335.

- Not a great solution because we don't know the root cause of the non-determinism, but it fixes the problem for now.
- Hard to test as the issue only happens _sometimes_ and it seems to be a concurrency bug.

We are analysing internally but for now let's ensure that fingerprints are deterministic.

To be continued...