### PR TITLE
Add team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @willem-delbare @dimitris-m
+* @willem-delbare @dimitris-m @maciejpirog @corneliuhoffman


### PR DESCRIPTION
## Changes

Adds @maciejpirog and @corneliuhoffman to `.github/CODEOWNERS`.