### PR TITLE
python: both parsers generate same structure of interpolated strings

### DIFF
--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -813,7 +813,7 @@ string:
 
 interpolated:
   | FSTRING_STRING { Str $1 }
-  | FSTRING_LBRACE interpolant fstring_print_spec "}" { InterpolatedString ($1, $2::$3, $4) }
+  | FSTRING_LBRACE interpolant fstring_print_spec "}" { if List.is_empty $3 then $2 else InterpolatedString ($1, $2::$3, $4) }
 
 fstring_print_spec:
   |     fstring_format_clause { $1 }

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -557,13 +557,15 @@ and map_interpolation (env : env) ((v1, v2, v3, v4, v5, v6) : CST.interpolation)
     | Some tok -> Some ((* pattern ![a-z] *) str env tok)
     | None -> None
   in
-  let _format_opt =
+  let format_opt =
     match v5 with
     | Some x -> Some (map_format_specifier env x)
     | None -> None
   in
   let rb = (* "}" *) token env v6 in
-  (lb, e, rb)
+  match format_opt with
+  | None | Some [] -> e
+  | Some xs -> InterpolatedString (lb, xs ,rb)
 
 and map_lambda_parameters (env : env) (x : CST.lambda_parameters) =
   map_parameters_ env x
@@ -947,8 +949,7 @@ and map_string_ (env : env) ((v1, v2, v3) : CST.string_) :
       (fun x ->
         match x with
         | `Interp x ->
-            let _lb, e, _rb = map_interpolation env x in
-            e
+            map_interpolation env x
         | `Esc_interp x ->
             let s = map_escape_interpolation env x in
             Str s


### PR DESCRIPTION
We make both Python parsers output similar generic AST for interpolated strings.

**Before:**

- Tree-sitter ignored format, e.g.

```python
f"pi = {pi:.2f}!"
```

was represented like

```ocaml
Call(IdSpecial((ConcatString(FString("f")), ())),
  [ Arg(L(String(("pi = ",()))));
    Arg(N(Id(("pi", ()), {...} )));
    Arg(L(String(("!", ()))))])), ())]))
```

- Menhir kept the entire interpolation as another string, e.g.:

```ocaml
Call(IdSpecial((ConcatString(FString("f")), ())),
  [ Arg(L(String(("pi = ",()))));
    Call(IdSpecial((ConcatString(FString("f")), ())),
      [ Arg(N(Id(("pi", ()), {...} )));
        Arg(L(String(".2f", ())))
      ]));
    Arg(L(String(("!", ()))))])), ())]))
```

When no format was given, the interpolation was still wrapped in one more layer of `Call (IdSpecial ...)`.

**Problem:**

When the files cannot be parsed with the primary parser, we get a mismatch between the parser used for the pattern and the parser used for the file. Since strings happen in patterns a lot, this was a real problem.

**After:**

Both parsers produce the same generic AST: strings as parsed as in tree-sitter when no format is given (the simpler option) and as in menhir when a format is given.