### PR TITLE
Elixir: add `defp` private functions

### DIFF
--- a/languages/elixir/ast/AST_elixir.ml
+++ b/languages/elixir/ast/AST_elixir.ml
@@ -325,6 +325,7 @@ and function_definition = {
   f_params : parameters;
   (* bracket is do/end *)
   f_body : stmts bracket;
+  f_is_private : bool;
 }
 
 and parameters = parameter list bracket

--- a/languages/elixir/ast/Elixir_to_elixir.ml
+++ b/languages/elixir/ast/Elixir_to_elixir.ml
@@ -75,7 +75,7 @@ class ['self] visitor =
       (* https://hexdocs.pm/elixir/Kernel.html#def/2
        * TODO: handle "implicit try" form
        *)
-      | ( I (Id ("def", tdef)),
+      | ( I (Id (( "def" | "defp" ) as def_str, tdef)),
           (_, ([ Call (I ident, args, None) ], []), _),
           Some (tdo, (Body body, []), tend) ) ->
           let body = self#visit_body env body in
@@ -86,6 +86,7 @@ class ['self] visitor =
               f_name = ident;
               f_params = params;
               f_body = (tdo, body, tend);
+              f_is_private = String.equal def_str "defp";
             }
           in
           S (D (FuncDef def))

--- a/languages/elixir/generic/Elixir_to_generic.ml
+++ b/languages/elixir/generic/Elixir_to_generic.ml
@@ -317,9 +317,14 @@ and map_stmt env (v : stmt) : G.stmt =
 
 and map_definition env (v : definition) : G.definition =
   match v with
-  | FuncDef { f_def; f_name; f_params; f_body } ->
+  | FuncDef { f_def; f_name; f_params; f_body; f_is_private } ->
       let id = map_ident_should_not_use env f_name in
-      let ent = G.basic_entity id in
+      let ent = G.basic_entity
+          ~attrs:(if f_is_private
+                  then [G.KeywordAttr (G.Private, Tok.fake_tok f_def "" (* vs. [G.fake ""] *))]
+                  else [])
+          id
+      in
       let fparams = map_parameters env f_params in
       let body = map_compound env f_body in
       let def =

--- a/tests/parsing/elixir/defp.ex
+++ b/tests/parsing/elixir/defp.ex
@@ -1,0 +1,4 @@
+defp sum(a, b) do
+    a + b
+end
+

--- a/tests/patterns/elixir/dots_params_private.ex
+++ b/tests/patterns/elixir/dots_params_private.ex
@@ -1,7 +1,8 @@
+
 defmodule MyAppWeb.UserController do
   use MyAppWeb, :controller
 
-  #ERROR: match
+  # This will not be matched by a "defp" pattern.
   def show(conn, %{"id" => id}) do
     user = Repo.get(User, id)
     render(conn, :show, user: user)

--- a/tests/patterns/elixir/dots_params_private.sgrep
+++ b/tests/patterns/elixir/dots_params_private.sgrep
@@ -1,0 +1,3 @@
+defp $VAL(...) do
+   ...
+end


### PR DESCRIPTION
Note that a `defp` pattern only matches `defp`, but a `def` pattern matches `def` or `defp`. 
This is implemented by adding a private attribute similarly to other languages.

Closes #343.