### PR TITLE
Add new rule option `max-match-per-file`

### DIFF
--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -176,6 +176,9 @@ type t = {
    *)
   ~decorators_order_matters <ocaml default="false"> : bool;
 
+  (* restrict the number of matches to report on a rule. *)
+  ?max_match_per_file : int option;
+
   (* TODO: equivalences:
    *   - require_to_import (but need pass config to Js_to_generic)
    *)

--- a/src/core/Core_match.ml
+++ b/src/core/Core_match.ml
@@ -153,8 +153,34 @@ and rule_id = {
   langs : Lang.t list;
   (* used for debugging (could be removed at some point) *)
   pattern_string : string;
+  options : rule_id_options option
 }
 [@@deriving show, eq]
+
+and rule_id_options  = {
+  max_match_per_file : int option;
+  (* maximum number of matches per file. *)
+}
+[@@deriving show, eq]
+
+let rule_id_options_of_rule_options (opts : Rule_options.t) =
+  { max_match_per_file = opts.max_match_per_file }
+
+let rule_id_options_of_rule_options_opt (opts : Rule_options.t option) =
+  Option.map rule_id_options_of_rule_options opts
+
+let rule_ids_to_map (opts: rule_id list) =
+  Rule_ID.Map.of_list (List_.map (fun r -> (r.id, r)) opts)
+
+let rule_ids_to_rule_id_options_map (opts: rule_id list) =
+  Rule_ID.Map.of_list
+    (List_.filter_map
+       (fun r ->
+          Option.map (fun opts -> (r.id, opts)) r.options)
+       opts)
+
+let to_rule_id_options_map (ms : t list) =
+  rule_ids_to_rule_id_options_map (List_.map (fun m -> m.rule_id) ms)
 
 (*****************************************************************************)
 (* Deduplication *)

--- a/src/core/Core_match.mli
+++ b/src/core/Core_match.mli
@@ -41,8 +41,22 @@ and rule_id = {
   fix_regexp : Rule.fix_regexp option;
   langs : Lang.t list;
   pattern_string : string;
+  options : rule_id_options option
 }
 [@@deriving show, eq]
+
+and rule_id_options  = {
+  max_match_per_file : int option;
+  (* maximum number of matches per file. *)
+}
+[@@deriving show, eq]
+
+val rule_id_options_of_rule_options: Rule_options_t.t -> rule_id_options
+val rule_id_options_of_rule_options_opt: Rule_options_t.t option -> rule_id_options option
+
+val rule_ids_to_map: rule_id list -> rule_id Rule_ID.Map.t
+val rule_ids_to_rule_id_options_map: rule_id list -> rule_id_options Rule_ID.Map.t
+val to_rule_id_options_map: t list -> rule_id_options Rule_ID.Map.t
 
 (* remove duplicate *)
 val uniq : t list -> t list

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -281,7 +281,12 @@ let output_core_results (caps : < Cap.stdout ; Cap.stderr ; Cap.exit >)
                        None
                    | Ok (match_ : Out.core_match) -> Some match_)
           in
-          let matches = Core_json_output.dedup_and_sort matches in
+          let matches =
+            Core_json_output.dedup_and_sort
+              (Core_match.to_rule_id_options_map
+                 List_.(map (fun (Core_result.{pm; _}) -> pm) res.processed_matches))
+              matches
+          in
           matches
           |> List.iter (Core_text_output.print_match (caps :> < Cap.stdout >));
           if config.matching_explanations then

--- a/src/engine/Match_SCA_mode.ml
+++ b/src/engine/Match_SCA_mode.ml
@@ -129,6 +129,7 @@ let check_rule (rule : Rule.t) (xtarget : Lockfile_xtarget.t)
                    langs = Xlang.to_langs rule.R.target_analyzer;
                    (* TODO: What should this be? *)
                    pattern_string = "";
+                   options = rule_id_options_of_rule_options_opt rule.options;
                  };
                path = Target.path_of_origin (Origin.File xtarget.target.path);
                (* TODO: should be pro if the pro engine is used in the match *)

--- a/src/engine/Match_env.ml
+++ b/src/engine/Match_env.ml
@@ -98,6 +98,7 @@ let fake_rule_id (id, str) =
     fix = None;
     fix_regexp = None;
     langs = [];
