### PR TITLE
Fix: pin ppxlib to 0.35.0

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -113,7 +113,7 @@ a few other projects developed at r2c.
     ; we're currently "vendoring" pcre2 in libs/pcre2
     ; so no need to get opam to install it
     ;(pcre2 (>= "7.5.3" ))
-    (ppxlib (>= "0.25.0"))
+    (ppxlib (= "0.35.0"))
     (ppx_deriving (>= "5.2.1"))
     (ppx_hash (>= "v0.14.0" ))
     (digestif (>= "1.0.0"))
@@ -479,7 +479,7 @@ For more information see https://opengrep.dev.
     ; CLI
     cmdliner
     ; PPX
-    ppxlib
+    (ppxlib (= 0.35.0)) ; because 0.36.0 moved to AST 5.2, breaking ppx_profiling.
     (ppx_deriving (>= 6.0.3))
     ppx_deriving_yojson
     ppx_hash

--- a/opam/commons.opam
+++ b/opam/commons.opam
@@ -21,7 +21,7 @@ depends: [
   "yojson" {>= "1.7.0"}
   "re" {>= "1.10.4"}
   "pcre" {>= "7.5.0"}
-  "ppxlib" {>= "0.25.0"}
+  "ppxlib" {= "0.35.0"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_hash" {>= "v0.14.0"}
   "digestif" {>= "1.0.0"}

--- a/opam/semgrep.opam
+++ b/opam/semgrep.opam
@@ -45,7 +45,7 @@ depends: [
   "xmlm"
   "sarif" {>= "0.3.0"}
   "cmdliner"
-  "ppxlib"
+  "ppxlib" {= "0.35.0"}
   "ppx_deriving" {>= "6.0.3"}
   "ppx_deriving_yojson"
   "ppx_hash"


### PR DESCRIPTION
With 0.36.0 (latest), ppxlib moved to AST 5.2, and ppx_profiling breaks. 

Later we can adapt the code but for now there is no compelling reason to urgently upgrade.