### PR TITLE
C/C++: allow for macros in structs

### DIFF
--- a/src/rule/Lang.ml
+++ b/src/rule/Lang.ml
@@ -94,8 +94,17 @@ let has_tag tag_name =
          if List.mem tag_name x.tags then Hashtbl.add tbl x.id ());
   fun lang -> Hashtbl.mem tbl lang
 
-let is_js = has_tag "is_js"
 let is_proprietary = has_tag "is_proprietary"
+
+let is_js lang =
+  match lang with
+  | Js | Ts -> true
+  | _ -> false
+
+let is_c_cpp lang =
+  match lang with
+  | C | Cpp -> true
+  |_ -> false
 
 (*****************************************************************************)
 (* Helpers *)

--- a/src/rule/Lang.mli
+++ b/src/rule/Lang.mli
@@ -139,6 +139,7 @@ val lang_of_filename_exn : Fpath.t -> t
 
 (* accept any variants *)
 val is_js : t -> bool
+val is_c_cpp : t -> bool
 
 (* accept any variants *)
 val is_proprietary : t -> bool

--- a/tests/parsing/c/macro-in-struct.c
+++ b/tests/parsing/c/macro-in-struct.c
@@ -1,0 +1,8 @@
+// adapted from OpenSSL
+
+struct some_struct {
+    
+# define SOME_CONSTANT 0x01
+    int flags;                  /* flags for internal use */
+};
+


### PR DESCRIPTION
**Before:** Naming raised `Common.Impossible` on code like this:

```
struct some_struct { 
# define SOME_CONSTANT 0x01
    int flags;                  /* flags for internal use */
};
```

**Reason:** macros during naming are treated similarly to functions, and the naming code does not allow for functions in structs in C.

**After:** Values defined inside structs are resolved as `EnclosedVar`, while macors are resolved as `Global`.

**Additionally:** A perf improvement: we don't need to make an expensive hashtable lookup to determine if a language is JS-like (meaning it is `Js` or `Ts`). :turtle: :snail: 