### PR TITLE
Fix double id_flags when printing AST

### DIFF
--- a/libs/ast_generic/Meta_AST.ml
+++ b/libs/ast_generic/Meta_AST.ml
@@ -229,7 +229,6 @@ and vof_id_info
   in
   let bnd = ("id_flags", arg) in
   let bnds = bnd :: bnds in
-  let bnds = bnd :: bnds in
   OCaml.VDict bnds
 
 and vof_xml

--- a/tests/snapshots/semgrep-core/1b426baf9922/stdout
+++ b/tests/snapshots/semgrep-core/1b426baf9922/stdout
@@ -2,21 +2,20 @@ E(
   Call(
     N(
       Id(("foo", ()),
-        {id_flags=Ref(0); id_flags=Ref(0); id_resolved_alternative=Ref(
-         []); id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(
-         None); })),
+        {id_flags=Ref(0); id_resolved_alternative=Ref([]); 
+         id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
     [Arg(Ellipsis(()));
      Arg(
        Call(IdSpecial((Op(Eq), ())),
          [Arg(
             N(
               Id(("$X", ()),
-                {id_flags=Ref(0); id_flags=Ref(0); 
-                 id_resolved_alternative=Ref([]); id_resolved=Ref(None); 
-                 id_type=Ref(None); id_svalue=Ref(None); })));
+                {id_flags=Ref(0); id_resolved_alternative=Ref([]); 
+                 id_resolved=Ref(None); id_type=Ref(None); 
+                 id_svalue=Ref(None); })));
           Arg(
             N(
               Id(("$X", ()),
-                {id_flags=Ref(0); id_flags=Ref(0); 
-                 id_resolved_alternative=Ref([]); id_resolved=Ref(None); 
-                 id_type=Ref(None); id_svalue=Ref(None); })))]))]))
+                {id_flags=Ref(0); id_resolved_alternative=Ref([]); 
+                 id_resolved=Ref(None); id_type=Ref(None); 
+                 id_svalue=Ref(None); })))]))]))

--- a/tests/snapshots/semgrep-core/201a11c8d7a5/stdout
+++ b/tests/snapshots/semgrep-core/201a11c8d7a5/stdout
@@ -6,9 +6,9 @@ Pr(
      ({
        name=EN(
               Id(("foo", ()),
-                {id_flags=Ref(0); id_flags=Ref(0); 
-                 id_resolved_alternative=Ref([]); id_resolved=Ref(None); 
-                 id_type=Ref(None); id_svalue=Ref(None); }));
+                {id_flags=Ref(0); id_resolved_alternative=Ref([]); 
+                 id_resolved=Ref(None); id_type=Ref(None); 
+                 id_svalue=Ref(None); }));
        attrs=[]; tparams=None; },
       FuncDef(
         {fkind=(Function, ()); fparams=[]; frettype=None; 


### PR DESCRIPTION
Before, when printing AST, the key `id_flags` in `id_info` appeared two times:

<img width="383" height="218" alt="Screenshot 2025-12-24 at 14 23 16" src="https://github.com/user-attachments/assets/ae487efe-8059-41e7-bbdf-bccfbd702f0e" />

After, it appears once:

<img width="271" height="130" alt="Screenshot 2025-12-24 at 14 31 11" src="https://github.com/user-attachments/assets/5b761ad0-d7e0-477a-84b6-5ed0421f4bd6" />
