### PR TITLE
Fix for several methods with the same name

### DIFF
--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -247,6 +247,27 @@ let check_fundef (taint_inst : Taint_rule_inst.t) name ctx ?glob_env ?class_name
   let effects = Effects.union env_effects effects in
   (fcfg, effects, mapping)
 
+let get_arity params info lang =
+  let filtered_params =
+    match (lang, info.class_name_str) with
+    (* Python methods: filter out 'self' and 'cls' params *)
+    | Lang.Python, Some _ ->
+        List.filter
+          (function
+            | G.Param { pname = Some (("self" | "cls"), _); _ } -> false
+            | _ -> true)
+          params
+    (* Go methods: filter out ParamReceiver *)
+    | Lang.Go, Some _ ->
+        List.filter
+          (function
+            | G.ParamReceiver _ -> false
+            | _ -> true)
+          params
+    | _ -> params
+  in
+  List.length filtered_params
+
 let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
     ?(signature_db : Shape_and_sig.signature_database option)
     (xconf : Match_env.xconfig) (xtarget : Xtarget.t) =
@@ -293,320 +314,351 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
     Common.with_time (fun () -> lazy_force lazy_ast_and_errors)
   in
   (* TODO: 'debug_taint' should just be part of 'res'
-     * (i.e., add a "debugging" field to 'Report.match_result'). *)
-  match Match_taint_spec.taint_config_of_rule ~per_file_formula_cache xconf lang
-      file (ast, []) rule with
+   * (i.e., add a "debugging" field to 'Report.match_result'). *)
+  match
+    Match_taint_spec.taint_config_of_rule ~per_file_formula_cache xconf lang
+      file (ast, []) rule
+  with
   | None -> None
   | Some (taint_inst, _TODO_debug_taint, expls) ->
-        
+      (* FIXME: This is no longer needed, now we can just check the type 'n'. *)
+      let ctx = ref AST_to_IL.empty_ctx in
+      Visit_function_defs.visit
+        (fun opt_ent _fdef ->
+          match opt_ent with
+          | Some { name = EN (Id (n, _)); _ } ->
+              ctx := AST_to_IL.add_entity_name !ctx n
+          | __else__ -> ())
+        ast;
 
-        (* FIXME: This is no longer needed, now we can just check the type 'n'. *)
-        let ctx = ref AST_to_IL.empty_ctx in
-        Visit_function_defs.visit
-            (fun opt_ent _fdef ->
-            match opt_ent with
-            | Some { name = EN (Id (n, _)); _ } ->
-                ctx := AST_to_IL.add_entity_name !ctx n
-            | __else__ -> ())
-            ast;
+      let glob_env, glob_effects = Taint_input_env.mk_file_env taint_inst ast in
+      record_matches glob_effects;
 
