### PR TITLE
For variables, calculate the range in the `extra` section using the original token

### DIFF
--- a/src/reporting/Metavar_replacement.ml
+++ b/src/reporting/Metavar_replacement.ml
@@ -30,11 +30,18 @@ let metavar_string_of_any any =
           x = 1; y = x + 1; ...
      we have y = 2 but there is no source location for 2.
      Handle such cases *)
-  any |> AST_generic_helpers.ii_of_any
-  |> List.filter Tok.is_origintok
-  |> List.sort_uniq Tok.compare_pos
-  |> List_.map Tok.content_of_tok
-  |> Core_text_output.join_with_space_if_needed
+  (* FIXME: If the match is a variable, extract the variable, not the
+     propagated value / definition assigned by name resolution. This is a
+     temporary fix for the nondeterministic behaviour bug (issue #335) *)
+  match any with
+  | G.E { e_range = Some (l1, l2); _ } when Int.equal l1.pos.bytepos l2.pos.bytepos ->
+      l1.str
+  | _ ->
+      any |> AST_generic_helpers.ii_of_any
+      |> List.filter Tok.is_origintok
+      |> List.sort Tok.compare_pos
+      |> List_.map Tok.content_of_tok
+      |> Core_text_output.join_with_space_if_needed
 
 let propagated_value_string_of_mval mval =
   let any = MV.mvalue_to_any mval in


### PR DESCRIPTION
Back to #335:

In the example provided in #335 by @aayachnes, we could observe non-deterministically `MessageDigest` or `MessageDigest MessageDigest MessageDigest` as the abstract content of the metavariable.

The reason why we saw the triple token was that constant propagation (or maybe name resolution?) was linking the occurrence of the matched variable with the import

```
java.security.MessageDigest
```

and tried to print it as the value of the metavariable.

For some reason, however, the identifier `java.security.MessageDigest` is treated as `DotAccess`, in which each segment is given the token of the occurrence of the variable (**!!!**), hence it is printed out as triple `MessageDigest` (dots in between become fake tokens, because `DottedIdentifier` does not hold dot tokens, while `DotAccess` does, for some weird reason).

This PR does not solve the nondet problem (sometimes the constant propagation does not seem to link to the import, but it is not clear why).