### PR TITLE
Make entropy data non-lazy

### DIFF
--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -798,7 +798,6 @@ let main_exn (caps : Cap.all_caps) (argv : string array) : unit =
    * also tests/Test.ml and osemgrep/cli/CLI.ml
    *)
   Parsing_init.init ();
-  Data_init.init ();
 
   (* must be done after Arg.parse, because Common.profile is set by it *)
   Profiling.profile_code "Main total" (fun () ->

--- a/src/data/Data_init.ml
+++ b/src/data/Data_init.ml
@@ -1,3 +1,0 @@
-let init () =
-  Entropy.english_trigrams_ref := Entropy_data.english_trigrams;
-  ()

--- a/src/data/Data_init.mli
+++ b/src/data/Data_init.mli
@@ -1,2 +1,0 @@
-(* setup the right link so the engine can leverage the data in this directory *)
-val init : unit -> unit

--- a/src/data/dune
+++ b/src/data/dune
@@ -6,7 +6,4 @@
  (public_name semgrep.data)
  (name semgrep_data)
  (wrapped false)
- (libraries
-   semgrep.engine
- )
 )

--- a/src/engine/Entropy.ml
+++ b/src/engine/Entropy.ml
@@ -44,11 +44,6 @@ let unknown_char_entropy = log2 62.
 
 let normalize_string s = String.map Char.uppercase_ascii s
 
-(* Set in Data_init.init() from data in Entropy_data.ml
- * The intermediate variable below is used to save space in engine.js
- *)
-let english_trigrams_ref = ref [||]
-
 (*
    Load trigrams:
    - determine each trigram's frequency, expressed as an entropy
@@ -59,7 +54,7 @@ let english_trigrams_ref = ref [||]
    end of strings where we don't have full trigrams.
 *)
 let load_trigrams () =
-  let ar = !english_trigrams_ref in
+  let ar = Entropy_data.english_trigrams in
   (* Load trigram frequencies *)
   let trigram_entropies = Trie.create () in
   (* we explicitly use int64 here to avoid overflow *)
@@ -101,7 +96,7 @@ let load_trigrams () =
   in
   (trigram_entropies, char_entropies)
 
-let data_tables = lazy (load_trigrams ())
+let data_tables = load_trigrams ()
 
 (*
    A string is scanned as follows:
@@ -121,7 +116,7 @@ let data_tables = lazy (load_trigrams ())
 *)
 
 let get_substring_entropy s =
-  let trigram_entropies, char_entropies = Lazy.force data_tables in
+  let trigram_entropies, char_entropies = data_tables in
   match String.length s with
   | 3 ->
       let trigram_entropy =

--- a/src/engine/Entropy.mli
+++ b/src/engine/Entropy.mli
@@ -31,6 +31,3 @@ val information_density : string -> float
 *)
 val score : string -> int
 val has_high_score : string -> bool
-
-(* Set in Data_init.init() from data in Entropy_data.ml *)
-val english_trigrams_ref : (string * int) array ref

--- a/src/engine/dune
+++ b/src/engine/dune
@@ -17,6 +17,7 @@
    aliengrep
 
    semgrep_core
+   semgrep_data
    semgrep_fixing
    semgrep_matching
    semgrep_tainting

--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -265,7 +265,6 @@ let main (caps : caps) (argv : string array) : Exit_code.t =
 
   (* hacks for having a smaller engine.js file *)
   Parsing_init.init ();
-  Data_init.init ();
   Http_helpers_.set_client_ref (module Cohttp_lwt_unix.Client);
 
   (* TOPORT: maybe_set_git_safe_directories() *)

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -213,7 +213,6 @@ let main (caps : Cap.all_caps) : unit =
       (* coupling: partial copy of the content of CLI.main() *)
       Core_CLI.register_exception_printers ();
       Parsing_init.init ();
-      Data_init.init ();
       Http_helpers.set_client_ref (module Cohttp_lwt_unix.Client);
       let reset () =
         (* Some tests change this configuration so we have to reset


### PR DESCRIPTION
Before: in Entropy.ml, the lazy variable `data_tables` leads to a bug, because it can be forced by different threads simultaneously, which is not allowed in OCaml.

After: `data_tables` is no longer lazy.