### PR TITLE
Vb.net: add partial parsing results

### DIFF
--- a/languages/vbnet/Unit_vbnet_parser.ml
+++ b/languages/vbnet/Unit_vbnet_parser.ml
@@ -11,25 +11,58 @@ let (>/>) (s : string) (p : 'a P.parser) : unit =
   assert (List.length r = 0
           || (List.hd r).P.next |> List.length > 1)
 
+let is_ok (s : string) : bool =
+  match P.tokenize_and_parse_string P.compilation_unit s with
+  | Ok _ -> true
+  | _ -> false
+
+let is_partial (s : string) : bool =
+  match P.tokenize_and_parse_string P.compilation_unit s with
+  | Partial _ -> true
+  | _ -> false
+
 let tests =
   Testo.categorize "parsing_vbnet"
   [
     Testo.create "parser smoke test" (fun () ->
-        "2 + ... + foo(1, $A, A$)"
-        >>> P.expression;
+      "2 + ... + foo(1, $A, A$)"
+      >>> P.expression;
 
-        "(2 + (3 + 4)"
-        >/> P.expression;
+      "(2 + (3 + 4)"
+      >/> P.expression;
 
-        "foo. ... (\"a\"\"b\")"
-        >>> P.expression;
+      "foo. ... (\"a\"\"b\")"
+      >>> P.expression;
 
-        "<a><b></b></a>.foo()"
-        >>> P.expression;
+      "<a><b></b></a>.foo()"
+      >>> P.expression;
 
-        {| $"hello{2 + 2 & "aa" & $"aa{b}"}""" |}
-        >>> P.expression;
+      {| $"hello{2 + 2 & "aa" & $"aa{b}"}""" |}
+      >>> P.expression;
 
-        "If (a := 1, b := 2) Then x = not await 4 : Exit Sub Else <foo></foo>"
-        >>> P.single_line_statement
-  )]
+      "If (a := 1, b := 2) Then x = not await 4 : Exit Sub Else <foo></foo>"
+      >>> P.single_line_statement);
+
+    Testo.create "partial result smoke test" (fun () ->
+        assert (is_ok "Class c \n End Class");
+        assert (is_ok "Class c \n Class d \n End Class \n End Class");
+        assert (is_ok "Class c \n Sub foo \n End Sub \n End Class");
+        assert (is_partial "Class c \n Class d \n End Class");
+        assert (is_ok "Class c \n Sub foo \n End Class"); (* tricky: declaration without body is ok *)
+        assert (is_ok "Class c \n Sub foo \n x = 1 \n End Sub \n End Class");
+        assert (is_partial "Class c \n Sub foo \n x = 1 \n xxx yyy zzz \n End Sub \n End Class");
+        assert (is_ok "Namespace n \n Class c \n End Class \n End Namespace");
+        assert (is_partial "Namespace n \n Class c xx yyy zzz \n End Class \n End Namespace");
+        assert (is_partial "Namespace n \n Class c \n End Class \n xxx yyy zzz \n End Namespace");
+        assert (is_ok "Module c \n End Module");
+        assert (is_ok "Module c \n Module d \n End Module \n End Module");
+        assert (is_ok "Module c \n Sub foo \n End Sub \n End Module");
+        assert (is_partial "Module c \n Module d \n End Module");
+        assert (is_ok "Module c \n Sub foo \n x = 1 \n End Sub \n End Module");
+        assert (is_partial "Module c \n Sub foo \n x = 1 \n xxx yyy zzz \n End Sub \n End Module");
+        assert (is_ok "Namespace c \n End Namespace");
+        assert (is_ok "Namespace n \n Module c \n End Module \n End Namespace");
+        assert (is_partial "Namespace n \n Module c xx yyy zzz \n End Module \n End Namespace");
+        assert (is_partial "Namespace n \n Module c \n End Module \n xxx yyy zzz \n End Namespace")
+      )
+  ]

--- a/languages/vbnet/Vbnet_token.ml
+++ b/languages/vbnet/Vbnet_token.ml
@@ -33,6 +33,11 @@ let token_ghost (tok : t) : bool =
   | { kind = LineTerminator; _ } -> true
   | _ -> false
 
+let token_line_terminator (tok : t) : bool =
+  match tok with
+  | { kind = LineTerminator; _ } -> true
+  | _ -> false
+
 let token_match (s : string) (tok : t) : bool =
   match s, tok with
   | "<IDENT>", { kind = Identifier; _ }


### PR DESCRIPTION
# Support for VB.NET part 4 (add partial parsing results)

To make the process of reviewing easier, the support for VB.NET will be added in steps. This is step 4: **add partial aprsing results**. This PR merges to the `mpir/vbnet` branch. Only when all parts are reviewed, I will merge it with `main`.

Notes:

1. This PR introduces a crude mechanism of error handling. We do not actually recover from errors, but try to parse up to (not including) the first element with an error. We can backtrack from namespaces, classes, modules, and interfaces, while we throw away all the inner entities (functions, properties, delegates, etc.) that contain the error.

For example, the file

```vb.net
Namespace SomeNamespace

Class C1
  Sub foo : Print("hello") : End Sub
End Class

Class C2
  Sub foo : Print("hello") : End Sub
  Sub foo : xxx yyy zzz : End Sub ' Incorrect syntax!
  Sub foo : Print("hello") : End Sub
End Class

End Namespace
```

is parsed as

```vb.net
Namespace SomeNamespace

Class C1
  Sub foo : Print("hello") : End Sub
End Class

Class C2
  Sub foo : Print("hello") : End Sub
End Class

End Namespace
```

with an additional annotation that it is only partially parsed

2. Since we wanted to avoid restructuring the parser, the parser works as follows: If there is a parse error inside a class, module, namespace or interface (i.e. after eagerly consuming all declarations we do not encounter `End`), we:
  - Remove all further input (so when returning from the recursion, all namespaces, classes, etc on the outside will also not encounter `End` end will continue the backtracking),
  - Set a domain-local flag to indicate that the returned result is partial.