### PR TITLE
C#: The `field` implicit param can be skipped in a pattern

### DIFF
--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -3413,7 +3413,7 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
             pname = Some ("field", tok);
             ptype = Some v3;
             pdefault = Some (G.N (G.Id (v5, G.empty_id_info ())) |> G.e);
-            pattrs = [];
+            pattrs = [G.KeywordAttr (G.Extern, fake "field")];
             pinfo = empty_id_info ~hidden:false ()
           }
       in

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -3227,14 +3227,14 @@ and m_parameters a b = m_bracket m_parameter_list a b
 (* in C# some function params are not real params, so we can skip them during matching *)
 and can_skip_special_cases lang =
   if lang =*= Lang.Csharp then
-  let is_extern = function
-    | G.KeywordAttr (G.Extern, _) -> true
-    | _ -> false
-  in
-    fun p ->
-      match p with
-      | G.Param p when List.exists is_extern p.pattrs -> true
+    let is_extern = function
+      | G.KeywordAttr (G.Extern, _) -> true
       | _ -> false
+    in
+      fun p ->
+        match p with
+        | G.Param p when List.exists is_extern p.pattrs -> true
+        | _ -> false
   else
     fun _ -> false
 

--- a/src/matching/Matching_generic.ml
+++ b/src/matching/Matching_generic.ml
@@ -643,6 +643,7 @@ let m_list_with_dots_and_metavar_ellipsis ?(can_skip=fun _ -> false) ~less_is_ok
     | [], [] -> return ()
     (* less-is-ok: empty list can sometimes match non-empty list *)
     | [], _ :: _ when less_is_ok -> return ()
+    | [], xb :: xsb when can_skip xb -> aux [] xsb 
     (* dots: '...', can also match no argument *)
     | [ a ], [] when is_dots a -> return ()
     (* opti: if is_metavar_ellipsis and less_is_ok is false, then

--- a/tests/tainting_rules/csharp/implicit_vars_in_props.cs
+++ b/tests/tainting_rules/csharp/implicit_vars_in_props.cs
@@ -7,9 +7,28 @@ class C
         //ruleid: taint_prop_field
         set => sink(field);
     }
+
     public string Message2
     {
-        // ruleid: taint_prop_value
+        // ruleid: taint_prop_value, taint_prop_value_no_field
         set => sink(value);
     }
+
+    extension (string s)
+    {
+        public string Message
+        {
+            // ruleid: taint_prop_field
+            get => sink(field);
+            //ruleid: taint_prop_field
+            set => sink(field);
+        }
+
+        public string Message2
+        {
+            // ruleid: taint_prop_value, taint_prop_value_no_field
+            set => sink(value);
+        }
+    }
+
 }

--- a/tests/tainting_rules/csharp/implicit_vars_in_props.yaml
+++ b/tests/tainting_rules/csharp/implicit_vars_in_props.yaml
@@ -10,10 +10,16 @@ rules:
       - pattern-inside: |
           [get] $T $F($FIELD) { ... }
       - focus-metavariable: $FIELD
+      - metavariable-regex:
+          metavariable: $FIELD
+          regex: field
     - patterns:
       - pattern-inside: |
           [set] $T $F($VALUE, $FIELD) { ... }
       - focus-metavariable: $FIELD
+      - metavariable-regex:
+          metavariable: $FIELD
+          regex: field
   pattern-sinks:
     - pattern: |
         sink(...)
@@ -28,6 +34,26 @@ rules:
       - pattern-inside: |
           [set] $T $F($VALUE, $FIELD) { ... }
       - focus-metavariable: $VALUE
+      - metavariable-regex:
+          metavariable: $VALUE
+          regex: value
+  pattern-sinks:
+    - pattern: |
+        sink(...)
+
+- id: taint_prop_value_no_field
+  languages: [csharp]
+  message: "tainted values reaches sink"
+  severity: WARNING
+  mode: taint
+  pattern-sources:
+    - patterns:
+      - pattern-inside: |
+          [set] $T $F($VALUE) { ... }
+      - focus-metavariable: $VALUE
+      - metavariable-regex:
+          metavariable: $VALUE
+          regex: value
   pattern-sinks:
     - pattern: |
         sink(...)


### PR DESCRIPTION
If we don't care about the `field` value in the rule, we can now skip it in the pattern. That is, we can write patterns like

```yaml
  pattern-sources:
    - patterns:
      - pattern-inside: |
          [set] $T $F($VALUE) { ... }
      - focus-metavariable: $VALUE
      - metavariable-regex:
          metavariable: $VALUE
          regex: value
```

This is more in line with what code is generated for properties by the C# compiler