### PR TITLE
Fix: ensure we fallback to python for `ci`

### DIFF
--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -83,6 +83,7 @@ let hook_semgrep_interactive =
  *)
 let known_subcommands =
   [
+    "ci";
     "lsp";
     "scan";
     (* osemgrep-only *)


### PR DESCRIPTION
We must keep `"ci"` in the known subcommands for fallback to happen, else it tries to execute `scan` by default.