### PR TITLE
remove metrics in the bench command

### DIFF
--- a/perf/opengrep-scripts/bench.py
+++ b/perf/opengrep-scripts/bench.py
@@ -32,7 +32,6 @@ def regular_cmd(repo):
             "-j", num_cpus,
             "--timeout", "0",
             "--max-memory", "4000",
-            "--metrics", "off",
             "--max-target-bytes", "200000",
             "--quiet"]
 


### PR DESCRIPTION
the bench.py script needs to be updated to remove the --metrics option