### PR TITLE
fix: flake.nix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -250,7 +250,6 @@ install-deps-for-semgrep-core:
 	cd libs/ocaml-tree-sitter-core \
 	&& ./configure \
 	&& ./scripts/install-tree-sitter-lib
-	./scripts/install-memprof-limits-dev.sh
 	make install-opam-deps
 
 # Install OCaml dependencies (globally) from *.opam files.
@@ -445,24 +444,19 @@ shell:
 	nix develop -c $(USER_SHELL)
 
 # Build targets
-# For all the .?submodules=1 we need because nix is weird:
-# https://github.com/NixOS/nix/issues/4423#issuecomment-791352686
-nix-osemgrep:
-	nix build ".?submodules=1#osemgrep"
+nix-build-opengrep:
+	nix build ".#opengrep"
 
-nix-semgrep-core:
-	nix build ".?submodules=1#semgrep-core"
+nix-build-pyopengrep:
+	nix build ".#pyopengrep"
 
-nix-semgrep:
-	nix build ".?submodules=1#semgrep"
-
-# Build + run tests (doesn't run python tests yet)
+# Run tests
 nix-check:
-	nix flake check ".?submodules=1#"
+	nix flake check
 
-# verbose and sandboxing are disabled to enable networking for tests
+# Verbose tests
 nix-check-verbose:
-	nix flake check -L ".?submodules=1#"
+	nix flake check -L
 
 # check flake is valid and not stale
 nix-check-flake:

--- a/dune
+++ b/dune
@@ -34,4 +34,5 @@
   languages
   src
   tools
+  opam
 )

--- a/dune-project
+++ b/dune-project
@@ -4,7 +4,7 @@
 ;; to autogenerate the semgrep.opam for 'opam'.
 
 (pin
- (url "git+https://gitlab.com/dimitris-m/memprof-limits.git#dm/ocaml-5.3.0-opengrep")
+ (url "git+https://gitlab.com/dimitris-m/memprof-limits.git#c2cced325a93d2271379f0712db85867b29dbee1")
  (package (name memprof-limits)))
 
 ;; classic dune-project settings
@@ -378,7 +378,7 @@ time and memory used by Semgrep.
     (ocaml (>= "5.3.0"))
     (dune (>= "3.2.0" ))
     (commons (>= "1.5.5"))
-    (memprof-limits (= "dev"))
+    memprof-limits
   )
 )
 
@@ -517,7 +517,7 @@ For more information see https://opengrep.dev.
     ; make our GHA opam cache useless. We might need to install here instead
     ; packages that would avoid this effect.
     git-unix
-    (memprof-limits (= "dev")) ; NOTE: Just to invalidate CI cache for now.
+    memprof-limits
     thread-local-storage ; NOTE: We should not mess with memprof-limits, but in
                          ; fact there is a TLS module in there also; however, it's
                          ; not exposed in the public interface.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -34,6 +34,23 @@
         "type": "github"
       }
     },
