### PR TITLE
Remove the offset_of_il hook

### DIFF
--- a/src/engine/Pro_hooks.ml
+++ b/src/engine/Pro_hooks.ml
@@ -52,7 +52,6 @@ let pro_hooks_refs =
     Pro_hook_ref Dataflow_svalue.hook_constness_of_function;
     Pro_hook_ref Dataflow_svalue.hook_transfer_of_assume;
     Pro_hook_ref Match_tainting_mode.hook_setup_hook_function_taint_signature;
-    Pro_hook_ref Taint.hook_offset_of_IL;
     Pro_hook_ref Taint_lval_env.hook_propagate_to;
     Pro_hook_ref Dataflow_tainting.hook_find_attribute_in_class;
     Pro_hook_ref Dataflow_tainting.hook_check_tainted_at_exit_sinks;

--- a/src/tainting/Taint.mli
+++ b/src/tainting/Taint.mli
@@ -83,9 +83,6 @@ type lval = {
 
 val lval_of_arg : arg -> lval
 
-val hook_offset_of_IL : (IL.offset -> offset) option ref
-(** Pro index sensitivity *)
-
 type source = {
   call_trace : Rule.taint_source call_trace;
   label : string;

--- a/src/tainting/Taint_signature_extractor.ml
+++ b/src/tainting/Taint_signature_extractor.ml
@@ -431,19 +431,6 @@ let find_class_for_function (ast : AST_generic.program) (target_name : IL.name)
       !found_class
   | _ -> None
 
-let enable_precise_index_tracking () =
-  let precise_offset_of_IL (o : IL.offset) =
-    match o.o with
-    | IL.Dot n -> Taint.Ofld n
-    | IL.Index { e = IL.Literal (Int pi); _ } -> (
-        match Parsed_int.to_int_opt pi with
-        | Some i -> Taint.Oint i
-        | None -> Taint.Oany)
-    | IL.Index { e = IL.Literal (String (_, (s, _), _)); _ } -> Taint.Ostr s
-    | IL.Index _ -> Taint.Oany
-  in
-  Taint.hook_offset_of_IL := Some precise_offset_of_IL
-
 let extract_signature_with_file_context
     ~arity
     ?(db : signature_database = Shape_and_sig.empty_signature_database ())
@@ -454,7 +441,6 @@ let extract_signature_with_file_context
     (taint_inst : Taint_rule_inst.t)
     func_cfg
     (ast : AST_generic.program) : signature_database * Signature.t =
-  enable_precise_index_tracking ();
   let global_sids = extract_global_var_sids_from_ast ast in
   let global_env = mk_global_assumptions_with_sids global_sids in
 


### PR DESCRIPTION
Remove the `offset_of_il` hook and always use what used to be called `precise_offset_of_IL` for `offset_of_IL`