### PR TITLE
vb: fix comment syntax for --test command on python

### DIFF
--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -37,7 +37,7 @@ from semgrep.verbose_logging import getLogger
 logger = getLogger(__name__)
 
 
-COMMENT_SYNTAXES = (("#", "\n"), ("//", "\n"), ("<!--", "-->"), ("(*", "*)"))
+COMMENT_SYNTAXES = (("#", "\n"), ("//", "\n"), ("<!--", "-->"), ("(*", "*)"), ("'", "\n"))
 SPACE_OR_NO_SPACE = ("", " ")
 TODORULEID = "todoruleid"
 RULEID = "ruleid"


### PR DESCRIPTION
Fix the comment syntax used by the implementation of the `--test` command on the python side (analogue of https://github.com/opengrep/opengrep/blob/main/src/osemgrep/cli_test/Test_annotation.ml#L115 for `--experimental`).