### PR TITLE
Add `taint_intrafile` param to `ci` command

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -283,6 +283,7 @@ def ci(
     dynamic_timeout: bool = DEFAULT_DYNAMIC_TIMEOUT,
     dynamic_timeout_unit_kb: int = DEFAULT_DYNAMIC_TIMEOUT_UNIT_KB,
     dynamic_timeout_max_multiplier: int = DEFAULT_DYNAMIC_TIMEOUT_MAX_MULTIPLIER,
+    taint_intrafile: bool = False,
 ) -> None:
     state = get_state()
 
@@ -616,6 +617,7 @@ def ci(
         "run_secrets": run_secrets,
         "disable_secrets_validation": disable_secrets_validation_flag,
         "output_handler": output_handler,
+        "taint_intrafile": taint_intrafile,
         "target": [target],
         "pattern": None,
         "lang": None,


### PR DESCRIPTION
Fixes the following error in v1.11.x:

```
  ci() got an unexpected keyword argument 'taint_intrafile'
  Traceback (most recent call last):
    File "/root/.cache/opengrep/v1.11.3/semgrep/commands/wrapper.py", line 37, in wrapper
  TypeError: ci() got an unexpected keyword argument 'taint_intrafile'
  Finished Opengrep scan.
  Exited with non-successful exit code: 2
```

There was also a semgrep text reference that I meant to push a while back, but forgot, so I'm including it here as well.
