### PR TITLE
Dart: Add more tests for tainting

### DIFF
--- a/tests/tainting_rules/dart/arrays_if.dart
+++ b/tests/tainting_rules/dart/arrays_if.dart
@@ -1,0 +1,64 @@
+class TestCases {
+
+  // -------------------------
+  // F
+  // -------------------------
+  void F(Object? x) {
+    // Dart has no tuple patterns, so we simulate them using List checks.
+    if (x is List && x.length == 2 && x[0] is int && x[1] is int) {
+      int y = x[0] as int;
+      int z = x[1] as int;
+
+      // ruleid: taint
+      sink(y);
+    } else {
+      sink(5);
+    }
+  }
+
+  // -------------------------
+  // G
+  // -------------------------
+  void G(Object? x) {
+    // Pattern: ((int y, int z), int w)
+    if (x is List &&
+        x.length == 2 &&
+        x[0] is List &&
+        (x[0] as List).length == 2 &&
+        (x[0] as List)[0] is int &&
+        (x[0] as List)[1] is int &&
+        x[1] is int) {
+      int y = (x[0] as List)[0] as int;
+      int z = (x[0] as List)[1] as int;
+      int w = x[1] as int;
+
+      // ruleid: taint
+      sink(y);
+    } else {
+      // ruleid: taint
+      sink(x);
+    }
+  }
+
+  // -------------------------
+  // H
+  // -------------------------
+  void H(Object? x) {
+    // Pattern: (int y, int z) when sink(y)
+    if (x is List &&
+        x.length == 2 &&
+        x[0] is int &&
+        x[1] is int) {
+      int y = x[0] as int;
+      int z = x[1] as int;
+
+      // ruleid: taint
+      if (sink(y) != null) {
+        // ruleid: taint
+        sink(z);
+      }
+    } else {
+      // default: break
+    }
+  }
+}

--- a/tests/tainting_rules/dart/arrays_if.yaml
+++ b/tests/tainting_rules/dart/arrays_if.yaml
@@ -1,0 +1,16 @@
+
+rules:
+- id: taint
+  mode: taint
+  languages: [dart]
+  message: "tainted"
+  severity: INFO
+  pattern-sources:
+    - patterns:
+        - pattern-inside: |
+            void $F($T $P) {
+              ...
+            }
+        - focus-metavariable: $P
+  pattern-sinks:
+    - pattern: sink($R)

--- a/tests/tainting_rules/dart/try_return.dart
+++ b/tests/tainting_rules/dart/try_return.dart
@@ -1,0 +1,57 @@
+// Translated from java/try_return.java
+
+class Main {
+  // These simulate the Java helper methods
+  String? couldThrow() {
+    // may throw
+    return null;
+  }
+
+  String source() {
+    return "tainted";
+  }
+
+  void sink(String s) {
+    print("sink: $s");
+  }
+
+  // -------------------------
+  // test1
+  // -------------------------
+  String? test1() {
+    String str = "safe";
+    try {
+      // Java: return could_throw();
+      // Dart: method returns String?, so this is valid
+      return couldThrow();
+    } catch (e) {
+      str = source();
+    }
+
+    // ruleid: test
+    sink(str);
+    return null;
+  }
+
+  // -------------------------
+  // test2
+  // -------------------------
+  int? test2() {
+    int cannotThrow = 42;
+    String str = "safe";
+
+    try {
+      // Java: return cannot_throw;
+      // Dart: method returns int?, so this is valid
+      return cannotThrow;
+    }
+    // vvv dead code (preserved exactly)
+    catch (e) {
+      str = source();
+    }
+
+    // OK:
+    sink(str);
+    return null;
+  }
+}

--- a/tests/tainting_rules/dart/try_return.yaml
+++ b/tests/tainting_rules/dart/try_return.yaml
@@ -1,0 +1,12 @@
+
+rules:
+  - id: test
+    languages:
+      - dart
+    message: Test.
+    mode: taint
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source(...)
+    severity: WARNING


### PR DESCRIPTION
Tests translated from C#.

The test for more complicated `case` cannot be translated directly, because Dart lacks this kind of constructs, but we take this opportunity to test representation of arrays