### PR TITLE
Improve deduplication and sorting of results

### DIFF
--- a/libs/commons/ATD_string_wrap.ml
+++ b/libs/commons/ATD_string_wrap.ml
@@ -6,7 +6,7 @@
 open Common
 
 module Fpath = struct
-  type t = Fpath.t [@@deriving show, eq]
+  type t = Fpath.t [@@deriving show, eq, ord]
 
   let unwrap = Fpath.to_string
   let wrap = Fpath.v

--- a/src/core/Core_match.ml
+++ b/src/core/Core_match.ml
@@ -215,22 +215,23 @@ end)
 
 (* Deduplicate matches *)
 let uniq (pms : t list) : t list =
-  (* perf: Previously used an initial size of 1024 but profiling with memtrace
-      revealed that this was oversized and contributed to 14% of all major heap
-      usage in an interfile run over juice-shop. Setting it to 8 meant it was
-      undersized in some cases and led to additional allocations as the table
-      gets resized. Change this only with some caution.
-      DOUBT(iago): What is the actual observed effect in terms of runtime and
-        peak memory usage?
-  *)
-  let size = List.length pms in
-  let matches_tbl = Tbl.create size in
-  (* dedup matches *)
-  pms
-  |> List.iter (fun match_ ->
-         if not (Tbl.mem matches_tbl match_) then Tbl.add matches_tbl match_ ());
-  (* list matches *)
-  Tbl.fold (fun m () acc -> m :: acc) matches_tbl []
+  let digest (t : t) =
+    (t.rule_id.id,
+     t.path,
+     (fst t.range_loc).pos.bytepos,
+     (snd t.range_loc).pos.bytepos,
+     t.env)
+  in
+  let cmp t1 t2 =
+    let c = compare (digest t1) (digest t2) in
+    if c <> 0 then c else
+      match t1.taint_trace, t2.taint_trace with
+      | None, None -> 0
+      | None, _ -> 1
+      | Some _, None -> -1
+      | Some t1, Some t2 -> compare (Lazy.force t1) (Lazy.force t2)
+  in
+  List.sort_uniq cmp pms
 [@@profiling]
 
 let range pm =

--- a/src/core/Core_match.ml
+++ b/src/core/Core_match.ml
@@ -213,6 +213,9 @@ end)
 (* API *)
 (*****************************************************************************)
 
+type digest = Rule_ID.t * Target.path * int * int * Metavariable.bindings
+[@@deriving ord]
+
 (* Deduplicate matches *)
 let uniq (pms : t list) : t list =
   let digest (t : t) =
@@ -223,13 +226,13 @@ let uniq (pms : t list) : t list =
      t.env)
   in
   let cmp t1 t2 =
-    let c = compare (digest t1) (digest t2) in
+    let c = compare_digest (digest t1) (digest t2) in
     if c <> 0 then c else
       match t1.taint_trace, t2.taint_trace with
       | None, None -> 0
       | None, _ -> 1
-      | Some _, None -> -1
-      | Some t1, Some t2 -> compare (Lazy.force t1) (Lazy.force t2)
+      | _, None -> -1
+      | Some t1, Some t2 -> Taint_trace.compare (Lazy.force t1) (Lazy.force t2)
   in
   List.sort_uniq cmp pms
 [@@profiling]

--- a/src/core/Metavariable.ml
+++ b/src/core/Metavariable.ml
@@ -25,7 +25,7 @@ module Log = Log_semgrep.Log
 (* Types *)
 (*****************************************************************************)
 
