### PR TITLE
C#: allow matching on function argument parameters (ref, in, scoped, etc.)

### DIFF
--- a/tests/patterns/csharp/param_attrs.cs
+++ b/tests/patterns/csharp/param_attrs.cs
@@ -1,0 +1,14 @@
+class A
+{
+  // OK:
+  void test1(int x) { }
+
+  // ERROR:
+  int test2(ref readonly int y) { }
+
+  // ERROR:
+  int test3(int x, ref readonly int y) { }
+
+  // OK:
+  int test4(int x, in int y) { }
+}

--- a/tests/patterns/csharp/param_attrs.sgrep
+++ b/tests/patterns/csharp/param_attrs.sgrep
@@ -1,0 +1,1 @@
+$TYPE $FOO(..., ref readonly $TYPE $VAR, ...) { ... }


### PR DESCRIPTION
Supported parameters: `in`, `out`, `ref`, `readonly`, `scoped`, `this`.

Example: `void foo(in int x, ref readonly string y) { ... }`

Previously these were parsed but were not included in the AST