### PR TITLE
Release version v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [1.6.0](https://github.com/opengrep/opengrep/releases/tag/v1.6.0) - 10-07-2025
+
+### Removed features
+
+* Remove semgrep-specific functionality including the `--metrics` parameter by @dimitris-m in #329 and #336
+
+### Improvements
+
+* Ensure that python has the expected version in the manylinux binary by @dimitris-m in #322
+* Make tests invariant to version by @dimitris-m in #325
+* Align --profile table output by @dimitris-m in #327
+
+### Bug fixes
+
+* Fix: install script flow for cosign by @dimitris-m in #321
+* Improve Ruby tainting by @corneliuhoffman in #324
+* Fix baseline scan when using --experimental by @dimitris-m in #326
+* Fix: pin memprof-limits by @dimitris-m in #328
+* fix: detect musl in install script by @securityPirate in #330
+* Ensure fingerprint is unique by @dimitris-m in #338
+
+### New Contributors
+* @securityPirate made their first contribution in #330
+
+**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.5.0...v1.6.0
+
+
 ## [1.5.0](https://github.com/opengrep/opengrep/releases/tag/v1.5.0) - 03-07-2025
 
 ### New features

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -130,7 +130,7 @@ install_requires = [
 
 setuptools.setup(
     name="opengrep",
-    version="1.5.0",
+    version="1.6.0",
     author="Semgrep Inc., Opengrep",
     author_email="support@opengrep.com",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",

--- a/cli/src/semgrep/__init__.py
+++ b/cli/src/semgrep/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = "1.5.0"
+__VERSION__ = "1.6.0"
 __SEMGREP_VERSION__ = "1.100.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="semgrep_pre_commit_package",
-    version="1.5.0",
+    version="1.6.0",
     # install_requires=["opengrep==1.2.0"], # Commented out since we're not on pypi.
     packages=[],
 )

--- a/src/core/Version.ml
+++ b/src/core/Version.ml
@@ -3,5 +3,5 @@
 
   Automatically modified by scripts/release/bump.
 *)
-let version = "1.5.0"
+let version = "1.6.0"
 let version_semgrep = "1.100.0"


### PR DESCRIPTION
### Removed features

* Remove semgrep-specific functionality including the `--metrics` parameter by @dimitris-m in #329 and #336

### Improvements

* Ensure that python has the expected version in the manylinux binary by @dimitris-m in #322
* Make tests invariant to version by @dimitris-m in #325
* Align --profile table output by @dimitris-m in #327

### Bug fixes

* Fix: install script flow for cosign by @dimitris-m in #321
* Improve Ruby tainting by @corneliuhoffman in #324
* Fix baseline scan when using --experimental by @dimitris-m in #326
* Fix: pin memprof-limits by @dimitris-m in #328
* fix: detect musl in install script by @securityPirate in #330
* Ensure fingerprint is unique by @dimitris-m in #338

### New Contributors
* @securityPirate made their first contribution in #330

**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.5.0...v1.6.0