+    options = None;
   }
 
 let adjust_xconfig_with_rule_options xconf options =

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -326,7 +326,7 @@ let rec remove_selectors (selector, acc) formulas =
                 * - pattern: $Y
             *)
             (* TODO: Should we fail here or just reported as a warning? This
-                * is something to catch with the meta-checker. *)
+             * is something to catch with the meta-checker. *)
             (Some s1, x :: acc)
       in
       remove_selectors (selector, acc) xs
@@ -1105,7 +1105,7 @@ and matches_of_formula xconf rule xtarget formula opt_context :
     |> RP.add_rule rule
   in
   Log.info (fun m -> m "found %d matches" (List.length res.matches));
-  (* match results per minirule id which is the same than pattern_id in
+  (* match results per minirule id which is the same as pattern_id in
    * the formula *)
   let pattern_matches_per_id = group_matches_per_pattern_id res.matches in
   let env =

--- a/src/engine/Range_with_metavars.ml
+++ b/src/engine/Range_with_metavars.ml
@@ -51,6 +51,7 @@ let range_to_pattern_match_adjusted (r : Rule.t) (range : t) : Core_match.t =
       langs;
       message = r.message (* keep pattern_str which can be useful to debug *);
       metadata = r.metadata;
+      options = Core_match.rule_id_options_of_rule_options_opt r.options;
     }
   in
   (* Need env to be the result of evaluate_formula, which propagates metavariables *)

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -158,6 +158,7 @@ let (rule_id_of_mini_rule : Mini_rule.t -> Core_match.rule_id) =
     fix = mr.fix;
     fix_regexp = mr.fix_regexp;
     langs = mr.langs;
+    options = None;
   }
 
 let match_rules_and_recurse

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -340,9 +340,12 @@ let o_max_match_per_file : int Term.t =
   let info =
     Arg.info [ "max-match-per-file" ]
       ~doc:
-        {|Maximum number of matches to report per file. Defaults to 10000. If the
-number of matches exceeds this limit, matches beyond this limit are discarded. The
-kept matches are chosen based on the order in which they are found in the file.
+        {|Maximum number of matches to allow per file. Defaults to 10000. If the
+number of matches before deduplication exceeds this limit, an error is reported for
+the target and no matches are returned for it. This should not be used to restrict
+the number of matches, but as a hard limit that can be used to identify problematic
+rules. In such cases, the option can be added to the rule's options section, and it
+will result in a restriction of the number of matches for that rule only.
 |}
   in
   Arg.value (Arg.opt Arg.int default info)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -167,7 +167,10 @@ let mk_file_match_hook (conf : Scan_CLI.conf) (rules : Rule.rules)
       |> pps_autofix
       |> pps_nosem
       |> Result_.partition Core_json_output.match_to_match
-      |> fst |> Core_json_output.dedup_and_sort
+      (* TODO: Print errors like in src/core_cli/Core_CLI.ml *)
+      |> fst
+      |> Core_json_output.dedup_and_sort
+           Core_match.(to_rule_id_options_map pms)
     in
     let hrules = Rule.hrules_of_rules rules in
     let fixed_env = Fixed_lines.mk_env () in

--- a/src/osemgrep/cli_scan/Test_scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Test_scan_subcommand.ml
@@ -46,6 +46,19 @@ rules:
     severity: ERROR
 |}
 
+let eqeq_with_max_match =
+  {|
+rules:
+  - id: eqeq-bad
+    options:
+      max_match_per_file: 1
+    patterns:
+      - pattern: $X == $X
+    message: "useless comparison"
+    languages: [python]
+    severity: ERROR
+|}
+
 (* coupling: similar to cli/tests/.../targets/basic/stupid.py *)
 let stupid_py_content = {|
 def foo(a, b):
@@ -180,6 +193,24 @@ let test_basic_output_max_match (caps : Scan_subcommand.caps) () =
           in
           Exit_code.Check.ok exit_code))
 
