### PR TITLE
Release v1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+
+## [1.8.3](https://github.com/opengrep/opengrep/releases/tag/v1.8.3) - 31-07-2025
+
+### Bug fixes
+
+* The option `max_match_per_file` now works with `--test` by @dimitris-m in #374
+* Inline metavars in incremental json output by @dimitris-m in #375
+
+### Improvements
+
+* Performance improvements by @maciejpirog and @dimitris-m in #369, #372, #373, #376
+* Make `--experimental` bypass the executable name by @dimitris-m in https://github.com/opengrep/opengrep/pull/370
+
+**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.8.2...v1.8.3
+
+
 ## [1.8.2](https://github.com/opengrep/opengrep/releases/tag/v1.8.2) - 25-07-2025
 
 ### Bug fixes

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -130,7 +130,7 @@ install_requires = [
 
 setuptools.setup(
     name="opengrep",
-    version="1.8.2",
+    version="1.8.3",
     author="Semgrep Inc., Opengrep",
     author_email="support@opengrep.com",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",

--- a/cli/src/semgrep/__init__.py
+++ b/cli/src/semgrep/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = "1.8.2"
+__VERSION__ = "1.8.3"
 __SEMGREP_VERSION__ = "1.100.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="semgrep_pre_commit_package",
-    version="1.8.2",
+    version="1.8.3",
     # install_requires=["opengrep==1.2.0"], # Commented out since we're not on pypi.
     packages=[],
 )

--- a/src/core/Version.ml
+++ b/src/core/Version.ml
@@ -3,5 +3,5 @@
 
   Automatically modified by scripts/release/bump.
 *)
-let version = "1.8.2"
+let version = "1.8.3"
 let version_semgrep = "1.100.0"


### PR DESCRIPTION
### Bug fixes

* The option `max_match_per_file` now works with `--test` by @dimitris-m in #374
* Inline metavars in incremental json output by @dimitris-m in #375

### Improvements

* Performance improvements by @maciejpirog and @dimitris-m in #369, #372, #373, #376
* Make `--experimental` bypass the executable name by @dimitris-m in https://github.com/opengrep/opengrep/pull/370

**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.8.2...v1.8.3
