### PR TITLE
Add `timeout` rule option and fix dynamic timeout parameter passing

### DIFF
--- a/cli/src/semgrep/core_runner.py
+++ b/cli/src/semgrep/core_runner.py
@@ -942,10 +942,10 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                 ]
             )
 
-            if allow_rule_timeout_control is not None:
+            if allow_rule_timeout_control:
                 cmd.append("-allow_rule_timeout_control")
 
-            if dynamic_timeout is not None:
+            if dynamic_timeout:
                 cmd.append("-dynamic_timeout")
 
             if max_match_per_file is not None:
@@ -1162,6 +1162,10 @@ Could not find the semgrep-core executable. Your Semgrep install is likely corru
                 bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
                 inline_metavariables=inline_metavariables,
                 max_match_per_file=max_match_per_file,
+                allow_rule_timeout_control=allow_rule_timeout_control,
+                dynamic_timeout=dynamic_timeout,
+                dynamic_timeout_unit_kb=dynamic_timeout_unit_kb,
+                dynamic_timeout_max_multiplier=dynamic_timeout_max_multiplier,
             )
         except SemgrepError as e:
             # Handle Semgrep errors normally

--- a/cli/src/semgrep/run_scan.py
+++ b/cli/src/semgrep/run_scan.py
@@ -957,6 +957,14 @@ def run_scan(
                         baseline_target_mode_config,
                         allow_local_builds=allow_local_builds,
                         prioritize_dependency_graph_generation=prioritize_dependency_graph_generation,
+                        opengrep_ignore_pattern=opengrep_ignore_pattern,
+                        bypass_includes_excludes_for_files=bypass_includes_excludes_for_files,
+                        inline_metavariables=inline_metavariables,
+                        max_match_per_file=max_match_per_file,
+                        allow_rule_timeout_control=allow_rule_timeout_control,
+                        dynamic_timeout=dynamic_timeout,
+                        dynamic_timeout_unit_kb=dynamic_timeout_unit_kb,
+                        dynamic_timeout_max_multiplier=dynamic_timeout_max_multiplier,
                     )
                     rule_matches_by_rule = remove_matches_in_baseline(
                         rule_matches_by_rule,

--- a/interfaces/Rule_options.atd
+++ b/interfaces/Rule_options.atd
@@ -182,6 +182,9 @@ type t = {
   (* override the default taint fixpoint timeout. *)
   ?taint_fixpoint_timeout : float option;
 
+  (* rule-specific timeout. *)
+  ?timeout : float option;
+
   (* adjust timeout according to target file size. *)
   ?dynamic_timeout : bool option;
 

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -68,6 +68,16 @@ let timeout_function (rule : Rule.t) (file : Fpath.t)
             | _ -> dynamic_timeout
           in
 
+          let timeout =
+            match allow_rule_timeout_control, rule.Rule.options with
+            | true, Some { timeout = Some tm; _ } ->
+              Log.info (fun m ->
+                  m "setting timeout for %s to %.2fs using a rule override"
+                    !!file tm);
+              tm
+            | _ -> timeout
+          in
+
           if not dynamic_timeout
           then
             Some (timeout, caps)


### PR DESCRIPTION
- fix some bugs where the new dynamic timeout option was not passed properly
- added a new `timeout` option in rules, requiring `--allow-rule-timeout-control` as usual