### PR TITLE
Fix: bump cygwin version in windows binary action

### DIFF
--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -61,7 +61,7 @@ jobs:
           path: ${{ env.NUITKA_CACHE_DIR }}
 
       - name: Set-up cygwin
-        uses: cygwin/cygwin-install-action@f61179d72284ceddc397ed07ddb444d82bf9e559 # ratchet:cygwin/cygwin-install-action@master
+        uses: cygwin/cygwin-install-action@f2009323764960f80959895c7bc3bb30210afe4d # ratchet:cygwin/cygwin-install-action@v6
         with:
           install-dir: D:/cygwin
           packages: diffutils,m4,make,mingw64-i686-gcc-core,mingw64-i686-gcc-g++,mingw64-i686-openssl,mingw64-x86_64-gcc-core,mingw64-x86_64-gcc-g++,mingw64-x86_64-openssl=1.0.2u+za-1,patch,perl,rsync,unzip,mingw64-x86_64-libssh2,mingw64-x86_64-nghttp2,mingw64-x86_64-pcre,mingw64-x86_64-pcre2,mingw64-x86_64-win-iconv,mingw64-x86_64-zstd,mingw64-x86_64-gettext,mingw64-x86_64-libidn2,mingw64-x86_64-curl,gnupg2,mingw64-x86_64-gmp,ccache


### PR DESCRIPTION
Windows CI fails with current version (pinned to v5).