### PR TITLE
Add core flags dump_rule and dump_patterns_of_rule as options in the show command

### DIFF
--- a/src/core_cli/Core_CLI.mli
+++ b/src/core_cli/Core_CLI.mli
@@ -33,3 +33,7 @@ val register_exception_printers : unit -> unit
 
 (* this can raise exn; useful in test context *)
 val main_exn : Cap.all_caps -> string array -> unit
+
+(* exporting for re-use in opengrep experimental *)
+
+val dump_patterns_of_rule : Fpath.t -> unit

--- a/src/osemgrep/cli_show/Show_CLI.ml
+++ b/src/osemgrep/cli_show/Show_CLI.ml
@@ -47,7 +47,9 @@ and show_kind =
   | DumpAST of Fpath.t * Lang.t
   | DumpIL  of Fpath.t * Lang.t
   | DumpConfig of Rules_config.config_string
+  | DumpRule of Fpath.t
   | DumpRuleV2 of Fpath.t
+  | DumpPatternsOfRule of Fpath.t
   (* 'semgrep show ???'
    * accessible also as 'semgrep scan --dump-engine-path
    * LATER: get rid of it? *)
@@ -98,7 +100,9 @@ let cmdline_term : conf Term.t =
       match args with
       | [ "version" ] -> Version
       | [ "dump-config"; config_str ] -> DumpConfig config_str
+      | [ "dump-rule"; file ] -> DumpRule (Fpath.v file)
       | [ "dump-rule-v2"; file ] -> DumpRuleV2 (Fpath.v file)
+      | [ "dump-patterns-of-rule"; file ] -> DumpPatternsOfRule (Fpath.v file)
       | [ "dump-cst"; file ] ->
           let path = Fpath.v file in
           let lang = Lang.lang_of_filename_exn path in
@@ -152,8 +156,12 @@ let man : Cmdliner.Manpage.block list =
     `P "Print a list of languages that are currently supported by Opengrep.";
     `Pre "opengrep show dump-config <STRING>";
     `P "Dump the internal representation of the result of --config=<STRING>";
+    `Pre "opengrep show dump-rule <FILE>";
+    `P "Dump the internal representation of a rule";
     `Pre "opengrep show dump-rule-v2 <FILE>";
     `P "Dump the internal representation of a rule using the new (v2) syntax";
+    `Pre "opengrep show dump-patterns-of-rule <FILE>";
+    `P "Dump the internal representation of all patterns found in a rule";
     `Pre "opengrep show dump-ast [<LANG>] <FILE>";
     `P
       "Dump the abstract syntax tree of the file (with some names/types \

--- a/src/osemgrep/cli_show/Show_CLI.mli
+++ b/src/osemgrep/cli_show/Show_CLI.mli
@@ -25,7 +25,9 @@ and show_kind =
   | DumpAST of Fpath.t * Lang.t
   | DumpIL  of Fpath.t * Lang.t
   | DumpConfig of Rules_config.config_string
+  | DumpRule of Fpath.t
   | DumpRuleV2 of Fpath.t
+  | DumpPatternsOfRule of Fpath.t
   | DumpEnginePath of bool (* pro = true *)
   | DumpCommandForCore
 [@@deriving show]

--- a/src/osemgrep/cli_show/Show_subcommand.ml
+++ b/src/osemgrep/cli_show/Show_subcommand.ml
@@ -192,6 +192,9 @@ let run_conf (caps : < caps ; .. >) (conf : Show_CLI.conf) : Exit_code.t =
       rules_and_errors
       |> List.iter (fun x -> print (Rule_fetching.show_rules_and_origin x));
       Exit_code.ok ~__LOC__
+  | DumpRule file ->
+      Core_actions.dump_rule file;
+      Exit_code.ok ~__LOC__
   | DumpRuleV2 file ->
       (* TODO: use validation ocaml code to enforce the
        * CHECK: in rule_schema_v2.atd.
@@ -201,6 +204,9 @@ let run_conf (caps : < caps ; .. >) (conf : Show_CLI.conf) : Exit_code.t =
        *)
       let rules = Parse_rules_with_atd.parse_rules_v2 file in
       print (Rule_schema_v2_t.show_rules rules);
+      Exit_code.ok ~__LOC__
+  | DumpPatternsOfRule file ->
+      Core_CLI.dump_patterns_of_rule file;
       Exit_code.ok ~__LOC__
   | DumpEnginePath _pro -> failwith "TODO: dump-engine-path not implemented yet"
   | DumpCommandForCore ->

--- a/src/osemgrep/cli_show/dune
+++ b/src/osemgrep/cli_show/dune
@@ -15,6 +15,7 @@
 
     semgrep.parsing
     semgrep.parsing.tests ; Test_parsing.dump_tree_sitter_cst
+    semgrep.core_cli
     osemgrep_core
     osemgrep_configuring
     osemgrep_networking


### PR DESCRIPTION
Previously, to run these debugging flags, you had to call `opengrep-core`, which is not very intuitive to use. Now they can be run straight from the basic "--experimental" binary:

```
$ opengrep show dump-rule some-rule.yaml
{ Rule.id = ("my_rule_id", ());
  mode =
  `Taint ({ Rule.sources =
            ((),
             [{ Rule.source_id = "source:0:0:rules";
                source_formula =
                { Rule.f =
                  (Rule.And ((),
                     [{ Rule.f =
                        (Rule.P
  ...

$ opengrep show dump-patterns-of-rule some-rule.taml
E(
  Call(
    N(
      Id(("SomeUnsafeFunction", ()),
        {id_flags=Ref(2); id_resolved_alternative=Ref([]);
         id_resolved=Ref(None); id_type=Ref(None); id_svalue=Ref(None); })),
    []))
  ...
```
