### PR TITLE
Bump python version to 3.13 in self-contained binary

### DIFF
--- a/.github/workflows/build-manylinux-binary.yml
+++ b/.github/workflows/build-manylinux-binary.yml
@@ -19,10 +19,11 @@ jobs:
     steps:
       - run: |
           yum update -y
-          yum install -y zip python3.12-pip python3.12 python3.12-devel ccache patchelf
-          alternatives --remove-all python3
-          alternatives --install /usr/bin/python3 python3 /usr/bin/python3.12 1
-          alternatives --auto python3
+          yum install -y zip ccache patchelf 
+          export PATH="/opt/python/cp313-cp313/bin:$PATH"
+          echo "PATH=/opt/python/cp313-cp313/bin:$PATH" >> $GITHUB_ENV
+          # Extract static Python libraries for Nuitka
+          cd /opt/_internal && tar xf static-libs-for-embedding-only.tar.xz
       
       # - run: find / -name "libpython*" #; exit 1
       # - run: yum install -y zip

--- a/.github/workflows/build-osx-binary.yml
+++ b/.github/workflows/build-osx-binary.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           python -m pip install --no-cache-dir --upgrade pipenv
       - name: Install pyinstaller
-        run: pipenv run pip install nuitka==2.7.16 protobuf jaraco.text
+        run: pipenv run pip install nuitka==2.8.9 protobuf jaraco.text
 
       - name: install some dependencies for windows (pyinstaller only)
         run: pipenv run pip install chardet charset-normalizer

--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: windows-2022
     steps:
 
-      - name: Set up Python 3.12.1
+      - name: Set up Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.13'
 
       - name: Query and set SymlinkEvaluation
         shell: pwsh


### PR DESCRIPTION
- Bumps python in nuitka build for manylinux and windows;
- Sets nuitka to latest version in the osx build action.

NOTE: The musl build remains as it was using version 3.12.12-r0. It was not possible to bump the version to 3.13 following he same approach as we did for manylinux at this time (see https://github.com/Nuitka/Nuitka/issues/ 2625).