### PR TITLE
Emit a warning when a rule gets deduped because of shared rule-id

### DIFF
--- a/libs/commons/List_.ml
+++ b/libs/commons/List_.ml
@@ -376,7 +376,7 @@ let uniq_by eq xs =
   in
   uniq_by [] xs |> List.rev
 
-let deduplicate_gen ~get_key xs =
+let deduplicate_gen_with_warning ~get_key ~warning xs =
   let tbl = Hashtbl.create (List.length xs) in
   (* We could use List.filter but it's not guaranteed to proceed from
      left to right which would result in not necessarily selecting the first
@@ -384,12 +384,18 @@ let deduplicate_gen ~get_key xs =
   List.fold_left
     (fun acc x ->
       let key = get_key x in
-      if Hashtbl.mem tbl key then acc
-      else (
+      if Hashtbl.mem tbl key then begin
+          warning x;
+          acc
+      end else begin
         Hashtbl.add tbl key ();
-        x :: acc))
+        x :: acc
+      end)
     [] xs
   |> List.rev
+
+let deduplicate_gen ~get_key xs =
+  deduplicate_gen_with_warning ~get_key ~warning:(fun _ -> ()) xs
 
 let deduplicate xs = deduplicate_gen (fun x -> x) xs
 

--- a/libs/commons/List_.mli
+++ b/libs/commons/List_.mli
@@ -113,7 +113,9 @@ val uniq_by : ('a -> 'a -> bool) -> 'a list -> 'a list
 *)
 val deduplicate_gen : get_key:('a -> 'key) -> 'a list -> 'a list
 
-(* Same as 'deduplicate_gen' but use the whole element as a key. *)
+val deduplicate_gen_with_warning : get_key:('a -> 'key) -> warning:('a -> unit) -> 'a list -> 'a list
+
+ (* Same as 'deduplicate_gen' but use the whole element as a key. *)
 val deduplicate : 'a list -> 'a list
 
 (* options and lists *)

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -449,9 +449,14 @@ let check_targets_with_rules
   in
   (* TODO: we should probably warn the user about rules using the same id *)
   let rules =
-    List_.deduplicate_gen
-      ~get_key:(fun r -> Rule_ID.to_string (fst r.Rule.id))
-      rules
+    rules
+    |> List_.deduplicate_gen_with_warning
+        ~get_key:(fun r -> Rule_ID.to_string (fst r.Rule.id))
+        ~warning:(fun r ->
+          Logs.warn (fun m ->
+            m "Duplicated rule id. Rule '%s' (%s) will be ignored."
+              (Rule_ID.to_string (fst r.Rule.id))
+              (Tok.stringpos_of_tok (snd r.Rule.id))))
   in
   let too_many_entries = conf.output_conf.max_log_list_entries in
   Logs.info (fun m ->


### PR DESCRIPTION
Closes #14

Example:

```yaml
$ cat -n rules.yaml       
     1	rules:
     2	- id: rule-A
     3	  pattern: foo($X)
     4	  message: here is $X
     5	  languages: [javascript]
     6	  severity: WARNING
     7	
     8	- id: rule-B
     9	  pattern: foo($X)
    10	  message: here is $X
    11	  languages: [javascript]
    12	  severity: WARNING
    13	
    14	- id: rule-A
    15	  pattern: foo($X)
    16	  message: here is $X
    17	  languages: [javascript]
    18	  severity: WARNING
    19	
    20	- id: rule-A
    21	  pattern: foo($X)
    22	  message: here is $X
    23	  languages: [javascript]
    24	  severity: WARNING
    25	
    26	- id: rule-B
    27	  pattern: foo($X)
    28	  message: here is $X
    29	  languages: [javascript]
    30	  severity: WARNING
 
$ opengrep -c rules.yaml .

┌──────────────┐
│ Opengrep CLI │
└──────────────┘

✔ Opengrep OSS
  ✔ Basic security coverage for first-party code vulnerabilities.

[00.09][WARNING]: Duplicated rule id. Rule 'rule-A' (rules.yaml:14:6) will be ignored.
[00.09][WARNING]: Duplicated rule id. Rule 'rule-A' (rules.yaml:20:6) will be ignored.
[00.09][WARNING]: Duplicated rule id. Rule 'rule-B' (rules.yaml:26:6) will be ignored.


┌─────────────┐
│ Scan Status │
└─────────────┘
  Scanning 3 files tracked by git with 2 Code rules:

  Language   Rules   Files          Origin   Rules
 ──────────────────────────        ────────────────
  js             2       1          Custom       2

...
```