### PR TITLE
Remove Semgrep's changelog folder

### DIFF
--- a/changelog.d/README
+++ b/changelog.d/README
@@ -1,9 +1,0 @@
-Valid suffixes:
-
-- .added
-- .changed
-- .fixed
-- .infra
-
-For details on changelog management, see the online documentation:
-https://semgrep.dev/docs/contributing/contributing-code/#adding-a-changelog-entry

--- a/changelog.d/gh-1234.example
+++ b/changelog.d/gh-1234.example
@@ -1,1 +1,0 @@
-Fix emojis absorbed by the [fleeb](https://rickandmorty.fandom.com/wiki/Fleeb) generator


### PR DESCRIPTION
This only contains the latest (at fork time) anyway, and we don't use it at all.