-        let glob_env, glob_effects = Taint_input_env.mk_file_env taint_inst ast in
-        record_matches glob_effects;
+      (* Only use signature database if cross-function taint analysis is enabled *)
+      let final_signature_db =
+        if taint_inst.options.taint_intrafile then (
+          (* Detect object initialization mappings for this file *)
+          let object_mappings =
+            Taint_signature_extractor.detect_object_initialization ast
+              taint_inst.lang
+          in
+          (* Add object mappings to initial signature database *)
+          let initial_signature_db =
+            Shape_and_sig.add_object_mappings
+              (signature_db ||| Shape_and_sig.empty_signature_database ())
+              object_mappings
+          in
 
-       
-  (* Only use signature database if cross-function taint analysis is enabled *)
-  let final_signature_db =
-  if taint_inst.options.taint_intrafile then (
-    (* Detect object initialization mappings for this file *)
-    let object_mappings = Taint_signature_extractor.detect_object_initialization ast taint_inst.lang in
-    (* Add object mappings to initial signature database *)
-    let initial_signature_db = Shape_and_sig.add_object_mappings (signature_db ||| Shape_and_sig.empty_signature_database ()) object_mappings in
-
-    (* Collect function metadata and prepare call graph based ordering. *)
-    let add_info info (infos, info_map) =
-      let infos = info :: infos in
-      let info_map =
-        if Shape_and_sig.FunctionMap.mem info.fn_id info_map then info_map
-        else Shape_and_sig.FunctionMap.add info.fn_id info info_map
-      in
-      (infos, info_map)
-    in
-
-    let collected_infos, info_map =
-      Visit_function_defs.fold_with_class_context
-        (fun (infos, info_map) opt_ent class_name fdef ->
-          match fst fdef.fkind with
-          | LambdaKind
-          | Arrow -> (
-              match opt_ent with
-              | None -> (infos, info_map)
-              | Some _ ->
-                  let opt_name =
-                    let* ent = opt_ent in
-                    AST_to_IL.name_of_entity ent
-                  in
-                  let class_name_il = Option.map AST_to_IL.var_of_name class_name in
-                  let fn_id = Shape_and_sig.{ class_name = class_name_il; name = opt_name } in
-                  let class_name_str =
-                    match class_name with
-                    | Some (G.Id ((str, _), _)) -> Some str
-                    | _ -> None
-                  in
-                  let fdef_il =
-                    AST_to_IL.function_definition taint_inst.lang ~ctx:!ctx fdef
-                  in
-                  let cfg = CFG_build.cfg_of_fdef fdef_il in
-                  let info =
-                    {
-                      fn_id;
-                      opt_name;
-                      class_name_str;
-                      method_properties = [];
-                      cfg;
-                      fdef;
-                      is_lambda_assignment = true;
-                    }
-                  in
-                  add_info info (infos, info_map))
-          | Function
-          | Method
-          | BlockCases ->
-              let opt_name =
-                let* ent = opt_ent in
-                AST_to_IL.name_of_entity ent
-              in
-              (* For Go methods, extract receiver type as class name *)
-              let go_receiver_name =
-                match lang with
-                | Lang.Go -> Function_call_graph.extract_go_receiver_type fdef
-                | _ -> None
-              in
-              let class_name_il =
-                match go_receiver_name with
-                | Some recv_name ->
-                    (* Create IL name from Go receiver type *)
-                    let fake_tok = Tok.unsafe_fake_tok recv_name in
-                    Some
-                      IL.
-                        {
-                          ident = (recv_name, fake_tok);
-                          sid = AST_generic.SId.unsafe_default;
-                          id_info = AST_generic.empty_id_info ();
-                        }
-                | None -> Option.map AST_to_IL.var_of_name class_name
-              in
-              let class_name_str =
-                match go_receiver_name with
-                | Some name -> Some name
-                | None -> (
-                    match class_name with
-                    | Some (G.Id ((str, _), _)) -> Some str
-                    | _ -> None)
-              in
-              let method_properties =
-                match fst fdef.fkind with
-                | Method -> Taint_signature_extractor.extract_method_properties fdef
-                | Function | LambdaKind | Arrow | BlockCases -> []
-              in
-              let fn_id = Shape_and_sig.{ class_name = class_name_il; name = opt_name } in
-              let fdef_il =
-                AST_to_IL.function_definition taint_inst.lang ~ctx:!ctx fdef
-              in
-              let cfg = CFG_build.cfg_of_fdef fdef_il in
-              let info =
-                {
-                  fn_id;
-                  opt_name;
-                  class_name_str;
-                  method_properties;
-                  cfg;
-                  fdef;
-                  is_lambda_assignment = false;
-                }
-              in
-              add_info info (infos, info_map)
-        )
-        ([], Shape_and_sig.FunctionMap.empty) ast
-    in
-    let collected_infos = List.rev collected_infos in
-
-    let call_graph = Function_call_graph.build_call_graph ~lang ~object_mappings ast in
-
-    (* Write call graph to dot file for debugging *)
-    let dot_file = open_out "call_graph.dot" in
-    Function_call_graph.Dot.output_graph dot_file call_graph;
-    close_out dot_file;
-    Log.debug (fun m -> m "TAINT_SIG: Wrote call graph to call_graph.dot");
-
-    let analysis_order =
-      Function_call_graph.Topo.fold (fun fn acc -> fn :: acc) call_graph []
-      |> List.rev
-    in
-
-    Log.debug (fun m ->
-        let names =
-          analysis_order
-          |> List.map Shape_and_sig.show_fn_id
-          |> String.concat " -> "
-        in
-        m "TAINT_SIG: analysis order: %s" names);
-
-    let process_fun_info info db =
-      let log_name = Option.map IL.str_of_name info.opt_name ||| "???" in
-      Log.info (fun m ->
-          m
-            "Match_tainting_mode:\n\
-             --------------------\n\
-             Extracting signature: %s\n\
-             --------------------"
-            log_name);
-      let updated_db, _signature =
-        Taint_signature_extractor.extract_signature_with_file_context
-          ~db taint_inst ~name:info.fn_id ~method_properties:info.method_properties
-          info.cfg ast
-      in
-      if info.is_lambda_assignment then updated_db
-      else (
-        let _flow, fdef_effects, _mapping =
-          check_fundef taint_inst info.fn_id !ctx ~glob_env
-            ?class_name:info.class_name_str ~signature_db:updated_db info.fdef
-        in
-        record_matches fdef_effects;
-        updated_db)
-    in
-
-    let signature_db_after_order =
-      List.fold_left
-        (fun db fn_id ->
-          match Shape_and_sig.FunctionMap.find_opt fn_id info_map with
-          | None -> db
-          | Some info ->
-              process_fun_info info db)
-        initial_signature_db analysis_order
-    in
-
-    let final_signature_db =
-      List.fold_left
-        (fun db info ->
-            process_fun_info info db)
-        signature_db_after_order collected_infos
-    in
-    Some final_signature_db
-  ) else (
-    (* Cross-function taint analysis disabled: use main branch behavior *)
-    Visit_function_defs.visit
-      (fun opt_ent fdef ->
-        match fst fdef.fkind with
-        | LambdaKind
-        | Arrow ->
-            (* We do not need to analyze lambdas here, they will be analyzed
-               together with their enclosing function. This would just duplicate
-               work. *)
-            ()
-        | Function
-        | Method
-        | BlockCases ->
-            let opt_name =
-              let* ent = opt_ent in
-              AST_to_IL.name_of_entity ent
+          (* Collect function metadata and prepare call graph based ordering. *)
+          let add_info info (infos, info_map) =
+            let infos = info :: infos in
+            let info_map =
+              if Shape_and_sig.FunctionMap.mem info.fn_id info_map then info_map
+              else Shape_and_sig.FunctionMap.add info.fn_id info info_map
             in
-            let name = Shape_and_sig.{ class_name = None; name = opt_name } in
+            (infos, info_map)
+          in
+
+          let collected_infos, info_map =
+            Visit_function_defs.fold_with_class_context
+              (fun (infos, info_map) opt_ent class_name fdef ->
+                match fst fdef.fkind with
+                | LambdaKind
+                | Arrow -> (
+                    match opt_ent with
+                    | None -> (infos, info_map)
+                    | Some _ ->
+                        let opt_name =
+                          let* ent = opt_ent in
+                          AST_to_IL.name_of_entity ent
+                        in
+                        let class_name_il =
+                          Option.map AST_to_IL.var_of_name class_name
+                        in
+                        let fn_id =
+                          Shape_and_sig.
+                            { class_name = class_name_il; name = opt_name }
+                        in
+                        let class_name_str =
+                          match class_name with
+                          | Some (G.Id ((str, _), _)) -> Some str
+                          | _ -> None
+                        in
+                        let fdef_il =
+                          AST_to_IL.function_definition taint_inst.lang
+                            ~ctx:!ctx fdef
+                        in
+                        let cfg = CFG_build.cfg_of_fdef fdef_il in
+                        let info =
+                          {
+                            fn_id;
+                            opt_name;
+                            class_name_str;
+                            method_properties = [];
+                            cfg;
+                            fdef;
+                            is_lambda_assignment = true;
+                          }
+                        in
+                        add_info info (infos, info_map))
+                | Function
+                | Method
+                | BlockCases ->
+                    let opt_name =
+                      let* ent = opt_ent in
+                      AST_to_IL.name_of_entity ent
+                    in
+                    (* For Go methods, extract receiver type as class name *)
+                    let go_receiver_name =
+                      match lang with
+                      | Lang.Go ->
+                          Function_call_graph.extract_go_receiver_type fdef
+                      | _ -> None
+                    in
+                    let class_name_il =
+                      match go_receiver_name with
+                      | Some recv_name ->
+                          (* Create IL name from Go receiver type *)
+                          let fake_tok = Tok.unsafe_fake_tok recv_name in
+                          Some
+                            IL.
+                              {
+                                ident = (recv_name, fake_tok);
+                                sid = AST_generic.SId.unsafe_default;
+                                id_info = AST_generic.empty_id_info ();
+                              }
+                      | None -> Option.map AST_to_IL.var_of_name class_name
+                    in
+                    let class_name_str =
+                      match go_receiver_name with
+                      | Some name -> Some name
+                      | None -> (
+                          match class_name with
+                          | Some (G.Id ((str, _), _)) -> Some str
+                          | _ -> None)
+                    in
+                    let method_properties =
+                      match fst fdef.fkind with
+                      | Method ->
+                          Taint_signature_extractor.extract_method_properties
+                            fdef
+                      | Function
+                      | LambdaKind
+                      | Arrow
+                      | BlockCases ->
+                          []
+                    in
+                    let fn_id =
+                      Shape_and_sig.
+                        { class_name = class_name_il; name = opt_name }
+                    in
+                    let fdef_il =
+                      AST_to_IL.function_definition taint_inst.lang ~ctx:!ctx
+                        fdef
+                    in
+                    let cfg = CFG_build.cfg_of_fdef fdef_il in
+                    let info =
+                      {
+                        fn_id;
+                        opt_name;
+                        class_name_str;
+                        method_properties;
+                        cfg;
+                        fdef;
+                        is_lambda_assignment = false;
+                      }
+                    in
+                    add_info info (infos, info_map))
+              ([], Shape_and_sig.FunctionMap.empty)
+              ast
+          in
+          let collected_infos = List.rev collected_infos in
+
+          let call_graph =
+            Function_call_graph.build_call_graph ~lang ~object_mappings ast
+          in
+
+          (* Write call graph to dot file for debugging *)
+          let dot_file = open_out "call_graph.dot" in
+          Function_call_graph.Dot.output_graph dot_file call_graph;
+          close_out dot_file;
+          Log.debug (fun m -> m "TAINT_SIG: Wrote call graph to call_graph.dot");
+
+          let analysis_order =
+            Function_call_graph.Topo.fold
+              (fun fn acc -> fn :: acc)
+              call_graph []
+            |> List.rev
+          in
+
+          Log.debug (fun m ->
+              let names =
+                analysis_order
+                |> List.map Shape_and_sig.show_fn_id
+                |> String.concat " -> "
+              in
+              m "TAINT_SIG: analysis order: %s" names);
+
+          let process_fun_info info db =
+            let log_name = Option.map IL.str_of_name info.opt_name ||| "???" in
             Log.info (fun m ->
                 m
                   "Match_tainting_mode:\n\
                    --------------------\n\
-                   Checking func def: %s\n\
+                   Extracting signature: %s\n\
                    --------------------"
-                  (Option.map IL.str_of_name opt_name ||| "???"));
-            let _flow, fdef_effects, _mapping =
-              check_fundef taint_inst name !ctx ~glob_env fdef
+                  log_name);
+            let params = Tok.unbracket info.fdef.fparams in
+            let arity = get_arity params info lang in
+            let updated_db, _signature =
+              Taint_signature_extractor.extract_signature_with_file_context
+                ~arity ~db taint_inst ~name:info.fn_id
+                ~method_properties:info.method_properties info.cfg ast
             in
-            record_matches fdef_effects)
-      ast;
-    None
-  )
-  in
+            if info.is_lambda_assignment then updated_db
+            else
+              let _flow, fdef_effects, _mapping =
+                check_fundef taint_inst info.fn_id !ctx ~glob_env
+                  ?class_name:info.class_name_str ~signature_db:updated_db
+                  info.fdef
+              in
+              record_matches fdef_effects;
+              updated_db
+          in
 
