### PR TITLE
Typescript lambda bug

### DIFF
--- a/tests/rules/ts_lambda_def.ts
+++ b/tests/rules/ts_lambda_def.ts
@@ -1,0 +1,8 @@
+class Myclass implements CRM {
+  private getUserFromEmail =  (email) => {
+    // ruleid:test
+   const q = `SELECT Id, Email FROM User WHERE Email = '${email}'`;
+  };
+
+}
+ 

--- a/tests/rules/ts_lambda_def.yaml
+++ b/tests/rules/ts_lambda_def.yaml
@@ -1,0 +1,19 @@
+ rules:
+  - id: test
+    message: Possible SQL injection
+    languages:
+      - javascript
+    severity: ERROR
+    mode: taint
+    pattern-sinks:
+     - patterns:
+        - pattern: |
+                    `$SQL${$EXPR}...`
+        - metavariable-regex:
+            metavariable: $SQL
+            regex: ^\s*(SELECT|select|DELETE|delete|INSERT|insert|UPDATE|update|CALL|call|REPLACE|replace)\s.*
+    pattern-sources:
+     - patterns:
+        - pattern-inside: (..., $INPUT, ...) => {...}
+        - pattern: $INPUT
+


### PR DESCRIPTION
This is a parser bug in TS/JS. the minimal example is from the test

```javascript
class Myclass  {
  private getUserFromEmail =  (email) => {
    // ruleid:test
   const q = `SELECT Id, Email FROM User WHERE Email = '${email}'`;
  };}
```
should taint the rule

```yaml
rules:
  - id: test
    message: Possible SQL injection
    languages:
      - javascript
    severity: ERROR
    mode: taint
    pattern-sinks:
     - patterns:
        - pattern: |
                    `$SQL${$EXPR}...`
        - metavariable-regex:
            metavariable: $SQL
            regex: ^\s*(SELECT|select|DELETE|delete|INSERT|insert|UPDATE|update|CALL|call|REPLACE|replace)\s.*
    pattern-sources:
     - patterns:
        - pattern-inside: (..., $INPUT, ...) => {...}
        - pattern: $INPUT
```

the issue was that, in the case of all function (including the lambdas) the parser would transform them into standard FuncDef and so he "lambda part" was lost. We chose the change so it parses the same as:
```python
class MyClass:
    get_user_from_email = lambda email: (
            f"SELECT Id, Email FROM User WHERE Email = '{email}'"
        )
```
or
```rust
struct MyClass;

impl MyClass {
    fn get_lambda() -> impl Fn(&str) -> String {
       let q = |email| format!("SELECT Id, Email FROM User WHERE Email = '{}'", email);
    }
}
```