### PR TITLE
Expose --max-match-per-file

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -30,6 +30,7 @@ from semgrep.app.scans import ScanHandler
 from semgrep.commands.scan import collect_additional_outputs
 from semgrep.commands.scan import scan_options
 from semgrep.commands.wrapper import handle_command_errors
+from semgrep.constants import DEFAULT_MAX_MATCH_PER_FILE
 from semgrep.console import console
 from semgrep.console import Title
 from semgrep.constants import OutputFormat
@@ -272,7 +273,8 @@ def ci(
     partial_output: Optional[Path],
     opengrep_ignore_pattern: Optional[str],
     bypass_includes_excludes_for_files: bool = True,
-    inline_metavariables: bool = False
+    inline_metavariables: bool = False,
+    max_match_per_file: Optional[int] = DEFAULT_MAX_MATCH_PER_FILE,
 ) -> None:
     state = get_state()
 
@@ -625,6 +627,7 @@ def ci(
         "no_git_ignore": (not use_git_ignore),
         "timeout": timeout,
         "max_memory": max_memory,
+        "max_match_per_file": max_match_per_file,
         "interfile_timeout": interfile_timeout,
         # "trace": trace,
         # "trace_endpoint": trace_endpoint,

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -33,6 +33,7 @@ from semgrep.constants import DEFAULT_MAX_LINES_PER_FINDING
 from semgrep.constants import DEFAULT_MAX_LOG_LIST_ENTRIES
 from semgrep.constants import DEFAULT_MAX_TARGET_SIZE
 from semgrep.constants import DEFAULT_TIMEOUT
+from semgrep.constants import DEFAULT_MAX_MATCH_PER_FILE
 from semgrep.constants import OutputFormat
 from semgrep.core_runner import CoreRunner
 from semgrep.engine import EngineType
@@ -183,6 +184,11 @@ _scan_options: List[Callable] = [
     optgroup.option(
         "--interfile-timeout",
         type=int,
+    ),
+    optgroup.option(
+        "--max-match-per-file",
+        type=int,
+        default=DEFAULT_MAX_MATCH_PER_FILE,
     ),
     optgroup.group("Display options"),
     optgroup.option(
@@ -594,7 +600,8 @@ def scan(
     allow_local_builds: bool,
     opengrep_ignore_pattern: Optional[str],
     bypass_includes_excludes_for_files: bool = True,
-    inline_metavariables: bool = False
+    inline_metavariables: bool = False,
+    max_match_per_file: Optional[int],
 ) -> Optional[Tuple[RuleMatchMap, List[SemgrepError], List[Rule], Set[Path]]]:
     if version:
         print(__VERSION__)
@@ -861,6 +868,7 @@ def scan(
                     opengrep_ignore_pattern=opengrep_ignore_pattern,
                     bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
                     inline_metavariables=inline_metavariables,
+                    max_match_per_file=max_match_per_file,
                 )
             except SemgrepError as e:
                 output_handler.handle_semgrep_errors([e])

--- a/cli/src/semgrep/constants.py
+++ b/cli/src/semgrep/constants.py
@@ -117,6 +117,9 @@ ELLIPSIS_STRING = " ... "
 # coupling: src/targeting/Find_targets.ml default_conf.max_target_bytes
 DEFAULT_MAX_TARGET_SIZE = 1000000  # 1 MB
 
+# Coupling: src/core_scan/Core_scan_config.ml
+DEFAULT_MAX_MATCH_PER_FILE = 10_000
+
 # Number of entries (rules, targets) beyond we're not logging anymore
 # coupling: with Output.ml
 DEFAULT_MAX_LOG_LIST_ENTRIES = 100

--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -790,6 +790,7 @@ class CoreRunner:
         opengrep_ignore_pattern: Optional[str],
         bypass_includes_excludes_for_files: bool = True,
         inline_metavariables: bool = False,
+        max_match_per_file: Optional[int] = None,
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
         state = get_state()
         logger.debug(f"Passing whole rules directly to semgrep_core")
@@ -928,6 +929,8 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                     str(self._max_memory),
                 ]
             )
+            if max_match_per_file is not None:
+                cmd.extend(["-max_match_per_file", str(max_match_per_file)])
             if matching_explanations:
                 cmd.append("-matching_explanations")
             if time_flag:
@@ -1109,6 +1112,7 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
         opengrep_ignore_pattern: Optional[str] = None,
         bypass_includes_excludes_for_files: bool = True,
         inline_metavariables: bool = False,
+        max_match_per_file: Optional[int] = None,
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
         """
         Sometimes we may run into synchronicity issues with the latest DeepSemgrep binary.
@@ -1134,6 +1138,7 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                 opengrep_ignore_pattern=opengrep_ignore_pattern,
                 bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
                 inline_metavariables=inline_metavariables,
+                max_match_per_file=max_match_per_file,
             )
         except SemgrepError as e:
             # Handle Semgrep errors normally
@@ -1177,6 +1182,7 @@ Exception raised: `{e}`
         opengrep_ignore_pattern: Optional[str] = None,
         bypass_includes_excludes_for_files: bool = True,
         inline_metavariables: bool = False,
+        max_match_per_file: Optional[int] = None,
     ) -> Tuple[RuleMatchMap, List[SemgrepError], OutputExtra,]:
         """
         Takes in rules and targets and returns object with findings
@@ -1202,6 +1208,7 @@ Exception raised: `{e}`
             opengrep_ignore_pattern=opengrep_ignore_pattern,
             bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
             inline_metavariables = inline_metavariables,
+            max_match_per_file=max_match_per_file,
         )
 
         logger.debug(

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -263,6 +263,7 @@ def run_rules(
     opengrep_ignore_pattern: Optional[str] = None,
     bypass_includes_excludes_for_files: bool = True,
     inline_metavariables: bool = False,
+    max_match_per_file: Optional[int] = None,
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -364,6 +365,7 @@ def run_rules(
         opengrep_ignore_pattern=opengrep_ignore_pattern,
         bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
         inline_metavariables=inline_metavariables,
+        max_match_per_file=max_match_per_file,
     )
 
     if join_rules:
@@ -548,6 +550,7 @@ def run_scan(
     opengrep_ignore_pattern: Optional[str] = None,
     bypass_includes_excludes_for_files: bool = True,
     inline_metavariables: bool = False,
+    max_match_per_file: Optional[int] = None,
 ) -> Tuple[
     RuleMatchMap,
     List[SemgrepError],
@@ -826,6 +829,7 @@ def run_scan(
         opengrep_ignore_pattern=opengrep_ignore_pattern,
         bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
         inline_metavariables=inline_metavariables,
+        max_match_per_file=max_match_per_file,
     )
     profiler.save("core_time", core_start_time)
     semgrep_errors: List[SemgrepError] = config_errors + scan_errors

--- a/src/core_scan/Core_scan_config.ml
+++ b/src/core_scan/Core_scan_config.ml
@@ -62,8 +62,7 @@ type t = {
    *)
   respect_rule_paths : bool;
   (* Hook to display match results incrementally, after a file has been fully
-   * processed. Note that this hook run in a child process of Parmap
-   * in Core_scan.scan(), so the hook should not rely on shared memory!
+   * processed.
    * This is also now used in Runner_service.ml and Git_remote.ml.
    *)
   file_match_hook : (Fpath.t -> Core_result.matches_single_file -> unit) option;

--- a/src/main/Main.ml
+++ b/src/main/Main.ml
@@ -145,7 +145,7 @@ let () =
        * This happens if the experimental flag is not passed. *)
       (* opengrep-cli a.k.a. osemgrep *)
       | "opengrep-cli"
-      (* in the long term (and in the short term on windows) we want to ship
+      (* In the long term (and in the short term on windows) we want to ship
        * opengrep-cli as the default "opengrep" binary, without any
        * wrapper script such as cli/bin/semgrep around it.
        *)

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -180,8 +180,8 @@ let o_inline_metavariables : bool Term.t =
   let info =
     Arg.info ["inline-metavariables"]
       ~doc:
-        {|Inlines metavarible references in metadata strings the same way it is done in message. 
-          This can be costly so use with care especially if the metadata is very deep.|}
+        {|Inlines metavariable references in metadata strings the same way it is done in the message.
+This can be costly so use with care especially if the metadata is very deep.|}
   in  
   Arg.value (Arg.flag info)
 

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -335,6 +335,18 @@ defaults to 5000 MiB.
   in
   Arg.value (Arg.opt Arg.int default info)
 
+let o_max_match_per_file : int Term.t =
+  let default = default.core_runner_conf.max_match_per_file in
+  let info =
+    Arg.info [ "max-match-per-file" ]
+      ~doc:
+        {|Maximum number of matches to report per file. Defaults to 10000. If the
+number of matches exceeds this limit, matches beyond this limit are discarded. The
+kept matches are chosen based on the order in which they are found in the file.
+|}
+  in
+  Arg.value (Arg.opt Arg.int default info)
+
 let o_optimizations : bool Term.t =
   let parse = function
     | "all" -> Ok true
@@ -1328,7 +1340,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       gitlab_sast gitlab_sast_outputs gitlab_secrets gitlab_secrets_outputs
       _historical_secrets include_ incremental_output incremental_output_postprocess
       json json_outputs junit_xml junit_xml_outputs lang matching_explanations max_chars_per_line
-      max_lines_per_finding max_log_list_entries max_memory_mb max_target_bytes
+      max_lines_per_finding max_log_list_entries max_match_per_file max_memory_mb max_target_bytes
       num_jobs no_secrets_validation nosem opengrep_ignore_pattern optimizations oss
       output output_enclosing_context pattern pro project_root pro_intrafile pro_lang
       pro_path_sensitive remote replacement rewrite_rule_ids sarif sarif_outputs
@@ -1424,6 +1436,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
         timeout;
         timeout_threshold;
         max_memory_mb;
+        max_match_per_file;
         dataflow_traces;
         nosem;
         strict;
@@ -1557,7 +1570,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     $ o_historical_secrets $ o_include $ o_incremental_output $ o_incremental_output_postprocess
     $ o_json $ o_json_outputs $ o_junit_xml $ o_junit_xml_outputs $ o_lang
     $ o_matching_explanations $ o_max_chars_per_line $ o_max_lines_per_finding
-    $ o_max_log_list_entries $ o_max_memory_mb $ o_max_target_bytes
+    $ o_max_log_list_entries $ o_max_match_per_file $ o_max_memory_mb $ o_max_target_bytes
     $ o_num_jobs $ o_no_secrets_validation $ o_nosem $ o_opengrep_ignore_pattern $ o_optimizations $ o_oss
     $ o_output $ o_output_enclosing_context $ o_pattern $ o_pro $ o_project_root $ o_pro_intrafile
     $ o_pro_languages $ o_pro_path_sensitive $ o_remote $ o_replacement

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -546,7 +546,12 @@ let check_targets_with_rules
           (* TOADAPT? Runner_exit.exit_semgrep (Unknown_exception e) instead *)
           Exception.reraise exn
       | Ok result ->
-          let (res : Core_runner.result) = Core_runner.mk_result ~inline:conf.core_runner_conf.inline_metavariables rules result in
+          let (res : Core_runner.result) =
+            Core_runner.mk_result
+              ~inline:conf.core_runner_conf.inline_metavariables
+              rules
+              result
+          in
           (* step 3'': adjust the matches, filter via nosemgrep and part1 autofix *)
           let keep_ignored =
             (not conf.core_runner_conf.nosem)

--- a/src/osemgrep/cli_scan/Test_scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Test_scan_subcommand.ml
@@ -86,6 +86,13 @@ public class A {
 }
 |}
 
+let three_findings_py_content = {|
+def foo(a, b):
+    f = a + b == a + b
+    g = a + b == a + b
+    return a + b == a + b
+|}
+
 let dummy_app_token = "FAKETESTINGAUTHTOKEN"
 
 (* coupling: subset of cli/tests/conftest.py ALWAYS_MASK *)
@@ -150,6 +157,25 @@ let test_basic_output_enclosing_context (caps : Scan_subcommand.caps) () =
                     "opengrep-scan"; "--experimental"; "--config"; "rules.yml";
                     "--output-enclosing-context";
                     "--json"
+                  |])
+          in
+          Exit_code.Check.ok exit_code))
+
+let test_basic_output_max_match (caps : Scan_subcommand.caps) () =
+  with_env_app_token (fun () ->
+      let repo_files =
+        [
+          F.File ("rules.yml", eqeq_basic_content);
+          F.File ("code.py", three_findings_py_content);
+        ]
+      in
+      Testutil_git.with_git_repo ~verbose:true repo_files (fun _cwd ->
+          let exit_code =
+            without_settings (fun () ->
+                Scan_subcommand.main caps
+                  [|
+                    "opengrep-scan"; "--experimental"; "--config"; "rules.yml";
+                    "--max-match-per-file"; "1"
                   |])
           in
           Exit_code.Check.ok exit_code))
