### PR TITLE
Add dump-il to the show command

### DIFF
--- a/src/osemgrep/cli_show/Show_CLI.ml
+++ b/src/osemgrep/cli_show/Show_CLI.ml
@@ -45,6 +45,7 @@ and show_kind =
    * alt: we could accept multiple Files via multiple target_roots *)
   | DumpCST of Fpath.t * Lang.t
   | DumpAST of Fpath.t * Lang.t
+  | DumpIL  of Fpath.t * Lang.t
   | DumpConfig of Rules_config.config_string
   | DumpRuleV2 of Fpath.t
   (* 'semgrep show ???'
@@ -112,6 +113,13 @@ let cmdline_term : conf Term.t =
       | [ "dump-ast"; lang_str; file ] ->
           let lang = Lang.of_string lang_str in
           DumpAST (Fpath.v file, lang)
+      | [ "dump-il"; file ] ->
+          let path = Fpath.v file in
+          let lang = Lang.lang_of_filename_exn path in
+          DumpIL (path, lang)
+      | [ "dump-il"; lang_str; file ] ->
+          let lang = Lang.of_string lang_str in
+          DumpIL (Fpath.v file, lang)
       | [ "dump-pattern"; lang_str; pattern ] ->
           let lang = Lang.of_string lang_str in
           DumpPattern (pattern, lang)
@@ -150,6 +158,8 @@ let man : Cmdliner.Manpage.block list =
     `P
       "Dump the abstract syntax tree of the file (with some names/types \
        resolved)";
+    `Pre "opengrep show dump-il [<LANG>] <FILE>";
+    `P "Dump the internal representation of the file";
     `Pre "opengrep show dump-cst [<LANG>] <FILE>";
     `P "Dump the concrete syntax tree of the file (tree sitter only)";
     `Pre "opengrep show dump-pattern <LANG> <STRING>";

--- a/src/osemgrep/cli_show/Show_CLI.mli
+++ b/src/osemgrep/cli_show/Show_CLI.mli
@@ -23,6 +23,7 @@ and show_kind =
   | DumpPattern of string * Lang.t
   | DumpCST of Fpath.t * Lang.t
   | DumpAST of Fpath.t * Lang.t
+  | DumpIL  of Fpath.t * Lang.t
   | DumpConfig of Rules_config.config_string
   | DumpRuleV2 of Fpath.t
   | DumpEnginePath of bool (* pro = true *)


### PR DESCRIPTION
Adjusted from core. For example:

```
$ cat ../test/test.py
def foo():
 while True:
  x = 3

def bar():
  x = 2

$ opengrep show dump-il ../test/test.py
=== Toplevel ===
{ s =
  (MiscStmt
     (DefStmt
        ({ name =
           (EN
              (Id (("foo", ()),
                 { id_resolved = ref (None);
                   id_resolved_alternatives = ref ([]); id_type = ref (None);
                   id_svalue = ref (None); id_flags = ref (0) }
                 )));
           attrs = []; tparams = None },
         (FuncDef
            { fkind = (Function, ()); fparams = ((), [], ());
              frettype = None;
              fbody =
              (FBStmt
                 { s =
                   (Block
                      ((),
                       [{ s =
                          (While ((),
                             (Cond
                                { e = (L (Bool (true, ()))); e_id = 0;
                                  e_range = None; is_implicit_return = false;
                                  facts = <opaque> }),
                             { s =
                   ...
```