### PR TITLE
Release version v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [1.8.0](https://github.com/opengrep/opengrep/releases/tag/v1.8.0) - 23-07-2025
+
+### New features
+
+* Add new rule option `max-match-per-file` by @dimitris-m in #359 and #357
+* Add new rule option `taint-fixpoint-timeout` by @dimitris-m in #360
+* Release opengrep-core by @spotdemo4 in #349
+
+### Bug fixes
+
+* For variables, calculate the range in the `extra` section using the original token by @maciejpirog in #356
+
+### Tech debt
+
+* Eliminated references in `AST_to_IL` by @corneliuhoffman in #351
+* Eliminated more references by @corneliuhoffman in #358
+
+### New Contributors
+* @spotdemo4 made their first contribution in #349
+
+**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.7.0...v1.8.0
+
+
 ## [1.7.0](https://github.com/opengrep/opengrep/releases/tag/v1.7.0) - 14-07-2025
 
 ### New features

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -130,7 +130,7 @@ install_requires = [
 
 setuptools.setup(
     name="opengrep",
-    version="1.7.0",
+    version="1.8.0",
     author="Semgrep Inc., Opengrep",
     author_email="support@opengrep.com",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",

--- a/cli/src/semgrep/__init__.py
+++ b/cli/src/semgrep/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = "1.7.0"
+__VERSION__ = "1.8.0"
 __SEMGREP_VERSION__ = "1.100.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="semgrep_pre_commit_package",
-    version="1.7.0",
+    version="1.8.0",
     # install_requires=["opengrep==1.2.0"], # Commented out since we're not on pypi.
     packages=[],
 )

--- a/src/core/Version.ml
+++ b/src/core/Version.ml
@@ -3,5 +3,5 @@
 
   Automatically modified by scripts/release/bump.
 *)
-let version = "1.7.0"
+let version = "1.8.0"
 let version_semgrep = "1.100.0"


### PR DESCRIPTION
## New features

* Add new rule option `max-match-per-file` by @dimitris-m in #359 and #357
* Add new rule option `taint-fixpoint-timeout` by @dimitris-m in #360
* Release opengrep-core by @spotdemo4 in #349

## Bug fixes

* For variables, calculate the range in the `extra` section using the original token by @maciejpirog in #356

## Tech debt

* Eliminated references in `AST_to_IL` by @corneliuhoffman in #351
* Eliminated more references by @corneliuhoffman in #358

## New Contributors
* @spotdemo4 made their first contribution in #349

**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.7.0...v1.8.0