### PR TITLE
Fix: install script `sed` call should be posix-compliant

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -266,7 +266,7 @@ main() {
 # Argument parsing
 if command -v cosign &> /dev/null; then
     HAS_COSIGN=true
-    COSIGN_MAJOR_VERSION=$(cosign version | grep GitVersion | sed 's/GitVersion:\s*//' | grep -oE '^[0-9]+')
+    COSIGN_MAJOR_VERSION=$(cosign version | grep GitVersion | sed 's/GitVersion:[[:space:]]*//' | grep -oE '^[0-9]+')
     if [[ "$COSIGN_MAJOR_VERSION" -lt 2 ]]; then
         echo "Warning: cosign version is less than 2.0.0, signature validation may fail."
     fi;


### PR DESCRIPTION
The previous version only worked on GNU sed, so ok for homebrew sed but not Mac OSX default sed.