### PR TITLE
Release v1.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [1.8.7](https://github.com/opengrep/opengrep/releases/tag/v1.8.7) - 29-08-2025
+
+### Bug fixes
+
+* Scala: support metavars as elements in interpolated strings by @maciejpirog in #403
+* Fix: reset memoisation hashtables when performing a baseline scan by @dimitris-m in #404
+
+**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.8.6...v1.8.7
+
+
 ## [1.8.6](https://github.com/opengrep/opengrep/releases/tag/v1.8.6) - 21-08-2025
 
 ### Bug fixes

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -130,7 +130,7 @@ install_requires = [
 
 setuptools.setup(
     name="opengrep",
-    version="1.8.6",
+    version="1.8.7",
     author="Semgrep Inc., Opengrep",
     author_email="support@opengrep.com",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",

--- a/cli/src/semgrep/__init__.py
+++ b/cli/src/semgrep/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = "1.8.6"
+__VERSION__ = "1.8.7"
 __SEMGREP_VERSION__ = "1.100.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="semgrep_pre_commit_package",
-    version="1.8.6",
+    version="1.8.7",
     # install_requires=["opengrep==1.2.0"], # Commented out since we're not on pypi.
     packages=[],
 )

--- a/src/core/Version.ml
+++ b/src/core/Version.ml
@@ -3,5 +3,5 @@
 
   Automatically modified by scripts/release/bump.
 *)
-let version = "1.8.6"
+let version = "1.8.7"
 let version_semgrep = "1.100.0"


### PR DESCRIPTION
## Bug fixes

* Scala: support metavars as elements in interpolated strings by @maciejpirog in #403
* Fix: reset memoisation hashtables when performing a baseline scan by @dimitris-m in #404

**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.8.6...v1.8.7