-type mvar = Mvar.t [@@deriving show, eq, hash]
+type mvar = Mvar.t [@@deriving show, eq, hash, ord]
 
 (* 'mvalue' below used to be just an alias to AST_generic.any, but it is more
  * precise to have a type just for the metavariable values; we do not
@@ -84,7 +84,7 @@ type mvalue =
      bind arbitrary matches to metavariables.
   *)
   | Any of AST_generic.any
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 
 (* we sometimes need to convert to an any to be able to use
  * Lib_AST.ii_of_any, or Lib_AST.abstract_position_info_any
@@ -235,4 +235,4 @@ let str_of_mval x = show_mvalue x
    TODO: ensure that ["$A", Foo; "$B", Bar] and ["$B", Bar; "$A", Foo]
    are equivalent for the equal functions.
 *)
-type bindings = (mvar * mvalue) list (* = Common.assoc *) [@@deriving show, eq]
+type bindings = (mvar * mvalue) list (* = Common.assoc *) [@@deriving show, eq, ord]

--- a/src/core/Metavariable.mli
+++ b/src/core/Metavariable.mli
@@ -1,5 +1,5 @@
 (* metavariable name (e.g., "$FOO") *)
-type mvar = Mvar.t [@@deriving show, eq, hash]
+type mvar = Mvar.t [@@deriving show, eq, hash, ord]
 
 (* metavariable content *)
 type mvalue =
@@ -33,13 +33,13 @@ type mvalue =
      bind arbitrary matches to metavariables.
   *)
   | Any of AST_generic.any
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 
 (* note that the mvalue acts as the value of the metavar and also
    as its concrete code "witness". You can get position information from it
    (if it is not Tok.Ab(stractPos)).
 *)