@@ -277,4 +303,6 @@ let tests (caps : < Scan_subcommand.caps >) =
            ~rules_content:java_arg_paren_yaml_content
            ~code_file:"java_arg_paren.java"
            ~code_content:java_arg_paren_java_content);
+      t "basic output with --max-match-per-file" ~checked_output:(Testo.stdxxx ()) ~normalize
+        (test_basic_output_max_match caps);
     ]

--- a/src/osemgrep/core_runner/Core_runner.ml
+++ b/src/osemgrep/core_runner/Core_runner.ml
@@ -26,6 +26,7 @@ type conf = {
   num_jobs : int;
   optimizations : bool;
   max_memory_mb : int;
+  max_match_per_file : int;
   timeout : float;
   timeout_threshold : int; (* output flags *)
   (* features *)
@@ -111,6 +112,7 @@ let default_conf : conf =
     (* ^ seconds, keep up-to-date with User_settings.ml and constants.py *)
     timeout_threshold = 3;
     max_memory_mb = 0;
+    max_match_per_file = Core_scan_config.default.max_match_per_file;
     optimizations = true;
     dataflow_traces = false;
     matching_explanations = false;
@@ -350,6 +352,7 @@ let core_scan_config_of_conf (conf : conf) : Core_scan_config.t =
    timeout;
    timeout_threshold;
    max_memory_mb;
+   max_match_per_file;
    optimizations;
    matching_explanations;
    nosem = _TODO;
@@ -386,7 +389,7 @@ let core_scan_config_of_conf (conf : conf) : Core_scan_config.t =
          *)
         equivalences_file = None;
         respect_rule_paths = true;
