### PR TITLE
Check Cosign version in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -266,6 +266,10 @@ main() {
 # Argument parsing
 if command -v cosign &> /dev/null; then
     HAS_COSIGN=true
+    COSIGN_MAJOR_VERSION=$(cosign version | grep GitVersion | sed 's/GitVersion:\s*//' | grep -oE '^[0-9]+')
+    if [[ "$COSIGN_MAJOR_VERSION" -lt 2 ]]; then
+        echo "Warning: cosign version is less than 2.0.0, signature validation may fail."
+    fi;
 else
     HAS_COSIGN=false
 fi


### PR DESCRIPTION
A user reported an error which was traced to an old cosign version.
We now check that it's recent enough.