### PR TITLE
Force python 3.13 for osx binary workflow

### DIFF
--- a/.github/workflows/build-osx-binary.yml
+++ b/.github/workflows/build-osx-binary.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Install pipenv
         run: |
           python -m pip install --no-cache-dir --upgrade pipenv
-      - name: Install pyinstaller
+          pipenv --python 3.13
+
+      - name: Install nuitka
         run: pipenv run pip install nuitka==2.8.9 protobuf jaraco.text
 
       - name: install some dependencies for windows (pyinstaller only)


### PR DESCRIPTION
We get errors with 3.14 on both x86 and ARM.

Full error for ARM:

```
Nuitka:   Version '2.8.9' on Python 3.14 (flavor 'Homebrew Python') commercial grade 'not installed'.

...

Nuitka: Running C compilation via Scons.
Nuitka-Scons: Backend C compiler: clang (clang 15.0.0).
Nuitka-Scons: Backend C linking with 481 files (no progress information available for this stage).
Undefined symbols for architecture arm64:
  "__Py_TriggerGC", referenced from:
      _MAKE_ITERATOR in module.__main__.o
      _impl___parents_main__$$36$$$36$$$36$function__7___nuitka_freeze_support in module.__parents_main__.o
      _impl___parents_main__$$36$$$36$$$36$function__7___nuitka_freeze_support in module.__parents_main__.o
      _impl_attr$_cmp$$36$$$36$$$36$function__4__is_comparable_to in module.attr._cmp.o
      _MAKE_ITERATOR in module.attr._funcs.o
      _MAKE_UNPACK_ITERATOR in module.attr._funcs.o
      _MAKE_ITERATOR in module.attr._make.o
      ...
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [/Users/runner/work/opengrep/opengrep/cli/entrypoint.dist/opengrep.bin] Error 1
FATAL: Failed unexpectedly in Scons C backend compilation.
```

Similar for x86:

```
Nuitka: Running C compilation via Scons.
Nuitka-Scons: Backend C compiler: clang (clang 15.0.0).
Nuitka-Scons: Backend C linking with 481 files (no progress information available for this stage).
Undefined symbols for architecture x86_64:
  "__Py_TriggerGC", referenced from:
      _MAKE_ITERATOR in module.__main__.o
      _impl___parents_main__$$36$$$36$$$36$function__7___nuitka_freeze_support in module.__parents_main__.o
      _impl___parents_main__$$36$$$36$$$36$function__7___nuitka_freeze_support in module.__parents_main__.o
      _impl_attr$_cmp$$36$$$36$$$36$function__4__is_comparable_to in module.attr._cmp.o
      _MAKE_ITERATOR in module.attr._funcs.o
      _MAKE_UNPACK_ITERATOR in module.attr._funcs.o
      _MAKE_ITERATOR in module.attr._make.o
      ...
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
scons: *** [/Users/runner/work/opengrep/opengrep/cli/entrypoint.dist/opengrep.bin] Error 1
FATAL: Failed unexpectedly in Scons C backend compilation.
```