### PR TITLE
When comparing locations, compare only selected fields

### DIFF
--- a/libs/lib_parsing/Pos.ml
+++ b/libs/lib_parsing/Pos.ml
@@ -60,8 +60,8 @@ type t = {
    *)
   bytepos : int; (* 0-based *)
   (* Those two fields can be derived from bytepos (See complete_position() *)
-  line : int; (* 1-based *)
-  column : int; (* 0-based *)
+  line : int [@eq.ignore][@ord.ignore]; (* 1-based *)
+  column : int [@eg.ignore][@ord.ignore]; (* 0-based *)
   (* TODO: use an Src.t/Origin.t instead? (see spacegrep Src_file.source *)
   file : Fpath_.t;
 }

--- a/libs/lib_parsing/Tok.ml
+++ b/libs/lib_parsing/Tok.ml
@@ -54,8 +54,9 @@ open Sexplib.Std
  * Note that Loc.t is now an alias for Tok.location.
  *)
 type location = {
-  (* the content of the "token" *)
-  str : string;
+  (* The content of the "token".
+   * No need to use it for comparison, as it is determined by the location. *)
+  str : string [@eq.ignore][@ord.ignore];
   (* TODO? the content of Pos.t used to be inlined in this location type.
    * It is cleaner to factorize things in Pos.t, but this introduces
    * an extra pointer which actually can have real performance implication


### PR DESCRIPTION
perf revealed 1.16% time is spent in `caml_string_compare` called from `Tok.equal_location`. Hence:

To compare tokens, we compare:

- `bytepos`
- `file`

We do not compare:

- content of a token,
- line and col

as they are determined by `bytepos` and `file`