-  (* Check execution of statements during object initialization. *)
-  Visit_class_defs.visit
-    (fun opt_ent cdef ->
-      let opt_name =
-        let* ent = opt_ent in
-        AST_to_IL.name_of_entity ent
-      in
-      let name = Shape_and_sig.{ class_name = None; name = opt_name } in
-      let fields =
-        cdef.G.cbody |> Tok.unbracket
-        |> List_.map (function G.F x -> x)
-        |> G.stmt1
-      in
-      let stmts = AST_to_IL.stmt taint_inst.lang fields in
-      let cfg, lambdas = CFG_build.cfg_of_stmts stmts in
-      Log.info (fun m ->
-          m
-            "Match_tainting_mode:\n\
-             --------------------\n\
-             Checking object initialization: %s\n\
-             --------------------"
-            (Option.map IL.str_of_name opt_name ||| "???"));
-      let init_effects, _mapping =
-        Dataflow_tainting.fixpoint taint_inst ~name ?signature_db:final_signature_db
-          IL.{ params = []; cfg; lambdas }
-      in
-      record_matches init_effects)
-    ast;
+          let signature_db_after_order =
+            List.fold_left
+              (fun db fn_id ->
+                match Shape_and_sig.FunctionMap.find_opt fn_id info_map with
+                | None -> db
+                | Some info -> process_fun_info info db)
+              initial_signature_db analysis_order
+          in
 