+let test_basic_output_max_match_in_rule (caps : Scan_subcommand.caps) () =
+  with_env_app_token (fun () ->
+      let repo_files =
+        [
+          F.File ("rules.yml", eqeq_with_max_match);
+          F.File ("code.py", three_findings_py_content);
+        ]
+      in
+      Testutil_git.with_git_repo ~verbose:true repo_files (fun _cwd ->
+          let exit_code =
+            without_settings (fun () ->
+                Scan_subcommand.main caps
+                  [|
+                    "opengrep-scan"; "--experimental"; "--config"; "rules.yml"
+                  |])
+          in
+          Exit_code.Check.ok exit_code))
+
 let test_basic_output_ignore_pattern (caps : Scan_subcommand.caps) () =
   with_env_app_token (fun () ->
       let repo_files =
@@ -305,4 +336,6 @@ let tests (caps : < Scan_subcommand.caps >) =
            ~code_content:java_arg_paren_java_content);
       t "basic output with --max-match-per-file" ~checked_output:(Testo.stdxxx ()) ~normalize
         (test_basic_output_max_match caps);
+      t "basic output with max-match-per-file rule option" ~checked_output:(Testo.stdxxx ()) ~normalize
+        (test_basic_output_max_match_in_rule caps);
     ]

--- a/src/reporting/Core_json_output.ml
+++ b/src/reporting/Core_json_output.ml
@@ -305,8 +305,9 @@ let unsafe_match_to_match ?(inline = false)
       x.taint_trace
   in
   let metavars = x.env |> List_.map (metavars startp) in
+  let bindings =  Metavar_replacement.(of_bindings x.env) in
   let replacement_fn st =
-    Metavar_replacement.(interpolate_metavars st (of_bindings x.env))
+    Metavar_replacement.(interpolate_metavars st bindings)
   in
   let metadata =
     let* json = x.rule_id.metadata in
@@ -320,7 +321,7 @@ let unsafe_match_to_match ?(inline = false)
   (* message where the metavars have been interpolated *)
   (* TODO(secrets): apply masking logic here *)
   let message =
-    Metavar_replacement.(interpolate_metavars x.rule_id.message (of_bindings x.env))
+    Metavar_replacement.(interpolate_metavars x.rule_id.message bindings)
   in
   let enclosing_context =
     x.enclosure |>

--- a/src/reporting/Core_json_output.mli
+++ b/src/reporting/Core_json_output.mli
@@ -11,7 +11,8 @@ val match_to_match :
 
 (* now used also in osemgrep *)
 val error_to_error : Core_error.t -> Out.core_error
-val dedup_and_sort : Out.core_match list -> Out.core_match list
+val dedup_and_sort :
+  Core_match.rule_id_options Rule_ID.Map.t -> Out.core_match list -> Out.core_match list
 
 (* For unit testing *)
 type key [@@deriving show]

--- a/src/reporting/Unit_core_json_output.ml
+++ b/src/reporting/Unit_core_json_output.ml
@@ -41,6 +41,7 @@ let make_core_result () : Core_result.processed_match =
             fix_regexp = None;
             langs = [];
             pattern_string = "";
