### PR TITLE
feat: release opengrep-core

### DIFF
--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -107,6 +107,9 @@ jobs:
           tar xzf ./opengrep-osx-arm64/artifacts.tgz --strip=1
           tar czf opengrep-core_osx_aarch64.tar.gz opengrep-core
 
+          tar xzf ./opengrep-core-and-dependent-libs-w64-artifact/artifacts.tgz
+          zip -r -j opengrep-core_windows_x86.zip artifacts
+
           unzip -j ./manylinux-x86-wheel/dist.zip "*.whl"
           unzip -j ./osx-arm64-wheel/dist.zip "*.whl"
 
@@ -174,6 +177,7 @@ jobs:
             artifacts/opengrep-core_linux_aarch64.tar.gz
             artifacts/opengrep-core_osx_x86.tar.gz
             artifacts/opengrep-core_osx_aarch64.tar.gz
+            artifacts/opengrep-core_windows_x86.zip
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86.cert
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86.sig

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -95,6 +95,11 @@ jobs:
         run: |
           pushd artifacts/
 
+          mv ./opengrep-core-x86/artifacts.tgz opengrep-core_linux_x86.tar.gz
+          mv ./opengrep-core-aarch64/artifacts.tgz opengrep-core_linux_aarch64.tar.gz
+          mv ./opengrep-osx-x86/artifacts.tgz opengrep-core_osx_x86.tar.gz
+          mv ./opengrep-osx-arm64/artifacts.tgz opengrep-core_osx_aarch64.tar.gz
+
           unzip -j ./manylinux-x86-wheel/dist.zip "*.whl"
           unzip -j ./osx-arm64-wheel/dist.zip "*.whl"
 
@@ -158,6 +163,10 @@ jobs:
           prerelease: true
           generate_release_notes: true
           files: |
+            artifacts/opengrep-core_linux_x86.tar.gz
+            artifacts/opengrep-core_linux_aarch64.tar.gz
+            artifacts/opengrep-core_osx_x86.tar.gz
+            artifacts/opengrep-core_osx_aarch64.tar.gz
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86.cert
             artifacts/opengrep_manylinux_binary_x86_64/opengrep_manylinux_x86.sig

--- a/.github/workflows/rolling-release.yml
+++ b/.github/workflows/rolling-release.yml
@@ -95,10 +95,17 @@ jobs:
         run: |
           pushd artifacts/
 
-          mv ./opengrep-core-x86/artifacts.tgz opengrep-core_linux_x86.tar.gz
-          mv ./opengrep-core-aarch64/artifacts.tgz opengrep-core_linux_aarch64.tar.gz
-          mv ./opengrep-osx-x86/artifacts.tgz opengrep-core_osx_x86.tar.gz
-          mv ./opengrep-osx-arm64/artifacts.tgz opengrep-core_osx_aarch64.tar.gz
+          tar xzf ./opengrep-core-x86/artifacts.tgz --strip=1
+          tar czf opengrep-core_linux_x86.tar.gz opengrep-core
+
+          tar xzf ./opengrep-core-aarch64/artifacts.tgz --strip=1
+          tar czf opengrep-core_linux_aarch64.tar.gz opengrep-core
+
+          tar xzf ./opengrep-osx-x86/artifacts.tgz --strip=1
+          tar czf opengrep-core_osx_x86.tar.gz opengrep-core
+
+          tar xzf ./opengrep-osx-arm64/artifacts.tgz --strip=1
+          tar czf opengrep-core_osx_aarch64.tar.gz opengrep-core
 
           unzip -j ./manylinux-x86-wheel/dist.zip "*.whl"
           unzip -j ./osx-arm64-wheel/dist.zip "*.whl"


### PR DESCRIPTION
closes #347

example of a successful release: https://github.com/spotdemo4/opengrep/releases/tag/v1.6.0