-        max_match_per_file = Core_scan_config.default.max_match_per_file;
+        max_match_per_file;
       }
 
 (* output adapter to Core_scan.scan.

--- a/src/osemgrep/core_runner/Core_runner.mli
+++ b/src/osemgrep/core_runner/Core_runner.mli
@@ -10,6 +10,7 @@ type conf = {
   num_jobs : int;
   optimizations : bool;
   max_memory_mb : int;
+  max_match_per_file : int;
   timeout : float;
   timeout_threshold : int; (* output flags *)
   (* features *)

--- a/src/osemgrep/language_server/server/User_settings.ml
+++ b/src/osemgrep/language_server/server/User_settings.ml
@@ -30,6 +30,7 @@ type t = {
   include_ : string list; [@key "include"] [@default []]
   jobs : int; [@default Domainslib_.get_cpu_count()]
   max_memory : int; [@key "maxMemory"] [@default 0]
+  max_match_per_file : int; [@key "maxMatchPerFile"] [@default Core_scan_config.default.max_match_per_file]
   max_target_bytes : int; [@key "maxTargetBytes"] [@default 1000000]
   timeout : int; [@default 30]
   timeout_threshold : int; [@key "timeoutThreshold"] [@default 3]
@@ -67,6 +68,7 @@ let core_runner_conf_of_t settings : Core_runner.conf =
       num_jobs = settings.jobs;
       optimizations = true;
       max_memory_mb = settings.max_memory;
+      max_match_per_file = settings.max_match_per_file;
       timeout = float_of_int settings.timeout;
       timeout_threshold = settings.timeout_threshold;
       dataflow_traces = false;

--- a/src/osemgrep/language_server/server/User_settings.mli
+++ b/src/osemgrep/language_server/server/User_settings.mli
@@ -4,6 +4,7 @@ type t = {
   include_ : string list;
   jobs : int;
   max_memory : int;
+  max_match_per_file : int;
   max_target_bytes : int;
   timeout : int;
   timeout_threshold : int;

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -176,7 +176,7 @@ let dedup_and_sort (xs : Out.core_match list) : Out.core_match list =
      This is because we yet again need to enforce that when Pysemgrep receives these
      matches, that they are sorted via sort_core_matches.
      If we don't do this, then stuff like test_baseline will start breaking.
-     So we end up sorting twice. Such is life.
+     So we end up sorting twice.
      LATER: Can optimize if necessary
   *)
   Hashtbl.to_seq_values seen |> List.of_seq |> OutUtils.sort_core_matches

--- a/tests/snapshots/semgrep-core/d4fef67ae34d/name
+++ b/tests/snapshots/semgrep-core/d4fef67ae34d/name
@@ -1,0 +1,1 @@
+Osemgrep Scan (e2e) > basic output with --max-match-per-file

--- a/tests/snapshots/semgrep-core/d4fef67ae34d/stdxxx
+++ b/tests/snapshots/semgrep-core/d4fef67ae34d/stdxxx
@@ -1,0 +1,54 @@
+--- begin input files ---
+code.py
+rules.yml
+--- end input files ---
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'init' '-b' 'main'
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.name' 'Tester'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.email' 'tester@example.com'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'add' '.'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'commit' '-m' 'Add files'
+[main (root-commit) <MASKED>] Add files
+ 2 files changed, 13 insertions(+)
+ create mode 100644 code.py
+ create mode 100644 rules.yml
+
+┌──────────────┐
+│ Opengrep CLI │
+└──────────────┘
+
+[32m✔[39m [1mOpengrep OSS[0m
+  [32m✔[39m Basic security coverage for first-party code vulnerabilities.
+
+[1m  Loading rules from local config...[0m
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 2 files tracked by git with 1 Code rule:
+  Scanning 2 files.
+[<MASKED TIMESTAMP>][WARNING]: too many matches on code.py, generating exn for it
+[<MASKED TIMESTAMP>][WARNING]: most offending rule: id = eqeq-bad, matches = 3, pattern = $X == $X
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    code.py
+   ❯❯❱ eqeq-bad
+          useless comparison
+
+            3┆ f = a + b == a + b
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+Ran 1 rule on 1 file: 1 finding.
+ASSERT exit code


### PR DESCRIPTION
This exposes a hardcoded limit that already exists, where any file with more than 10,000 findings becomes an error.

- Now the limit is configurable.
- The behaviour has changed: we now keep findings up to that limit even when the limit is exceeded for a file, while continuing to create errors which can be useful for tooling. Previously all findings were thrown away.
- Note: now, for each file with more than the limit, we _will_ get findings. So if there are files with more than 10,000 findings we will get a lot more findings than before (10k per such file, instead of 0).

Added a test with `--max-match-per-file 1` on a file with 3 matches, producing the following snapshot: 

```
--- begin input files ---
code.py
rules.yml
--- end input files ---
[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'init' '-b' 'main'
Initialized empty Git repository in <TMP>/<MASKED>/.git/
[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.name' 'Tester'
[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.email' 'tester@example.com'
[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'add' '.'
[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'commit' '-m' 'Add files'
[main (root-commit) <MASKED>] Add files
 2 files changed, 13 insertions(+)
 create mode 100644 code.py
 create mode 100644 rules.yml

┌──────────────┐
│ Opengrep CLI │
└──────────────┘

[32m✔[39m [1mOpengrep OSS[0m
  [32m✔[39m Basic security coverage for first-party code vulnerabilities.

[1m  Loading rules from local config...[0m


┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 2 files tracked by git with 1 Code rule:
  Scanning 2 files.
[<MASKED TIMESTAMP>][WARNING]: too many matches on code.py, generating exn for it
[<MASKED TIMESTAMP>][WARNING]: most offending rule: id = eqeq-bad, matches = 3, pattern = $X == $X


┌────────────────┐
│ 1 Code Finding │
└────────────────┘

    code.py
   ❯❯❱ eqeq-bad
          useless comparison

            3┆ f = a + b == a + b



┌──────────────┐
│ Scan Summary │
└──────────────┘
Some files were skipped or only partially analyzed.
  Scan was limited to files tracked by git.

Ran 1 rule on 1 file: 1 finding.
ASSERT exit code

```