-type bindings = (mvar * mvalue) list [@@deriving show, eq]
+type bindings = (mvar * mvalue) list [@@deriving show, eq, ord]
 
 (* Mvalue equality reduces to equality on ASTs, which ignores the tokens
    and instead compares the structure. It may optionally include the ident

--- a/src/core/Semgrep_output_utils.ml
+++ b/src/core/Semgrep_output_utils.ml
@@ -168,7 +168,11 @@ let compare_match (a : core_match) (b : core_match) =
   let (bloc : location) = { path = b.path; start = b.start; end_ = b.end_ } in
 
   let c = compare_location aloc bloc in
-  if c <> 0 then c else compare_match_extra a.extra b.extra
+  if c <> 0 then c else
+  let e = compare_match_extra a.extra b.extra in
+  if e <> 0 then e else
+  (* make a deep comparison to make sure the order is always deterministic *)
+  compare a b
 
 let sort_metavars (metavars : (string * metavar_value) list) =
   List.stable_sort compare_metavar_binding metavars

--- a/src/core/Semgrep_output_utils.ml
+++ b/src/core/Semgrep_output_utils.ml
@@ -171,8 +171,7 @@ let compare_match (a : core_match) (b : core_match) =
   if c <> 0 then c else
   let e = compare_match_extra a.extra b.extra in
   if e <> 0 then e else
-  (* make a deep comparison to make sure the order is always deterministic *)
-  compare a b
+  Option.compare Semgrep_output_v1_j.compare_match_dataflow_trace a.extra.dataflow_trace b.extra.dataflow_trace
 
 let sort_metavars (metavars : (string * metavar_value) list) =
   List.stable_sort compare_metavar_binding metavars

--- a/src/core/Taint_trace.ml
+++ b/src/core/Taint_trace.ml
@@ -34,10 +34,10 @@
 (* Types *)
 (*****************************************************************************)
 (* The locations of variables which taint propagates through *)
-type tainted_tokens = Tok.t list [@@deriving show, eq]
+type tainted_tokens = Tok.t list [@@deriving show, eq, ord]
 
 (* The tokens associated with a single pattern match involved in a taint trace *)
-type pattern_match_tokens = Tok.t list [@@deriving show, eq]
+type pattern_match_tokens = Tok.t list [@@deriving show, eq, ord]
 
 (* Simplified version of Taint.source_to_sink meant for finding reporting *)
 type call_trace =
@@ -49,7 +49,7 @@ type call_trace =
       intermediate_vars : tainted_tokens;
       call_trace : call_trace;
     }
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 
 (* The trace of a single source of taint, to the sink.
    There may be many of these, taking different paths. For a single
@@ -70,6 +70,6 @@ type item = {
       (** This is the path that the taint takes, from the function context,
         to get to the sink. *)
 }
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 
-type t = item list [@@deriving show, eq]
+type t = item list [@@deriving show, eq, ord]

--- a/src/rule/Mvar.ml
+++ b/src/rule/Mvar.ml
@@ -6,7 +6,7 @@ open Ppx_hash_lib.Std.Hash.Builtin
 (* less: could want to remember the position in the pattern of the metavar
  * for error reporting on pattern itself? so use a 'string AST_generic.wrap'?
  *)
-type t = string [@@deriving show, eq, hash]
+type t = string [@@deriving show, eq, hash, ord]
 
 (* ex: $X, $FAIL, $VAR2, $_
  * Note that some languages such as PHP or Javascript allows '$' in identifier

--- a/src/rule/Mvar.mli
+++ b/src/rule/Mvar.mli
@@ -1,5 +1,5 @@
 (* a metavariable name (e.g. "$FOO") *)
-type t = string [@@deriving show, eq, hash]
+type t = string [@@deriving show, eq, hash, ord]
 
 (* return whether a string could be a metavariable name (e.g., "$FOO", but not
  * "FOO"). This mostly check for the regexp $[A-Z_][A-Z_0-9]* but

--- a/src/target/Target.ml
+++ b/src/target/Target.ml
@@ -25,7 +25,7 @@ module Out = Semgrep_output_v1_j
 (*****************************************************************************)
 
 type path = { origin : Origin.t; internal_path_to_content : Fpath.t }
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 
 type regular = {
   path : path;

--- a/src/target/Target.mli
+++ b/src/target/Target.mli
@@ -24,7 +24,7 @@ type path = {
           should be used to obtain the contents of the target, but not for
           reporting to the user, other than possibly for debugging purposes. *)
 }
-[@@deriving show, eq]
+[@@deriving show, eq, ord]
 (** Information about where a target from for both the purpose of
    {ul
     {- informing the user: [origin]}


### PR DESCRIPTION
Improvements in the implementation of deduplication and sorting of matches and results. Makes the implementation simpler and deterministic.

## Summary of changes

- A custom comparison in `Core_match.uniq`
- `List.sort_uniq` instead of a hashtable-based deduplication
- A more deterministic comparison of matches in `Semgrep_output_utils.compare_match`.

## Rationale:

- Code simplification
- Fixes the nondeterminism bug (#339), hopefully
- Slight performance improvement

## Data:

Using a hashtable in `Core_match.uniq` is an overkill. Running opengrep-rules on a few mid-sized repos revealed that this function is run on lists of the following lengths:

| Length of input | # calls for pmd | # calls for jellyfin |
| ---: | ---: | ---: |
| 0 | 80800 | 43326 |
| 1 | 639 | 270 |
| 2 - 9| 1976 | 274 
| 10-99 | 2356 | 385 |
| 100-999 | 803 | 448 |
| 1000-9999 | 58 | 78 |
| 10000 - ... | 0 | 0 |

This means that for a real-life set of rules and real-life repos, only about 1% of applications to `uniq` are to lists of length greater or equal to 100, and, moreover, there are no cases in which the list is of length greater or equal to 10000. I such cases, the overhead of creating a hashtable in each of these cases and their internal working makes it less efficient then `List.sort_uniq`.

Also, looking at the arguments to `uniq`, most often they come more or less sorted already. In such cases the chunked mergesort that is used in the implementation of `List.sort.uniq`  is very efficient.

## Experiments

- In the great scheme of things, the perf improvement is neglegable,
- I can no longer reproduce the nondet bug,
- The tests pass,
- Compared the results using opengrep-rules on the 7 repos from the perf script, they all match