### PR TITLE
Cancel taint on no sinks or sources

### DIFF
--- a/src/engine/Match_taint_spec.mli
+++ b/src/engine/Match_taint_spec.mli
@@ -43,7 +43,7 @@ val taint_config_of_rule :
   Fpath.t ->
   AST_generic.program * Tok.location list ->
   Rule.taint_rule ->
-  Taint_rule_inst.t * spec_matches * Matching_explanation.t list
+  (Taint_rule_inst.t * spec_matches * Matching_explanation.t list) option
 
 (* Exposed for Pro *)
 

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -32,8 +32,8 @@ val check_rules :
   match_hook:(Core_match.t list -> Core_match.t list) ->
   per_rule_boilerplate_fn:
     (Rule.rule ->
-    (unit -> Core_profiling.rule_profiling Core_result.match_result) ->
-    Core_profiling.rule_profiling Core_result.match_result) ->
+    (unit -> Core_profiling.rule_profiling Core_result.match_result option) ->
+    Core_profiling.rule_profiling Core_result.match_result option) ->
   Rule.taint_rule list ->
   Match_env.xconfig ->
   Xtarget.t ->

--- a/src/engine/tests/Test_dataflow_tainting.ml
+++ b/src/engine/tests/Test_dataflow_tainting.ml
@@ -70,6 +70,7 @@ let test_dfg_tainting rules_file file =
   let taint_inst, spec_matches, _exps =
     Match_taint_spec.taint_config_of_rule ~per_file_formula_cache:tbl xconf lang
       file (ast, []) rule
+    |> Option.get
   in
   UCommon.pr2 "\nSources";
   UCommon.pr2 "-------";

--- a/src/engine/tests/Unit_engine.ml
+++ b/src/engine/tests/Unit_engine.ml
@@ -659,11 +659,11 @@ let tainting_test (lang : Lang.t) (rules_file : Fpath.t) (file : Fpath.t) =
            in
            match results with
            | [ res ] -> res.matches
+           | [] -> []
            (* By construction, `check_rules` should only return the same number of results as rules it
               was initially given.
               So this case is impossible.
            *)
-           | []
            | _ :: _ :: _ ->
                raise Impossible)
   in


### PR DESCRIPTION
While tainting, when there are no matches for a sink or a source, cancel the rule early.

co-author: @corneliuhoffman