### PR TITLE
Direct implementation of is_metavar_name and `is_metavar_ellipsis`, not via memoized regex

### DIFF
--- a/src/rule/Mvar.ml
+++ b/src/rule/Mvar.ml
@@ -18,9 +18,8 @@ type t = string [@@deriving show, eq, hash, ord]
  * the same convention than OCaml).
  * However this conflicts with PHP superglobals, hence the special
  * cases below in is_metavar_name.
- * coupling: AST_generic.is_metavar_name
  *)
-let metavar_regexp_string = "^\\(\\$[A-Z_][A-Z_0-9]*\\)$"
+(* previously: regex "^\\(\\$[A-Z_][A-Z_0-9]*\\)$" *)
 
 (*
  * Hacks abusing existing constructs to encode extra constructions.
@@ -45,13 +44,13 @@ let is_metavar_name s =
     (* todo: there's also "$GLOBALS" but this may interface with existing rules*)
     ->
       false
-  | __else__ -> s =~ metavar_regexp_string
+  | __else__ -> AST_generic.is_metavar_name s
 
 (* $...XXX multivariadic metavariables. Note that I initially chose
  * $X... but this leads to parsing conflicts in Javascript.
  *)
-let metavar_ellipsis_regexp_string = "^\\(\\$\\.\\.\\.[A-Z_][A-Z_0-9]*\\)$"
-let is_metavar_ellipsis s = s =~ metavar_ellipsis_regexp_string
+(* previously: regex "^\\(\\$\\.\\.\\.[A-Z_][A-Z_0-9]*\\)$" *)
+let is_metavar_ellipsis s = AST_generic.is_metavar_ellipsis s
 
 (* TODO: Add version where [pcre_compile] is done in advance, or is memoised. *)
 let mvars_of_regexp_string s =


### PR DESCRIPTION
A direct implementation of `is_metavar_name`  and `is_metavar_ellipsis`, which are used **a lot** during matching. The direct implementation should be faster and more GC-friendly.

Quick unreliable benchmarks:

name | main | fix | diff(s) | diff(%) | same-results
-- | -- | -- | -- | -- | --
jellyfin | 81.70 | 79.38 | -2.32 | -2.84% | True
lemur | 35.96 | 33.85 | -2.11 | -5.87% | True
ComfyUI-Custom-Scripts | 14.34 | 14.08 | -0.26 | -1.82% | True
pmd | 105.70 | 90.56 | -15.14 | -14.32% | True
leakcanary | 9.83 | 9.76 | -0.07 | -0.72% | True