-  (* Check the top-level statements.
-   * In scripting languages it is not unusual to write code outside
-   * function declarations and we want to check this too. We simply
-   * treat the program itself as an anonymous function. *)
-  let (), match_time =
-    Common.with_time (fun () ->
-        let xs = AST_to_IL.stmt taint_inst.lang (G.stmt1 ast) in
-        let cfg, lambdas = CFG_build.cfg_of_stmts xs in
-        Log.info (fun m ->
-            m
-              "Match_tainting_mode:\n\
-               --------------------\n\
-               Checking top-level program\n\
-               --------------------");
-        let top_effects, _mapping =
-          Dataflow_tainting.fixpoint taint_inst ?signature_db:final_signature_db
-            IL.{ params = []; cfg; lambdas }
-        in
-        record_matches top_effects)
-  in
-  let matches =
-    !matches
-    (* same post-processing as for search-mode in Match_rules.ml *)
-    |> PM.uniq
-    |> PM.no_submatches (* see "Taint-tracking via ranges" *) |> match_hook
-  in
+          let final_signature_db =
+            List.fold_left
+              (fun db info -> process_fun_info info db)
+              signature_db_after_order collected_infos
+          in
+          Some final_signature_db)
+        else (
+          (* Cross-function taint analysis disabled: use main branch behavior *)
+          Visit_function_defs.visit
+            (fun opt_ent fdef ->
+              match fst fdef.fkind with
+              | LambdaKind
+              | Arrow ->
+                  (* We do not need to analyze lambdas here, they will be analyzed
+               together with their enclosing function. This would just duplicate
+               work. *)
+                  ()
+              | Function
+              | Method
+              | BlockCases ->
+                  let opt_name =
+                    let* ent = opt_ent in
+                    AST_to_IL.name_of_entity ent
+                  in
+                  let name =
+                    Shape_and_sig.{ class_name = None; name = opt_name }
+                  in
+                  Log.info (fun m ->
+                      m
+                        "Match_tainting_mode:\n\
+                         --------------------\n\
+                         Checking func def: %s\n\
+                         --------------------"
+                        (Option.map IL.str_of_name opt_name ||| "???"));
+                  let _flow, fdef_effects, _mapping =
+                    check_fundef taint_inst name !ctx ~glob_env fdef
+                  in
+                  record_matches fdef_effects)
+            ast;
+          None)
+      in
 