+    "memprof-limits": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1738760381,
+        "narHash": "sha256-oY/ElDhsL+wfz9MpwqO/rwvHt3wOeKly0BYcR4ckAYQ=",
+        "owner": "dimitris-m",
+        "repo": "memprof-limits",
+        "rev": "c2cced325a93d2271379f0712db85867b29dbee1",
+        "type": "gitlab"
+      },
+      "original": {
+        "owner": "dimitris-m",
+        "ref": "dm/ocaml-5.3.0-opengrep",
+        "repo": "memprof-limits",
+        "type": "gitlab"
+      }
+    },
     "mirage-opam-overlays": {
       "flake": false,
       "locked": {
@@ -52,11 +69,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733581040,
-        "narHash": "sha256-Qn3nPMSopRQJgmvHzVqPcE3I03zJyl8cSbgnnltfFDY=",
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "22c3f2cf41a0e70184334a958e6b124fb0ce3e01",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
         "type": "github"
       },
       "original": {
@@ -81,11 +98,11 @@
         "opam2json": "opam2json"
       },
       "locked": {
-        "lastModified": 1732617437,
-        "narHash": "sha256-jj25fziYrES8Ix6HkfSiLzrN6MZjiwlHUxFSIuLRjgE=",
+        "lastModified": 1751892529,
+        "narHash": "sha256-7Yk1FWNOmQB3jEB1OUlihy8OTNJAAt8AjgJOF6L1WcY=",
         "owner": "tweag",
         "repo": "opam-nix",
-        "rev": "ea8b9cb81fe94e1fc45c6376fcff15f17319c445",
+        "rev": "dd669ba8909880f69def7878fc912a97923709d5",
         "type": "github"
       },
       "original": {
@@ -97,11 +114,11 @@
     "opam-overlays": {
       "flake": false,
       "locked": {
-        "lastModified": 1726822209,
-        "narHash": "sha256-bwM18ydNT9fYq91xfn4gmS21q322NYrKwfq0ldG9GYw=",
+        "lastModified": 1741116009,
+        "narHash": "sha256-Z0PIW82fHJFvAv/JYpAffnp2DaOjLhsPutqyIrORZd0=",
         "owner": "dune-universe",
         "repo": "opam-overlays",
-        "rev": "f2bec38beca4aea9e481f2fd3ee319c519124649",
+        "rev": "e031bb64e33bf93be963e9a38b28962e6e14381f",
         "type": "github"
       },
       "original": {
@@ -113,11 +130,11 @@
     "opam-repository": {
       "flake": false,
       "locked": {
-        "lastModified": 1732612513,
-        "narHash": "sha256-kju4NWEQo4xTxnKeBIsmqnyxIcCg6sNZYJ1FmG/gCDw=",
+        "lastModified": 1751808506,
+        "narHash": "sha256-H0WN/VhgaI6GLYmLAThoRcsf4XwnMNEBsz/w8FbLSrU=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "3d52b66b04788999a23f22f0d59c2dfc831c4f32",
+        "rev": "bd82a8dde3f816d8b45ecbe005ac1f8e7f25c207",
         "type": "github"
       },
       "original": {
@@ -129,11 +146,11 @@
     "opam-repository_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1733656817,
-        "narHash": "sha256-ddoiIYY6AhWLUxkgtXhPbB7Du0OcHPyR4iEF/Tm8BsY=",
+        "lastModified": 1751928587,
+        "narHash": "sha256-3m+YxrePHsxF+nm/hPZaUWGNnLaNLgv+70u60pS59Q0=",
         "owner": "ocaml",
         "repo": "opam-repository",
-        "rev": "211ce1c3d5d6eb57dee3ca21cb1e4a16da41d01f",
+        "rev": "11a53009bd75423d805636ff9384bf7cce8b0a9a",
         "type": "github"
       },
       "original": {
@@ -147,14 +164,15 @@
         "nixpkgs": [
           "opam-nix",
           "nixpkgs"
-        ]
+        ],
+        "systems": "systems_2"
       },
       "locked": {
-        "lastModified": 1671540003,
-        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "lastModified": 1749457947,
+        "narHash": "sha256-+QVm+HOYikF3wUhqSIV8qJbE/feSG+p48fgxIosbHS0=",
         "owner": "tweag",
         "repo": "opam2json",
-        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "rev": "0ecd66fc2bfb25d910522c990dd36412259eac1f",
         "type": "github"
       },
       "original": {
@@ -166,12 +184,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "memprof-limits": "memprof-limits",
         "nixpkgs": "nixpkgs",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository_2"
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -34,23 +34,6 @@
         "type": "github"
       }
     },
-    "memprof-limits": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1738760381,
-        "narHash": "sha256-oY/ElDhsL+wfz9MpwqO/rwvHt3wOeKly0BYcR4ckAYQ=",
-        "owner": "dimitris-m",
-        "repo": "memprof-limits",
-        "rev": "c2cced325a93d2271379f0712db85867b29dbee1",
-        "type": "gitlab"
-      },
-      "original": {
-        "owner": "dimitris-m",
-        "ref": "dm/ocaml-5.3.0-opengrep",
-        "repo": "memprof-limits",
-        "type": "gitlab"
-      }
-    },
     "mirage-opam-overlays": {
       "flake": false,
       "locked": {
@@ -184,7 +167,6 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "memprof-limits": "memprof-limits",
         "nixpkgs": "nixpkgs",
         "opam-nix": "opam-nix",
         "opam-repository": "opam-repository_2"

--- a/flake.nix
+++ b/flake.nix
@@ -194,27 +194,19 @@
       url = "github:ocaml/opam-repository";
       flake = false;
     };
-    memprof-limits = {
-      url = "gitlab:dimitris-m/memprof-limits/dm/ocaml-5.3.0-opengrep";
-      flake = false;
-    };
   };
   outputs = {
     nixpkgs,
     flake-utils,
     opam-nix,
     opam-repository,
-    memprof-limits,
     ...
   }:
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
       on = opam-nix.lib.${system};
       pythonPackages = pkgs.python311Packages;
-      opamRepos = [
-        (opam-nix.lib.${system}.makeOpamRepo memprof-limits)
-        opam-repository
-      ];
+      opamRepos = [opam-repository];
       lib = pkgs.lib;
       isDarwin = lib.strings.hasSuffix "darwin" system;
     in let

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,12 @@
 # ## Overview
 #
-# This is a Nix file for Semgrep developers.
+# This is a Nix file for Opengrep developers.
 #
 # Nix is a dependency manager. Nix allows to use just one command
 # to get a fully functional correct and near identical development
 # environment across any OS, instead of the 10-20 commands it normally takes.
 # It's totally opt-in and will not impact anyones work flow.
 # See https://shopify.engineering/what-is-nix for more information.
-#
-# Note that there is also a Nix(OS) file for semgrep here:
-# https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/security/semgrep
-# so people can install Semgrep on NixOS.
-# However the current file is directed at Semgrep developers, not Semgrep users.
 #
 # ## Quick install of Nix
 #
@@ -25,24 +20,6 @@
 # To disallow all deps outside of Nix:
 # nix develop -i
 #
-# Then setup caching (optional, but recommended):
-#
-# Easy way:
-#   nix profile install --accept-flake-config nixpkgs#cachix
-#   cachix use semgrep
-#   cachix use nix-community
-#
-# Harder way:
-#   echo "trusted-users = <USERNAME>" | sudo tee -a /etc/nix/nix.conf && sudo pkill nix-daemon
-#   vim ~/.config/nix/nix.conf
-#   # then add the following lines to nix.conf:
-#   substituters = https://cache.nixos.org https://semgrep.cachix.org https://nix-community.cachix.org
-#   trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= semgrep.cachix.org-1:waxSNb3ism0Vkmfa31//YYrOC2eMghZmTwy9bvMAGBI= nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=
-#
-# To contribute to the cache, go to 1password "Semgrep Cachix Auth Token" and run
-#   cachix authtoken <TOKEN>
-#
-
 # What is Nix?
 #
 # Nix is a package dependency manager for reproducible and correct builds. Nix
@@ -56,7 +33,7 @@
 # tools made with nix are built this way, nix knows exactly what any dependency
 # needs to build, and to run, meaning *all builds are easily reproducible, and
 # are not affected by what you may or may not have installed on your system*.
-
+#
 # ### What is the difference with a Dockerfile?
 #
 # A Dockerfile is a great way to build an entire OS, and run a program in that
@@ -65,7 +42,7 @@
 # Docker still relies on Linux, and that Linux distro still relies on some
 # package manager. This means that even if you use Docker, your environment is
 # still not reproducible as packages are not built deterministically like Nix.
-# So you can create a Dockerfile building Semgrep, but you will need a different
+# So you can create a Dockerfile building Opengrep, but you will need a different
 # build script + Dockerfile for every system, and you must determine what the
 # different distributions all ship and have package wise. Meanwhile this Nix
 # file will work (almost) exactly the same across any system.
@@ -84,22 +61,22 @@
 # Because they explicitly declare the dependencies, instead of hoping you have
 # said dependencies installed already, or shipping a bash script/Makefile that
 # installs them for you.
-
+#
 # ## Why should I care?
 #
 # Our OCaml code is (mostly) correct because that's a focus of the language
 # itself. But it relies on a lot of C code and external dependencies, like
 # `libev`, `libcurl`, `tree-sitter` etc. This means that if someone wants to
-# build and contribute to Semgrep, they must install these dependencies, and
+# build and contribute to Opengrep, they must install these dependencies, and
 # hope that their versions is compatible. For example if you install the OCaml
-# packages needed for osemgrep, and then install libev, things won't work, since
+# packages needed for Opengrep, and then install libev, things won't work, since
 # the lwt package needs libev when its initially installed. If you're on mac,
 # you also have to tell opam where libev is before installing lwt. So our OCaml
 # is correct, but only if you can build it, and only if you build it with the
 # right dependencies.
-
+#
 # By using Nix, we can declare all these dependencies explicitly, and then
-# anyone across any *nix system can easily build Semgrep with only one command!
+# anyone across any *nix system can easily build Opengrep with only one command!
 # What's even better, is for regular contributors, these dependencies will auto
 # update and rebuild whenever a new dependency is added. So if someone adds a
 # dependency for lwt, libev will automatically be pulled in with 0 thought from
@@ -108,51 +85,49 @@
 # matter what system you're on, so if someone runs into a bug in developing, you
 # can have more confidence in eliminating a system difference as the source of
 # the bug.
-
+#
 # Another bonus is that it's easy to know what version of a dependency you're
 # on, e.g. what version of tree-sitter, or what version of OCaml. You can see
 # how this also would be good for security :).
-
+#
 # There's a lot more places this can simplify things for us, like CI and
 # releases. See future work for more details.
-
+#
 # Finally, nix configurations are written in a functional programming language.
 # Don't you want to declare dependencies in a functional language?
-
+#
 # ## Who uses Nix?
 #
 # Not convinced? Here are some other notable OCaml projects using nix:
-
 # - [dune](https://github.com/ocaml/dune)
 # - [merlin](https://github.com/ocaml/merlin)
 # - [ocaml-lsp](https://github.com/ocaml/ocaml-lsp)
 # - [ocaml-re](https://github.com/ocaml/ocaml-re)
-
+#
 # There's also a ton of projects outside the OCaml world using nix too. Nix is
 # battle tested, and has a huge community, with support for almost anything you
-# can think of. There's even someone packaging Semgrep for nix.
-
+# can think of. There's even someone packaging Opengrep for nix.
+#
 # ## Try it out
 #
 # If you want to see what it's like to use nix, get a clean Linux or macOS box.
 # Then [install nix](https://github.com/DeterminateSystems/nix-installer) with
 # flake support. Finally run `nix develop`. Now you can run `make core` or any
-# make targets in the CLI. That's one command to always be able to build Semgrep
+# make targets in the CLI. That's one command to always be able to build Opengrep
 # vs the 10-20 needed right now, if you're lucky, and then 2-3 every once in
 # awhile to keep up to date.
-
+#
 # If you want to reproduce and help with a bug in someones branch, you can just
 # run `nix develop` and `make test` to instantly have the same exact environment
 # they ran into the bug in. If you're really unsure about if it's a system bug,
 # you can run `nix develop -i` to exclude any non nix dependencies completely.
-
+#
 # If you don't use bash run `nix develop -c $SHELL` to get an environment with
 # your shell.
-
-# If you want to just build semgrep and run it you can do `nix run
-# ".?submodules=1#"` for semgrep or `nix run ".?submodules=1#<target>"` where
-# target is semgrep, pysemgrep, osemgrep, or semgrep-core.
-
+#
+# If you want to just build opengrep and run it you can do `nix run` for opengrep
+# or `nix run ".#<target>"` where target is opengrep or pyopengrep.
+#
 # ## What's the catch?
 #
 # There's not a real big catch to using nix, except development time to set it
@@ -160,7 +135,7 @@
 # slow on a first build, but no more than say `make dev-setup`, and that it uses
 # a decent amount of storage space, but again, not much more than any other
 # package manager.
-
+#
 # ## Contributing/Maintennance
 #
 # The maintenance for nix is super low. It automatically pulls in any dependency
@@ -170,28 +145,12 @@
 # means you have to read some comments then add the name of the package to an
 # array somewhere, super easy. If you're interested in doing anything more
 # complex, see the future reading section.
-
-# # Future work
-# ## Some issues with our current usage of Dune and Opam
 #
-# Right now our usage of dune is a little incorrect. In every language semgrep
-# tree-sitter dune file (i.e. bash/tree-sitter/semgrep-bash), we don't pass the
-# standard c/c++ flags to compile the C files. This means that the compiler
-# provided by nix doesn't know if a c++ file is a c++ file, and fails to include
-# the standard c++ library. There's an ongoing PR to fix this logic for nix, but
-# really we should add ":standard" to the list of c++ flags in these dune files.
-# There's a patch for now in the nix configuration but it's a bit ugly.
-
-# Another issue with our opam usage is we don't declare dependencies on
-# libraries provided by semgrep. I.e. we depend on commons, but don't declare
-# that dependency in semgrep.opam. This breaks some autoresolving things in nix,
-# which are patched for now, but would be nice if we fixed our usage of opam.
-
 # ## CI testing
 #
 # If people like this tool, at some point it'd be great to add a CI workflow
 # that ensures all PRs work even with nix. But let's see how this goes first.
-
+#
 # ## Improving our CI
 #
 # Where nix would smooth things over for us even more is simplifying our CI.
@@ -201,8 +160,8 @@
 # make sure they all have the right package names. If we use nix in CI, all we
 # need is to install nix on the target OS/architecture, then run nix build and
 # it can run all build processes, and all e2e tests. Super simple workflow. It
-# can even build the wheels, and static versions of Semgrep we'd want!
-
+# can even build the wheels, and static versions of Opengrep we'd want!
+#
 # # More reading
 #
 # Interested in reading more about nix? Here are some hand sources
@@ -220,15 +179,11 @@
 #
 # - [Nix PhD Thesis](https://edolstra.github.io/pubs/phd-thesis.pdf) - Nix
 #   creator's PhD thesis on Nix. ~275 pages but really approachable
-
 {
-  description =
-    "Semgrep OSS is a fast, open-source, static analysis tool for searching code, finding bugs, and enforcing code standards at editor, commit, and CI time.";
+  description = "Opengrep is an ultra-fast static analysis tool for searching code patterns with the power of semantic grep.";
   inputs = {
+    self.submodules = true;
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-    # all the follows here are so we don't use diff versions of
-    # nixpkgs/flake-utils than semgrep. This is good for debugging, and reducing
-    # build time/cache size
     flake-utils.url = "github:numtide/flake-utils";
     opam-nix = {
       url = "github:tweag/opam-nix";
@@ -239,282 +194,289 @@
       url = "github:ocaml/opam-repository";
       flake = false;
     };
+    memprof-limits = {
+      url = "gitlab:dimitris-m/memprof-limits/dm/ocaml-5.3.0-opengrep";
+      flake = false;
+    };
   };
-  outputs = { self, nixpkgs, flake-utils, opam-nix, opam-repository }@inputs:
-    let package = "semgrep";
-    in flake-utils.lib.eachDefaultSystem (system:
-      let
-        # TODO Use pkgsStatic if on linux
-        pkgs = nixpkgs.legacyPackages.${system};
-        on = opam-nix.lib.${system};
-        pythonPackages = pkgs.python310Packages;
-        opamRepos = [ "${opam-repository}" ];
-        lib = pkgs.lib;
-        isDarwin = lib.strings.hasSuffix "darwin" system;
-        hasSubmodules = !builtins.hasAttr "submodules" self || self.submodules;
-        # TODO split out osemgrep and pysemgrep into diff nix files
-      in let
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    opam-nix,
+    opam-repository,
+    memprof-limits,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      on = opam-nix.lib.${system};
+      pythonPackages = pkgs.python311Packages;
+      opamRepos = [
+        (opam-nix.lib.${system}.makeOpamRepo memprof-limits)
+        opam-repository
+      ];
+      lib = pkgs.lib;
+      isDarwin = lib.strings.hasSuffix "darwin" system;
+    in let
+      # opengrep inputs
+      devOpamPackagesQuery = {
+        # You can add "development" ocaml packages here. They will get added to the devShell automatically.
+        ocaml-lsp-server = "*";
+        utop = "*";
+        ocamlformat = "*";
+        earlybird = "*";
+        merlin = "*";
+      };
+      opamQuery =
+        devOpamPackagesQuery
+        // {
+          # You can force versions of certain packages here
+          ocaml-base-compiler = "5.3.0";
+          mirage-runtime = "4.9.0";
 
-        # osemgrep/semgrep-core inputs
-        osemgrepInputs = with pkgs; [ pcre2 tree-sitter ];
-        devOpamPackagesQuery = {
-          # You can add "development" ocaml packages here. They will get added
-          # to the devShell automatically.
-          ocaml-lsp-server = "*";
-          utop = "*";
-          ocamlformat = "*";
-          earlybird = "*";
-          merlin = "*";
-        };
-        opamQuery = devOpamPackagesQuery // {
-          ## You can force versions of certain packages here
-          # force the ocaml compiler to be 4.14.2 and from opam
-          ocaml-base-compiler = "4.14.2";
-          #TODO: needed for semgrep pro, should be in ../flake.nix instead
-          #coupling: if you add one thing here, need to update also the
-          # buildInputs overlay below
-          junit_alcotest = "*";
+          # coupling: if you add one thing here, need to update also the buildInputs overlay below
           git-unix = "*";
-          mirage-runtime = "4.4.2";
+          junit_alcotest = "*";
           notty = "*";
           tsort = "*";
-          # needed for tests
           tyxml = "*";
         };
 
-        # repos = opamRepos to force newest version of opam
-        # pkgs = pkgs to force newest version of nixpkgs instead of using opam-nix's
-        scope = on.buildOpamProject' {
-          pkgs = pkgs;
-          repos = opamRepos;
-        } ./. opamQuery;
-        scopeOverlay = final: prev: {
-          # You can add overrides here
-          conf-pkg-config = prev.conf-pkg-config.overrideAttrs (prev: {
-            # We need to add the pkg-config path to the PATH so that dune can find it
-            nativeBuildInputs = prev.nativeBuildInputs ++ [ pkgs.pkg-config ];
-          });
-          ${package} = prev.${package}.overrideAttrs (prev: {
-            # Prevent the ocaml dependencies from leaking into dependent environments
-            doNixSupport = false;
-            buildInputs = prev.buildInputs ++ [
-              final.tsort
-              final.notty
-              final.tyxml
+      scope =
+        on.buildOpamProject' {
+          pkgs = pkgs; # to force newest version of nixpkgs instead of using opam-nix's
+          repos = opamRepos; # to force newest version of opam
+        }
+        ./.
+        opamQuery;
+      scopeOverlay = final: prev: {
+        # You can add overrides here
+        conf-pkg-config = prev.conf-pkg-config.overrideAttrs (prev: {
+          # We need to add the pkg-config path to the PATH so that dune can find it
+          nativeBuildInputs = prev.nativeBuildInputs ++ [pkgs.pkg-config];
+        });
+        semgrep = prev.semgrep.overrideAttrs (prev: {
+          # Prevent the ocaml dependencies from leaking into dependent environments
+          doNixSupport = false;
+          buildInputs =
+            prev.buildInputs
+            ++ [
               final.git-unix
               final.junit_alcotest
+              final.notty
+              final.tsort
+              final.tyxml
             ];
-          });
-        };
-        scope' = scope.overrideScope scopeOverlay;
-
-        # for development
-        devOpamPackages = builtins.attrValues
-          (pkgs.lib.getAttrs (builtins.attrNames devOpamPackagesQuery) scope');
-
-        # osemgrep/semgrep-core
-        # package with all opam deps but nothing else
-        baseOpamPackage = scope'.${package}; # Packages from devPackagesQuery
-
-        # Special environment variables for osemgrep for linking stuff
-        osemgrepEnvDarwin = {
-          # all the dune files of semgrep treesitter <LANG> are missing the
-          # :standard field. Basically all compilers autodetct if something is c
-          # or c++ based on file extension, and add the c stdlib based on that.
-          # Nix doesn't because reasons:
-          # https://github.com/NixOS/nixpkgs/issues/150655 Dune also passes
-          # -xc++ if it detects a c++ file (again sane), but it's included in
-          # the :standard var, which we don't add because ??? TODO add and
-          # commit them instead of doing this
-          NIX_CFLAGS_COMPILE = "-I${pkgs.libcxx.dev}/include/c++/v1";
-        };
-        osemgrepEnv = {
-          SEMGREP_NIX_BUILD = "1";
-        } // lib.optionalAttrs (isDarwin) osemgrepEnvDarwin;
-        #
-        # osemgrep
-        #
-
-        osemgrep = baseOpamPackage.overrideAttrs (prev: rec {
-          pname = "osemgrep";
-          env = osemgrepEnv;
-          buildInputs = prev.buildInputs ++ osemgrepInputs;
-          buildPhase' = ''
-            make core
-          '';
-          buildPhaseFail = ''
-            echo "Derivation ${pname} won't build outside of a nix shell without submodules:"
-            echo "  nix build '.?submodules=1#' # build from local sources"
-            echo "  nix build '<uri>?submodules=1#' # build from remote sources"
-            echo "  nix run '.?submodules=1#osemgrep' # run osemgrep from local sources"
-            echo "  nix run '<uri>.?submodules=1#osemgrep' # run osemgrep from remote source"
-            exit 1
-          '';
-          # make sure we have submodules
-          # See https://github.com/NixOS/nix/pull/7862
-          buildPhase = if hasSubmodules then
-            osemgrep.buildPhase'
-          else
-            osemgrep.buildPhaseFail;
-          nativeCheckInputs = (with pkgs; [ cacert git ]);
-          # git init is needed so tests work successfully since many rely on git root existing
-          checkPhase = ''
-            git init
-            make test
-          '';
-
-          # DONE! Copy semgrep binaries!!!!
-          installPhase = ''
-            mkdir -p $out/bin
-            cp _build/install/default/bin/* $out/bin
-          '';
-
         });
+      };
+      scope' = scope.overrideScope scopeOverlay;
 
-        # TODO semgrep-js
-        # needs new emscripten: https://github.com/NixOS/nixpkgs/issues/306649
-        # for the special wasm pass
+      # Packages for development
+      devOpamPackages =
+        builtins.attrValues
+        (pkgs.lib.getAttrs (builtins.attrNames devOpamPackagesQuery) scope');
 
-        # pysemgrep inputs
-        # coupling: anything added to pysemgrep for testing should be added here
-        devPipInputs = with pythonPackages; [
-          pkgs.git
-          flaky
-          pytest-snapshot
-          pytest-mock
-          pytest-freezegun
-          types-freezegun
-        ];
+      # Package with all opam deps but nothing else
+      baseOpamPackage = scope'.semgrep;
 
-        #
-        # pysemgrep
-        #
+      # Special environment variables for linking
+      opengrepEnvDarwin = {
+        # all the dune files of semgrep treesitter <LANG> are missing the
+        # :standard field. Basically all compilers autodetct if something is c
+        # or c++ based on file extension, and add the c stdlib based on that.
+        # Nix doesn't because reasons:
+        # https://github.com/NixOS/nixpkgs/issues/150655 Dune also passes
+        # -xc++ if it detects a c++ file (again sane), but it's included in
+        # the :standard var, which we don't add because ??? TODO add and
+        # commit them instead of doing this
+        NIX_CFLAGS_COMPILE = "-I${pkgs.libcxx.dev}/include/c++/v1";
+      };
+      opengrepEnv =
+        {
+          SEMGREP_NIX_BUILD = "1";
+        }
+        // lib.optionalAttrs isDarwin opengrepEnvDarwin;
 
-        pysemgrep = with pythonPackages;
-          buildPythonApplication {
-            # thanks to @06kellyjac
-            pname = "semgrep";
-            inherit (osemgrep) version;
-            src = ./cli;
-            # TODO checks
-            doCheck = false;
+      #
+      # opengrep
+      #
 
-            # coupling: anything added to the pysemgrep setup.py should be added here
-            propagatedBuildInputs = [
-              attrs
-              boltons
-              colorama
-              click
-              click-option-group
-              glom
-              requests
-              rich
-              ruamel-yaml
-              tqdm
-              packaging
-              jsonschema
-              wcmatch
-              peewee
-              defusedxml
-              urllib3
-              typing-extensions
-              tomli
-            ];
-            # doesn't work for some reason
-            dontUseSetuptoolsShellHook = true;
+      opengrep = baseOpamPackage.overrideAttrs (prev: {
+        pname = "opengrep";
+        env = opengrepEnv;
 
-            preFixup = ''
-              makeWrapperArgs+=(--prefix PATH : ${osemgrep}/bin)
-            '';
-          };
-        # TODO semgrep-js
-      in {
-        # For a lot of nix commands, nix uses the cwd's flake. So
-        #   nix develop
-        # will run the current flake. But because semgrep has submodules we have
-        # to specify `.?submodules=1#` to enable checking out submodules`
-        #
-        # The target of the command is structured
-        # `<FLAKE_LOCATION>(?OPTIONAL_PARAMS)#<TARGET>` so you can run
-        #   nix run nixpkgs#gcc
-        # to run gcc from the default nix repository nixpkgs.
-        #
-        # But the location is similar to a url! So you can run
-        #   nix run github:DeterminateSystems/flake-checker
-        # to run DeterminateSystem's
-        # cool flake checker, without ever needing to install it or anything! Or
-        # other nix users who want to try osemgrep can run
-        #   nix run github:semgrep/semgrep?submodules=1#osemgrep
-        #
-        # See: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#types
-        # for more on flake refs
-        #
-        # See: https://nixos.org/manual/nix/stable/command-ref/experimental-commands
-        # for other useful commands
+        buildInputs =
+          prev.buildInputs
+          ++ (with pkgs; [
+            pcre2
+            tree-sitter
+          ]);
+        buildPhase = ''
+          make core
+        '';
 
-        #   nix build ".?submodules=1#<PKG_NAME>"
-        # builds the below package leaving it empty builds the default. The
-        # output will be linked into the cwd in a folder called "result". Also
-        # exports packages for other nix packages to use
-        packages.osemgrep = osemgrep;
-        packages.semgrep = pysemgrep;
-        packages.default = pysemgrep;
+        nativeCheckInputs = with pkgs; [cacert git];
+        # git init is needed so tests work successfully since many rely on git root existing
+        checkPhase = ''
+          git init
+          make test
+        '';
 
-        #   nix run ".?submodules=1#<PKG_NAME>"
-        # builds and runs the package specified, without linking the output
-        # result into the cwd. You can try other nixpkgs similarly by running
-        # `nix run nixpkgs#<PKG_NAME>` like `nix run nixpkgs#hello_world`.
-        apps = {
-          osemgrep = {
-            type = "app";
-            program = "${osemgrep}/bin/osemgrep";
-          };
-          semgrep-core = {
-            type = "app";
-            program = "${osemgrep}/bin/semgrep-core";
-          };
-          semgrep = {
-            type = "app";
-            program = "${pysemgrep}/bin/semgrep";
-          };
-          pysemgrep = {
-            type = "app";
-            program = "${pysemgrep}/bin/pysemgrep";
-          };
-          default = {
-            type = "app";
-            program = "${pysemgrep}/bin/semgrep";
-          };
+        # Copy opengrep binaries
+        installPhase = ''
+          mkdir -p $out/bin
+          cp _build/install/default/bin/* $out/bin
+        '';
+      });
+
+      # pyopengrep inputs
+      # coupling: anything added for testing should be added here
+      devPipInputs = with pythonPackages; [
+        pkgs.git
+        flaky
+        pytest-snapshot
+        pytest-mock
+        pytest-freezegun
+        types-freezegun
+      ];
+
+      #
+      # pyopengrep
+      #
+
+      pyopengrep = with pythonPackages;
+        buildPythonApplication {
+          pname = "pyopengrep";
+          inherit (opengrep) version;
+          src = ./cli;
+
+          pyproject = true;
+          build-system = [setuptools];
+
+          pythonRelaxDeps = [
+            "boltons"
+            "defusedxml"
+            "exceptiongroup"
+            "glom"
+            "rich"
+            "tomli"
+            "wcmatch"
+          ];
+
+          # coupling: anything added to the pysemgrep setup.py should be added here
+          propagatedBuildInputs = [
+            attrs
+            boltons
+            click
+            click-option-group
+            colorama
+            defusedxml
+            exceptiongroup
+            glom
+            jsonschema
+            packaging
+            peewee
+            requests
+            rich
+            ruamel-yaml
+            tomli
+            tqdm
+            typing-extensions
+            urllib3
+            wcmatch
+            protobuf
+            jaraco-text
+          ];
+
+          preFixup = ''
+            makeWrapperArgs+=(--prefix PATH : ${opengrep}/bin)
+          '';
         };
-        #   nix flake check ".?submodules=1#"
-        # makes sure the flake is a valid structure, all the derivations are
-        # valid, and runs anyting put in checks
-        checks = {
-          osemgrep = osemgrep.overrideAttrs (prev: {
-            # We don't want to force people to run the test suite everytime they
-            # build semgrep, but we do want to run it here
-            doCheck = true;
-          });
-        };
+    in {
+      # For a lot of nix commands, nix uses the cwd's flake. So
+      #   nix develop
+      # will run the current flake.
+      #
+      # The target of the command is structured
+      # `<FLAKE_LOCATION>(?OPTIONAL_PARAMS)#<TARGET>` so you can run
+      #   nix run nixpkgs#gcc
+      # to run gcc from the default nix repository nixpkgs.
+      #
+      # But the location is similar to a url! So you can run
+      #   nix run github:DeterminateSystems/flake-checker
+      # to run DeterminateSystem's
+      # cool flake checker, without ever needing to install it or anything! Or
+      # other nix users who want to try opengrep can run
+      #   nix run github:opengrep/opengrep
+      #
+      # See: https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake.html#types
+      # for more on flake refs
+      #
+      # See: https://nixos.org/manual/nix/stable/command-ref/experimental-commands
+      # for other useful commands
 
-        #   nix fmt
-        # formats this file. In the future we can add ocaml, python, and other
-        # formatters here to run also
-        formatter = pkgs.nixpkgs-fmt;
-        #   nix develop -c $SHELL
-        # runs this shell which has all dependencies needed to make semgrep
-        devShells.default = pkgs.mkShell {
-          # See comment above osemgrep.buildPhase for why we need this
-          # This doesnt work there because idk
-          env = {
+      #   nix build ".#<PKG_NAME>"
+      # builds the below package, leaving it empty builds the default. The
+      # output will be linked into the cwd in a folder called "result". Also
+      # exports packages for other nix packages to use
+      packages = {
+        opengrep = opengrep;
+        pyopengrep = pyopengrep;
+        default = pyopengrep;
+      };
+
+      #   nix run ".#<PKG_NAME>"
+      # builds and runs the package specified, without linking the output
+      # result into the cwd. You can try other nixpkgs similarly by running
+      # `nix run nixpkgs#<PKG_NAME>` like `nix run nixpkgs#hello_world`.
+      apps = {
+        opengrep = {
+          type = "app";
+          program = "${opengrep}/bin/opengrep";
+        };
+        pyopengrep = {
+          type = "app";
+          program = "${opengrep}/bin/pyopengrep";
+        };
+        default = {
+          type = "app";
+          program = "${opengrep}/bin/pyopengrep";
+        };
+      };
+
+      #   nix flake check
+      # makes sure the flake is a valid structure, all the derivations are
+      # valid, and runs anyting put in checks
+      checks = {
+        check-opengrep = opengrep.overrideAttrs (prev: {
+          # We don't want to force people to run the test suite everytime they
+          # build opengrep, but we do want to run it here
+          doCheck = true;
+        });
+      };
+
+      #   nix fmt
+      # formats this file. In the future we can add ocaml, python, and other
+      # formatters here to run also
+      formatter = pkgs.alejandra;
+
+      #   nix develop -c $SHELL
+      # runs this shell which has all dependencies needed to make opengrep
+      devShells.default = pkgs.mkShell {
+        env =
+          {
             # add env vars here
-          } // osemgrepEnv;
-          inputsFrom = [ osemgrep pysemgrep ];
-          buildInputs = devOpamPackages ++ devPipInputs ++ (with pkgs; [
+          }
+          // opengrepEnv;
+        inputsFrom = [opengrep pyopengrep];
+        buildInputs =
+          devOpamPackages
+          ++ devPipInputs
+          ++ (with pkgs; [
             pre-commit
             pipenv
             yq-go # for GHA workflows
           ]);
-        };
-      });
+      };
+    });
 }

--- a/opam/process_limits.opam
+++ b/opam/process_limits.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml" {>= "5.3.0"}
   "dune" {>= "3.8" & >= "3.2.0"}
   "commons" {>= "1.5.5"}
-  "memprof-limits" {= "dev"}
+  "memprof-limits"
   "odoc" {with-doc}
 ]
 build: [
@@ -34,3 +34,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/opengrep/opengrep.git"
+pin-depends: [
+  ["memprof-limits.dev" "git+https://gitlab.com/dimitris-m/memprof-limits.git#c2cced325a93d2271379f0712db85867b29dbee1"]
+]

--- a/opam/process_limits.opam.template
+++ b/opam/process_limits.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["memprof-limits.dev" "git+https://gitlab.com/dimitris-m/memprof-limits.git#c2cced325a93d2271379f0712db85867b29dbee1"]
+]

--- a/opam/semgrep.opam
+++ b/opam/semgrep.opam
@@ -74,7 +74,7 @@ depends: [
   "conf-libev" {os != "win32"}
   "integers_stubs_js"
   "git-unix"
-  "memprof-limits" {= "dev"}
+  "memprof-limits"
   "thread-local-storage"
   "domainslib"
   "kcas_data"
@@ -95,3 +95,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/opengrep/opengrep.git"
+pin-depends: [
+  ["memprof-limits.dev" "git+https://gitlab.com/dimitris-m/memprof-limits.git#c2cced325a93d2271379f0712db85867b29dbee1"]
+]

--- a/opam/semgrep.opam.template
+++ b/opam/semgrep.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["memprof-limits.dev" "git+https://gitlab.com/dimitris-m/memprof-limits.git#c2cced325a93d2271379f0712db85867b29dbee1"]
+]

--- a/scripts/install-memprof-limits-dev.sh
+++ b/scripts/install-memprof-limits-dev.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-opam pin -y add memprof-limits.dev \
-    https://gitlab.com/dimitris-m/memprof-limits.git\#dm/ocaml-5.3.0-opengrep

--- a/scripts/workflow-build-inside-alpine-container.sh
+++ b/scripts/workflow-build-inside-alpine-container.sh
@@ -35,7 +35,6 @@ echo "Building in $(pwd)"
 if [ "$SHOULD_INIT_OPAM" = true ]; then
   opam init --yes --disable-sandboxing --root=$OPAMROOT --compiler=$OCAML_VERSION
   opam install dune
-  ./scripts/install-memprof-limits-dev.sh
   make install-opam-deps
 else
   echo "OPAM switch already exists, skipping creation: SHOULD_INIT_OPAM=$SHOULD_INIT_OPAM"


### PR DESCRIPTION
Currently, the nix flake is completely broken. This PR fixes it and cleans it up a bit.
- Bumped `ocaml-base-compiler` 4.14.2 -> 5.3.0
- Bumped `mirage-runtime` 4.4.2 -> 4.9.0
- Replaced `nixpkgs-fmt` -> `alejandra`
- Replaced most instances of semgrep with opengrep
- Removed all of the submodule warnings/errors, instead just set `self.submodules = true`

```zsh
> nix build
trace: [opam-nix] mirage-random: mirage-random is deprecated
> ls result/bin
opengrep  pyopengrep
```

Unfortunately, the biggest culprit is memprof-limits. I don't know of a way of getting opam-nix to work if memprof-limits depends on [install-memprof-limits-dev.sh](https://github.com/opengrep/opengrep/blob/main/scripts/install-memprof-limits-dev.sh) getting run first to create the pin. Instead, this PR creates opam.template files that pin memprof-limits to the equivalent hash using [pin-depends](https://ocaml.org/docs/managing-dependencies#adding-a-git-dependency-to-a-dune-project-file). If there is a better way of accomplishing this let me know.