### PR TITLE
fix failure in to-ast-generic for C and C++

### DIFF
--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -476,7 +476,6 @@ and map_expr env x : G.expr =
       and l, v2, r = map_bracket env (map_of_list (map_initialiser env)) v2 in
       let v2 =
         match v2 with
-        | [] -> failwith "should not be empty by precondition"
         | [ x ] -> x
         | xs -> Container (List, fb xs) |> G.e
       in


### PR DESCRIPTION
For C and C++ files that were parsed (or partially parsted), we sometimes encountered failure during the to-ast-generic step for incorrect programs or programs that use the preprocessor. After this fix we never fail: if the file is (at least partially) parsed, we always produce an AST.