### PR TITLE
Refactor: remove duplicate `metavar_string_of_any`

### DIFF
--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -595,7 +595,7 @@ let children_explanations_of_xpat (env : env) (xpat : Xpattern.t) : ME.t list =
                  in
                  let matches = match_result.matches in
                  (* TODO: equivalent to an abstract_content, so not great *)
-                 let pstr = Core_json_output.metavar_string_of_any pat in
+                 let pstr = Metavar_replacement.metavar_string_of_any pat in
                  (* TODO: could use first_info_of_any pat, but not sure the
                   * tok position in pat are related to the rule of the intermediate
                   * file used to parse the pattern in xpat.pat.

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -18,6 +18,7 @@ open AST_generic
 module E = Core_error
 module J = JSON
 module MV = Metavariable
+module MR = Metavar_replacement
 module RP = Core_result
 module PM = Core_match
 open Core_match
@@ -184,19 +185,6 @@ let dedup_and_sort (xs : Out.core_match list) : Out.core_match list =
 (* Converters *)
 (*****************************************************************************)
 
-let metavar_string_of_any any =
-  (* TODO: metavar_string_of_any is used in get_propagated_value
-      to get the string for propagated values. Not all propagated
-      values will have origintoks. For example, in
-          x = 1; y = x + 1; ...
-     we have y = 2 but there is no source location for 2.
-     Handle such cases *)
-  any |> AST_generic_helpers.ii_of_any
-  |> List.filter Tok.is_origintok
-  |> List.sort_uniq Tok.compare_pos
-  |> List_.map Tok.content_of_tok
-  |> Core_text_output.join_with_space_if_needed
-
 let get_propagated_value default_start mvalue =
   let any_to_svalue_value any =
     match range_of_any_opt default_start any with
@@ -206,7 +194,7 @@ let get_propagated_value default_start mvalue =
             {
               svalue_start = Some start;
               svalue_end = Some end_;
-              svalue_abstract_content = metavar_string_of_any any;
+              svalue_abstract_content = MR.metavar_string_of_any any;
             }
     | None ->
         Some
@@ -214,7 +202,7 @@ let get_propagated_value default_start mvalue =
             {
               svalue_start = None;
               svalue_end = None;
-              svalue_abstract_content = metavar_string_of_any any;
+              svalue_abstract_content = MR.metavar_string_of_any any;
             }
   in
   match mvalue with
@@ -243,7 +231,7 @@ let metavars startp_of_match_range (s, mval) =
           {
             start = startp;
             end_ = endp;
-            abstract_content = metavar_string_of_any any;
+            abstract_content = MR.metavar_string_of_any any;
             propagated_value = get_propagated_value startp_of_match_range any;
           } )
 

--- a/src/reporting/Core_json_output.mli
+++ b/src/reporting/Core_json_output.mli
@@ -9,11 +9,6 @@ val core_output_of_matches_and_errors : ?inline:bool -> Core_result.t -> Out.cor
 val match_to_match :
  ?inline:bool -> Core_result.processed_match -> (Out.core_match, Core_error.t) result
 
-(* for abstract_content and subpatterns matching-explanations
- * TODO: should not use! the result may miss some commas
- *)
-val metavar_string_of_any : AST_generic.any -> string
-
 (* now used also in osemgrep *)
 val error_to_error : Core_error.t -> Out.core_error
 val dedup_and_sort : Out.core_match list -> Out.core_match list

--- a/src/reporting/Metavar_replacement.ml
+++ b/src/reporting/Metavar_replacement.ml
@@ -32,7 +32,7 @@ let metavar_string_of_any any =
      Handle such cases *)
   any |> AST_generic_helpers.ii_of_any
   |> List.filter Tok.is_origintok
-  |> List.sort Tok.compare_pos
+  |> List.sort_uniq Tok.compare_pos
   |> List_.map Tok.content_of_tok
   |> Core_text_output.join_with_space_if_needed
 

--- a/src/reporting/Metavar_replacement.mli
+++ b/src/reporting/Metavar_replacement.mli
@@ -1,5 +1,10 @@
 type replacement_ctx
 
+(* for abstract_content and subpatterns matching-explanations
+ * TODO: should not use! the result may miss some commas
+ *)
+val metavar_string_of_any : AST_generic.any -> string
+
 val of_bindings : Metavariable.bindings -> replacement_ctx
 val of_out : Semgrep_output_v1_t.metavars -> replacement_ctx
 val interpolate_metavars : string -> replacement_ctx -> string


### PR DESCRIPTION
This function was copy-pasted in 2 places, now we kept one definition.