+            options = None;
           };
         engine_of_match = `OSS;
         env =

--- a/src/rule/Mini_rule.ml
+++ b/src/rule/Mini_rule.ml
@@ -50,6 +50,7 @@ type rule = {
   pattern_string : string;
   fix : string option;
   fix_regexp : Rule.fix_regexp option;
+  (* Do we need the rule options here? *)
 }
 
 and rules = rule list [@@deriving show]

--- a/src/rule/Rule.ml
+++ b/src/rule/Rule.ml
@@ -912,6 +912,6 @@ let rule_of_xpattern ?fix (xlang : Xlang.t) (xpat : Xpattern.t) : rule =
 
    Currently, we did the choice to **only** hash the [ID.t] of the given rule
    which is clearly not enough comparing to the Python code. But, again, we can
-   improve that by serialize everything and compute a hash from it. *)
+   improve that by serializing everything and compute a hash from it. *)
 let sha256_of_rule rule =
   Digestif.SHA256.digest_string (Rule_ID.to_string (fst rule.id))

--- a/src/rule/Rule_ID.ml
+++ b/src/rule/Rule_ID.ml
@@ -28,9 +28,15 @@
 (* Types *)
 (*****************************************************************************)
 
-type t = string [@@deriving show, eq]
+type t = string [@@deriving show, eq, ord]
 
 exception Malformed_rule_ID of string
+
+module Map = Map.Make (struct
+  type nonrec t = t
+  let compare = compare
+end)
+
 
 (*****************************************************************************)
 (* Entry points *)

--- a/src/rule/Rule_ID.mli
+++ b/src/rule/Rule_ID.mli
@@ -6,6 +6,8 @@ type t [@@deriving show, eq]
 
 exception Malformed_rule_ID of string
 
+module Map : Map.S with type key = t
+
 (* conversion functions *)
 val to_string : t -> string
 

--- a/tests/snapshots/semgrep-core/0f4f85949646/name
+++ b/tests/snapshots/semgrep-core/0f4f85949646/name
@@ -1,0 +1,1 @@
+Osemgrep Scan (e2e) > basic output with max-match-per-file rule option

--- a/tests/snapshots/semgrep-core/0f4f85949646/stdxxx
+++ b/tests/snapshots/semgrep-core/0f4f85949646/stdxxx
@@ -1,0 +1,52 @@
+--- begin input files ---
+code.py
+rules.yml
+--- end input files ---
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'init' '-b' 'main'
+Initialized empty Git repository in <TMP>/<MASKED>/.git/
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.name' 'Tester'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'config' 'user.email' 'tester@example.com'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'add' '.'
+[<MASKED TIMESTAMP>][INFO]: Running external command: 'git' 'commit' '-m' 'Add files'
+[main (root-commit) <MASKED>] Add files
+ 2 files changed, 15 insertions(+)
+ create mode 100644 code.py
+ create mode 100644 rules.yml
+
+┌──────────────┐
+│ Opengrep CLI │
+└──────────────┘
+
+[32m✔[39m [1mOpengrep OSS[0m
+  [32m✔[39m Basic security coverage for first-party code vulnerabilities.
+
+[1m  Loading rules from local config...[0m
+
+
+┌─────────────┐
+│ Scan Status │
+└─────────────┘
+  Scanning 2 files tracked by git with 1 Code rule:
+  Scanning 2 files.
+
+
+┌────────────────┐
+│ 1 Code Finding │
+└────────────────┘
+
+    code.py
+   ❯❯❱ eqeq-bad
+          useless comparison
+
+            3┆ f = a + b == a + b
+
+
+
+┌──────────────┐
+│ Scan Summary │
+└──────────────┘
+Some files were skipped or only partially analyzed.
+  Scan was limited to files tracked by git.
+
+Ran 1 rule on 1 file: 1 finding.
+ASSERT exit code

--- a/tests/snapshots/semgrep-core/d4fef67ae34d/stdxxx
+++ b/tests/snapshots/semgrep-core/d4fef67ae34d/stdxxx
@@ -32,23 +32,11 @@ Initialized empty Git repository in <TMP>/<MASKED>/.git/
 [<MASKED TIMESTAMP>][WARNING]: most offending rule: id = eqeq-bad, matches = 3, pattern = $X == $X
 
 
-┌────────────────┐
-│ 1 Code Finding │
-└────────────────┘
-
-    code.py
-   ❯❯❱ eqeq-bad
-          useless comparison
-
-            3┆ f = a + b == a + b
-
-
-
 ┌──────────────┐
 │ Scan Summary │
 └──────────────┘
 Some files were skipped or only partially analyzed.
   Scan was limited to files tracked by git.
 
-Ran 1 rule on 1 file: 1 finding.
+Ran 1 rule on 1 file: 0 findings.
 ASSERT exit code


### PR DESCRIPTION
## Changes

- Revert the global `--max-match-per-file` parameter's behaviour: since this check happens before de-duplication, we retain the original behaviour of Semgrep in which no matches are retained for such targets.

- Add a `max-match-per-file`option to rule options, which allows to report deduplicated matches only up to that limit. Useful with rules that typically result in many matches per file.

How to use the new rule option: 

``` yaml
rules:
- id: some-rule-with-many-matches-per-file
  options:
    max_match_per_file: 1 # any positive integer.
```