### PR TITLE
Add `taint-fixpoint-timeout` rule option

### DIFF
--- a/.github/workflows/build-manylinux-binary.yml
+++ b/.github/workflows/build-manylinux-binary.yml
@@ -42,6 +42,8 @@ jobs:
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-glibc-${{ hashFiles('cli/src/semgrep/**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-glibc-
           path: "${{ env.NUITKA_CACHE_DIR }}"
 
       - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4

--- a/.github/workflows/build-musllinux-binary.yml
+++ b/.github/workflows/build-musllinux-binary.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-musl-${{ hashFiles('cli/src/semgrep/**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-musl-
           path: "${{ env.NUITKA_CACHE_DIR }}"
 
       - name: Set ALPINE_CONTAINER based on inputs.arch

--- a/.github/workflows/build-osx-binary.yml
+++ b/.github/workflows/build-osx-binary.yml
@@ -32,6 +32,8 @@ jobs:
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-${{ hashFiles('cli/src/semgrep/**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-
           path: "${{ env.NUITKA_CACHE_DIR }}"
 
       - name: Install pipenv

--- a/.github/workflows/build-test-manylinux.yml
+++ b/.github/workflows/build-test-manylinux.yml
@@ -108,6 +108,7 @@ jobs:
       - uses: Vampire/setup-wsl@3b46b44374d5d0ae94654c45d114a3ed7a0e07a8 # ratchet:Vampire/setup-wsl@v5.0.1
       - name: Install Python
         run: |
+          sudo sed -i '/bullseye-backports/d' /etc/apt/sources.list
           sudo apt update -y
           sudo apt install -y make python3 python3-pip
           sudo ln -s /usr/bin/python3 /usr/bin/python

--- a/.github/workflows/build-test-manylinux.yml
+++ b/.github/workflows/build-test-manylinux.yml
@@ -105,7 +105,7 @@ jobs:
         with:
           name: manylinux-x86-wheel
       - run: unzip dist.zip
-      - uses: Vampire/setup-wsl@6c400b755bcd0583e60c2e7aa0cdc61794355c9b # ratchet:Vampire/setup-wsl@v3
+      - uses: Vampire/setup-wsl@3b46b44374d5d0ae94654c45d114a3ed7a0e07a8 # ratchet:Vampire/setup-wsl@v5.0.1
       - name: Install Python
         run: |
           sudo apt update -y

--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -56,6 +56,8 @@ jobs:
         uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # ratchet:actions/cache@v4
         with:
           key: ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-${{ hashFiles('cli/src/semgrep/**/*.py') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-v1-nuitka-
           path: ${{ env.NUITKA_CACHE_DIR }}
 
       - name: Set-up cygwin

--- a/cli/src/semgrep/rule_lang.py
+++ b/cli/src/semgrep/rule_lang.py
@@ -104,7 +104,7 @@ class YamlTree(Generic[T]):
             return {str(k.unroll()): v.unroll() for k, v in self.value.items()}
         elif isinstance(self.value, YamlTree):
             return self.value.unroll()
-        elif isinstance(self.value, (str, int)) or self.value is None:
+        elif isinstance(self.value, (str, int, float)) or self.value is None:
             return self.value
         else:
             raise ValueError(

--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -179,6 +179,9 @@ type t = {
   (* restrict the number of matches to report on a rule. *)
   ?max_match_per_file : int option;
 
+  (* override the default taint fixpoint timeout. *)
+  ?taint_fixpoint_timeout : float option;
+
   (* TODO: equivalences:
    *   - require_to_import (but need pass config to Js_to_generic)
    *)

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1961,7 +1961,9 @@ and fixpoint_aux taint_inst func ?(needed_vars = IL.NameSet.empty)
   (* THINK: Why I cannot just update mapping here ? if I do, the mapping gets overwritten later on! *)
   (* DataflowX.display_mapping flow init_mapping show_tainted; *)
   let end_mapping, timeout =
-    DataflowX.fixpoint ~timeout:Limits_semgrep.taint_FIXPOINT_TIMEOUT
+    DataflowX.fixpoint
+      ~timeout:Common.(
+          taint_inst.options.taint_fixpoint_timeout ||| Limits_semgrep.taint_FIXPOINT_TIMEOUT)
       ~eq_env:Lval_env.equal ~init:init_mapping ~trans:(transfer env ~fun_cfg)
       ~forward:true ~flow
   in


### PR DESCRIPTION
This option allows to override the default value (0.2 sec).

It only has effect in taint mode.

To use: 

``` yaml
rules:
- id: some-taint-rule
  options:
    taint_fixpoint_timeout: 0.5
```

This will override the default value of 0.2 seconds only for this rule.