-  let errors = Parse_target.errors_from_skipped_tokens skipped_tokens in
-  let report =
-    RP.mk_match_result matches errors
-      {
-        Core_profiling.rule_id = fst rule.R.id;
-        rule_parse_time = parse_time;
-        rule_match_time = match_time;
-      }
-  in
-  let explanations =
-    if xconf.matching_explanations then
-      [
-        {
-          ME.op = OutJ.Taint;
-          children = expls;
-          matches = report.matches;
-          pos = snd rule.id;
-          extra = None;
-        };
-      ]
-    else []
-  in
-  let report = { report with explanations } in
-  Some report
+      (* Check execution of statements during object initialization. *)
+      Visit_class_defs.visit
+        (fun opt_ent cdef ->
+          let opt_name =
+            let* ent = opt_ent in
+            AST_to_IL.name_of_entity ent
+          in
+          let name = Shape_and_sig.{ class_name = None; name = opt_name } in
+          let fields =
+            cdef.G.cbody |> Tok.unbracket
+            |> List_.map (function G.F x -> x)
+            |> G.stmt1
+          in
+          let stmts = AST_to_IL.stmt taint_inst.lang fields in
+          let cfg, lambdas = CFG_build.cfg_of_stmts stmts in
+          Log.info (fun m ->
+              m
+                "Match_tainting_mode:\n\
+                 --------------------\n\
+                 Checking object initialization: %s\n\
+                 --------------------"
+                (Option.map IL.str_of_name opt_name ||| "???"));
+          let init_effects, _mapping =
+            Dataflow_tainting.fixpoint taint_inst ~name
+              ?signature_db:final_signature_db
+              IL.{ params = []; cfg; lambdas }
+          in
+          record_matches init_effects)
+        ast;
+
+      (* Check the top-level statements.
+       * In scripting languages it is not unusual to write code outside
+       * function declarations and we want to check this too. We simply
+       * treat the program itself as an anonymous function. *)
+      let (), match_time =
+        Common.with_time (fun () ->
+            let xs = AST_to_IL.stmt taint_inst.lang (G.stmt1 ast) in
+            let cfg, lambdas = CFG_build.cfg_of_stmts xs in
+            Log.info (fun m ->
+                m
+                  "Match_tainting_mode:\n\
+                   --------------------\n\
+                   Checking top-level program\n\
+                   --------------------");
+            let top_effects, _mapping =
+              Dataflow_tainting.fixpoint taint_inst
+                ?signature_db:final_signature_db
+                IL.{ params = []; cfg; lambdas }
+            in
+            record_matches top_effects)
+      in
+      let matches =
+        !matches
+        (* same post-processing as for search-mode in Match_rules.ml *)
+        |> PM.uniq
+        |> PM.no_submatches (* see "Taint-tracking via ranges" *) |> match_hook
+      in
+
+      let errors = Parse_target.errors_from_skipped_tokens skipped_tokens in
+      let report =
+        RP.mk_match_result matches errors
+          {
+            Core_profiling.rule_id = fst rule.R.id;
+            rule_parse_time = parse_time;
+            rule_match_time = match_time;
+          }
+      in
+      let explanations =
+        if xconf.matching_explanations then
+          [
+            {
+              ME.op = OutJ.Taint;
+              children = expls;
+              matches = report.matches;
+              pos = snd rule.id;
+              extra = None;
+            };
+          ]
+        else []
+      in
+      let report = { report with explanations } in
+      Some report
 
 let check_rules ~match_hook
     ~(per_rule_boilerplate_fn :
@@ -618,31 +670,46 @@ let check_rules ~match_hook
     Core_profiling.rule_profiling Core_result.match_result list =
   (* Check for language support warnings when taint_intrafile is enabled *)
   (Dataflow_tainting.reset_constructor ();
-  match rules with
-  | rule :: _ ->
-      (* Check if any rule has taint_intrafile enabled *)
-      let has_taint_intrafile = 
-        match rule.options with
-        | Some opts -> opts.taint_intrafile
-        | None -> xconf.config.taint_intrafile
-      in
-      if has_taint_intrafile then (
-        (* Warn for unsupported languages *)
-        let lang = xtarget.xlang |> Xlang.to_lang_exn in
-        match lang with
-        | Lang.Apex | Lang.C | Lang.Cpp | Lang.Csharp | Lang.Elixir | Lang.Go 
-        | Lang.Java | Lang.Js | Lang.Julia | Lang.Kotlin | Lang.Lua 
-        | Lang.Python | Lang.Ruby | Lang.Rust | Lang.Scala 
-        | Lang.Swift | Lang.Ts ->
-            (* Known supported languages - no warning *)
-            ()
-        | other_lang ->
-            (* Unknown or unsupported language - warn user *)
-            Logs.warn (fun m ->
-                m "Cross-function taint analysis (--taint-intrafile) may not be fully supported for %s. Results may be limited to intraprocedural analysis only."
-                  (Lang.to_string other_lang))
-      )
-  | [] -> ());
+   match rules with
+   | rule :: _ -> (
+       (* Check if any rule has taint_intrafile enabled *)
+       let has_taint_intrafile =
+         match rule.options with
+         | Some opts -> opts.taint_intrafile
+         | None -> xconf.config.taint_intrafile
+       in
+       if has_taint_intrafile then
+         (* Warn for unsupported languages *)
+         let lang = xtarget.xlang |> Xlang.to_lang_exn in
+         match lang with
+         | Lang.Apex
+         | Lang.C
+         | Lang.Cpp
+         | Lang.Csharp
+         | Lang.Elixir
+         | Lang.Go
+         | Lang.Java
+         | Lang.Js
+         | Lang.Julia
+         | Lang.Kotlin
+         | Lang.Lua
+         | Lang.Python
+         | Lang.Ruby
+         | Lang.Rust
+         | Lang.Scala
+         | Lang.Swift
+         | Lang.Ts ->
+             (* Known supported languages - no warning *)
+             ()
+         | other_lang ->
+             (* Unknown or unsupported language - warn user *)
+             Logs.warn (fun m ->
+                 m
+                   "Cross-function taint analysis (--taint-intrafile) may not \
+                    be fully supported for %s. Results may be limited to \
+                    intraprocedural analysis only."
+                   (Lang.to_string other_lang)))
+   | [] -> ());
 
   (* We create a "formula cache" here, before dealing with individual rules, to
      permit sharing of matches for sources, sanitizers, propagators, and sinks
@@ -656,8 +723,7 @@ let check_rules ~match_hook
   in
 
   rules
-  |> List.filter_map
-       (fun rule ->
+  |> List.filter_map (fun rule ->
          let xconf =
            Match_env.adjust_xconfig_with_rule_options xconf rule.R.options
          in

--- a/src/tainting/Function_call_graph.ml
+++ b/src/tainting/Function_call_graph.ml
@@ -1,12 +1,7 @@
 open Common
 module G = AST_generic
 module Log = Log_tainting.Log
-
-(* Use the same function identifier type as the signature database *)
-type fn_id = Shape_and_sig.fn_id = {
-  class_name : IL.name option;
-  name : IL.name option;
-}
+open Shape_and_sig
 
 (* Type for function information including AST node *)
 type func_info = {
@@ -15,6 +10,14 @@ type func_info = {
   fdef : G.function_definition;
 }
 
+let compare_as_str f1 f2 =
+  let compare_il_name n1 n2 =
+    String.compare (fst n1.IL.ident) (fst n2.IL.ident)
+  in
+  let cmp_opt = Option.compare compare_il_name in
+  let c1 = cmp_opt f1.class_name f2.class_name in
+  if c1 <> 0 then c1 else cmp_opt f1.name f2.name
+
 (* OCamlgraph: Define vertex module for functions *)
 module FuncVertex = struct
   type t = fn_id
@@ -22,15 +25,22 @@ module FuncVertex = struct
   (* Compare by string name only (same as signature database) to handle
      cases where call site and definition have different SIds *)
   let compare f1 f2 =
-    let compare_il_name n1 n2 = String.compare (fst n1.IL.ident) (fst n2.IL.ident) in
+    let compare_il_name n1 n2 =
+      let st = String.compare (fst n1.IL.ident) (fst n2.IL.ident) in
+      if st <> 0 then st else Tok.compare_pos (snd n1.IL.ident) (snd n2.IL.ident)
+    in
     let cmp_opt = Option.compare compare_il_name in
     let c1 = cmp_opt f1.class_name f2.class_name in
     if c1 <> 0 then c1 else cmp_opt f1.name f2.name
 
   let hash (f : fn_id) =
-    let h1 = Option.fold ~none:0 ~some:(fun n -> Hashtbl.hash (fst n.IL.ident)) f.name in
+    let h1 =
+      Option.fold ~none:0 ~some:(fun n -> Hashtbl.hash (fst n.IL.ident)) f.name
+    in
     let h2 =
-      Option.fold ~none:0 ~some:(fun c -> Hashtbl.hash (fst c.IL.ident)) f.class_name
+      Option.fold ~none:0
+        ~some:(fun c -> Hashtbl.hash (fst c.IL.ident))
+        f.class_name
     in
     Hashtbl.hash (h1, h2)
 
@@ -50,16 +60,20 @@ module Dot = Graph.Graphviz.Dot (struct
 
   let graph_attributes _ = []
   let default_vertex_attributes _ = []
+
   let vertex_name v =
-    let class_part = match v.class_name with
+    let class_part =
+      match v.class_name with
       | Some c -> fst c.IL.ident ^ "."
       | None -> ""
     in
-    let name = match v.name with
+    let name =
+      match v.name with
       | Some n -> fst n.IL.ident
       | None -> "???"
     in
     Printf.sprintf "\"%s%s\"" class_part name
+
   let vertex_attributes _ = []
   let get_subgraph _ = None
   let default_edge_attributes _ = []
@@ -75,14 +89,20 @@ let extract_go_receiver_type (fdef : G.function_definition) : string option =
     :: _ ->
       Some name
   (* Pointer receiver: func (r *Type) ... *)
-  | G.ParamReceiver { ptype = Some { t = G.TyPointer (_, { t = G.TyN (G.Id ((name, _), _)); _ }); _ }; _ }
+  | G.ParamReceiver
+      {
+        ptype =
+          Some
+            { t = G.TyPointer (_, { t = G.TyN (G.Id ((name, _), _)); _ }); _ };
+        _;
+      }
     :: _ ->
       Some name
   | _ -> None
 
 (* Build fn_id from entity *)
-let fn_id_of_entity ~(lang : Lang.t) (opt_ent : G.entity option) (class_name : G.name option) (fdef : G.function_definition) :
-    fn_id option =
+let fn_id_of_entity ~(lang : Lang.t) (opt_ent : G.entity option)
+    (class_name : G.name option) (fdef : G.function_definition) : fn_id option =
   let* ent = opt_ent in
   let* name = AST_to_IL.name_of_entity ent in
   (* For Go methods, extract receiver type as class name *)
@@ -126,15 +146,24 @@ let extract_calls ?(object_mappings = []) (current_class : IL.name option)
             super#visit_arguments env args
         (* Qualified call: Module.foo() *)
         | G.Call
-            ({ e = G.N (G.IdQualified { name_last = id, _; name_info; _ }); _ }, args)
-          ->
+            ( { e = G.N (G.IdQualified { name_last = id, _; name_info; _ }); _ },
+              args ) ->
             let callee_name = AST_to_IL.var_of_id_info id name_info in
             let fn_id = { class_name = None; name = Some callee_name } in
             calls := fn_id :: !calls;
             (* Continue visiting arguments for nested calls *)
             super#visit_arguments env args
         (* Method call: this.method() or self.method() *)
-        | G.Call ({ e = G.DotAccess ({ e = G.IdSpecial ((G.This | G.Self), _); _ }, _, G.FN (G.Id (id, id_info))); _ }, args) ->
+        | G.Call
+            ( {
+                e =
+                  G.DotAccess
+                    ( { e = G.IdSpecial ((G.This | G.Self), _); _ },
+                      _,
+                      G.FN (G.Id (id, id_info)) );
+                _;
+              },
+              args ) ->
             let method_name = AST_to_IL.var_of_id_info id id_info in
             let fn_id =
               { class_name = current_class; name = Some method_name }
@@ -168,23 +197,21 @@ let extract_calls ?(object_mappings = []) (current_class : IL.name option)
             calls := fn_id :: !calls;
             (* Continue visiting arguments for nested calls *)
             super#visit_arguments env args
-        | G.Call _ ->
-            super#visit_expr env e
-        | _ ->
-            super#visit_expr env e
+        | G.Call _ -> super#visit_expr env e
+        | _ -> super#visit_expr env e
     end
   in
   v#visit_function_definition () fdef;
   (* Deduplicate calls by comparing fn_id *)
   let unique_calls =
-    !calls
-    |> List.sort_uniq (fun f1 f2 -> FuncVertex.compare f1 f2)
+    !calls |> List.sort_uniq (fun f1 f2 -> FuncVertex.compare f1 f2)
   in
   unique_calls
 
 (* Build call graph - Visit_function_defs handles regular functions,
    arrow functions, and lambda assignments like const x = () => {} *)
-let build_call_graph ~(lang : Lang.t) ?(object_mappings = []) (ast : G.program) : FuncGraph.t =
+let build_call_graph ~(lang : Lang.t) ?(object_mappings = []) (ast : G.program)
+    : FuncGraph.t =
   let funcs, graph =
     Visit_function_defs.fold_with_class_context
       (fun (funcs, graph) opt_ent class_name fdef ->
@@ -192,6 +219,15 @@ let build_call_graph ~(lang : Lang.t) ?(object_mappings = []) (ast : G.program) 
         | Some fn_id ->
             let func = { fn_id; entity = opt_ent; fdef } in
             let graph = FuncGraph.add_vertex graph fn_id in
+            (func :: funcs, graph)
+        | None -> (funcs, graph))
+      ([], FuncGraph.empty) ast
+  in
+  let graph =
+    Visit_function_defs.fold_with_class_context
+      (fun graph opt_ent class_name fdef ->
+        match fn_id_of_entity ~lang opt_ent class_name fdef with
+        | Some fn_id ->
             (* Extract calls with object context *)
             (* For Go methods, use the receiver type as current_class *)
             let current_class_il =
@@ -210,18 +246,31 @@ let build_call_graph ~(lang : Lang.t) ?(object_mappings = []) (ast : G.program) 
                   | None -> Option.map AST_to_IL.var_of_name class_name)
               | _ -> Option.map AST_to_IL.var_of_name class_name
             in
-            let callee_fn_ids =
+            let callee_fn_names =
               extract_calls ~object_mappings current_class_il fdef
             in
+            let callee_fn_id =
+              List.fold_left
+                (fun acc x ->
+                  acc
+                  @ List.filter_map
+                      (fun y ->
+                        if Int.equal (compare_as_str x y.fn_id) 0 then
+                          Some y.fn_id
+                        else None)
+                      funcs)
+                [] callee_fn_names
+            in
+
             (* Add edges for each call - edge from callee to caller for bottom-up analysis *)
             let graph =
               List.fold_left
                 (fun g callee_fn_id -> FuncGraph.add_edge g callee_fn_id fn_id)
-                graph callee_fn_ids
+                graph callee_fn_id
             in
-            (func :: funcs, graph)
-        | None -> (funcs, graph))
-      ([], FuncGraph.empty) ast
+            graph
+        | None -> graph)
+      graph ast
   in
 
   (* Add implicit edges from constructors to all methods in the same class.
@@ -229,18 +278,32 @@ let build_call_graph ~(lang : Lang.t) ?(object_mappings = []) (ast : G.program) 
   let graph =
     List.fold_left
       (fun g func ->
-        let func_name = Option.fold ~none:"" ~some:(fun n -> fst n.IL.ident) func.fn_id.name in
-        let class_name_str = Option.map (fun n -> fst n.IL.ident) func.fn_id.class_name in
-        if Object_initialization.is_constructor lang func_name class_name_str then
+        let func_name =
+          Option.fold ~none:"" ~some:(fun n -> fst n.IL.ident) func.fn_id.name
+        in
+        let class_name_str =
+          Option.map (fun n -> fst n.IL.ident) func.fn_id.class_name
+        in
+        if Object_initialization.is_constructor lang func_name class_name_str
+        then
           (* Find all methods in the same class *)
           let same_class_methods =
             List.filter
               (fun other ->
-                let other_name = Option.fold ~none:"" ~some:(fun n -> fst n.IL.ident) other.fn_id.name in
-                let other_class_name_str = Option.map (fun n -> fst n.IL.ident) other.fn_id.class_name in
-                not (Object_initialization.is_constructor lang other_name other_class_name_str)
+                let other_name =
+                  Option.fold ~none:""
+                    ~some:(fun n -> fst n.IL.ident)
+                    other.fn_id.name
+                in
+                let other_class_name_str =
+                  Option.map (fun n -> fst n.IL.ident) other.fn_id.class_name
+                in
+                (not
+                   (Object_initialization.is_constructor lang other_name
+                      other_class_name_str))
                 && Option.equal
-                     (fun n1 n2 -> String.equal (fst n1.IL.ident) (fst n2.IL.ident))
+                     (fun n1 n2 ->
+                       String.equal (fst n1.IL.ident) (fst n2.IL.ident))
                      func.fn_id.class_name other.fn_id.class_name)
               funcs
           in
@@ -254,4 +317,3 @@ let build_call_graph ~(lang : Lang.t) ?(object_mappings = []) (ast : G.program) 
   in
 
   graph
-

--- a/src/tainting/Taint_signature_extractor.mli
+++ b/src/tainting/Taint_signature_extractor.mli
@@ -36,6 +36,7 @@ val mk_global_tracking_without_taint :
 (** Register global variables for tracking without pre-tainting them *)
 
 val extract_signature_with_file_context :
+  arity:int ->
   ?db:signature_database ->
   Taint_rule_inst.t ->
   ?name:Shape_and_sig.fn_id ->
@@ -63,18 +64,12 @@ val extract_method_properties :
 (* Batch extraction *)
 (*****************************************************************************)
 
-val extract_signatures_from_ast :
-  Taint_rule_inst.t ->
-  AST_generic.program ->
-  (Shape_and_sig.fn_id * IL.fun_cfg * AST_generic.expr list) list ->
-  signature_database
-(** Extract signatures from a list of functions using AST context *)
 
 val empty_signature_database : unit -> signature_database
 (** Create an empty signature database *)
 
 val lookup_signature :
-  signature_database -> Shape_and_sig.fn_id -> Shape_and_sig.Signature.t option
+  signature_database -> Shape_and_sig.fn_id -> int -> Shape_and_sig.Signature.t option
 (** Look up a signature by function name *)
 
 val show_signature_database : signature_database -> string

--- a/tests/rules/cross_function_tainting/test_csharp_method_overloading.cs
+++ b/tests/rules/cross_function_tainting/test_csharp_method_overloading.cs
@@ -1,0 +1,33 @@
+class C
+{
+    string data;
+
+    void Process(int first, string second)
+    {
+        this.data = second;
+    }
+    void Process(int number)
+    {
+        this.data = number;
+    }
+
+    void Process(string input)
+    {
+        this.data = input;
+    }
+
+    static void Main()
+    {
+        C c = new C();
+        string tainted = source();
+        c.Process(tainted);
+        // OK: csharp_method_overload not found, double method with this arity
+        sink(c.data);
+        c.Process(2, tainted);
+        // ruleid: csharp_method_overload
+        sink(c.data);
+    }
+
+    static string source() { return "tainted"; }
+    static void sink(string s) { }
+}

--- a/tests/rules/cross_function_tainting/test_csharp_method_overloading.yaml
+++ b/tests/rules/cross_function_tainting/test_csharp_method_overloading.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: csharp_method_overload
+    message: Taint through method overloading
+    languages:
+      - csharp
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
The algo is as follows:
For each call we look for all the funcs/methods that have this name. If more than one has the same arity with the calling function we ignore the def, warn and behave as in no taint-intrafile. Otherwise we pick the one and continue as before. See the new test to see this in action