### PR TITLE
Intrafile tainting with variadic functions

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1835,6 +1835,8 @@ and parameters params : param list =
   |> List_.map (function
        | G.Param { pname = Some i; pinfo; pdefault; _ } ->
            Param { pname = var_of_id_info i pinfo; pdefault }
+       | G.ParamRest (_, { pname = Some i; pinfo; pdefault; _ }) ->
+           ParamRest { pname = var_of_id_info i pinfo; pdefault }
        | G.ParamPattern pat -> ParamPattern pat
        | G.ParamReceiver _param ->
            (* TODO: Treat receiver as this parameter *)

--- a/src/analyzing/Fold_IL_params.ml
+++ b/src/analyzing/Fold_IL_params.ml
@@ -29,7 +29,8 @@ let fold :
     IL.(
       fun acc par ->
         match par with
-        | Param { pname = name; pdefault } ->
+        | Param { pname = name; pdefault }
+        | ParamRest { pname = name; pdefault } ->
             f acc name.ident name.id_info pdefault
         (* JS: {arg} : type *)
         | ParamPattern

--- a/src/il/IL.ml
+++ b/src/il/IL.ml
@@ -185,6 +185,7 @@ type name_param = { pname : name; pdefault : G.expr option }
 
 type param =
   | Param of name_param
+  | ParamRest of name_param
   | ParamPattern of G.pattern
   | ParamFixme
 [@@deriving show { with_path = false }]
@@ -220,7 +221,9 @@ class virtual ['self] iter_parent =
 
     method visit_param env param =
       match param with
-      | Param { pname; pdefault = _ } -> self#visit_name env pname
+      | Param { pname; pdefault = _ }
+      | ParamRest { pname; pdefault = _ } ->
+          self#visit_name env pname
       | ParamPattern _
       | ParamFixme ->
           ()

--- a/src/tainting/Shape_and_sig.ml
+++ b/src/tainting/Shape_and_sig.ml
@@ -599,10 +599,14 @@ end
  *)
 and Signature : sig
   (** A simplified version of 'AST_generic.parameter', we use 'Other' to
-      represent * parameter kinds that we do not support yet. We don't want to
-      just remove * those unsupported parameters because we rely on the position
-      of a parameter * to represent taint variables, see 'Taint.arg'. *)
-  type param = P of string | Other [@@deriving eq, ord]
+      represent parameter kinds that we do not support yet. We don't want to
+      just remove those unsupported parameters because we rely on the position
+      of a parameter to represent taint variables, see 'Taint.arg'. *)
+  type param =
+    | P of string
+    | PRest of string
+    | Other
+  [@@deriving eq, ord, show]
 
   type params = param list [@@deriving eq, ord]
 
@@ -619,26 +623,15 @@ end = struct
   (*************************************)
 
   (* TODO: Now with HOFs we run the risk of shadowing... *)
-  type param = P of string | Other
+  type param =
+    | P of string
+    | PRest of string
+    | Other [@@deriving eq, ord, show]
   type params = param list
-
-  let equal_param param1 param2 =
-    match (param1, param2) with
-    | P s1, P s2 -> String.equal s1 s2
-    | Other, Other -> true
-    | P _, Other
-    | Other, P _ ->
-        false
-
-  let compare_param param1 param2 =
-    match (param1, param2) with
-    | P s1, P s2 -> String.compare s1 s2
-    | Other, Other -> 0
-    | P _, Other -> -1
-    | Other, P _ -> 1
 
   let show_param = function
     | P s -> s
+    | PRest s -> "*" ^ s (* Python syntax for "rest" params *)
     | Other -> "_?"
 
   let equal_params params1 params2 = List.equal equal_param params1 params2
@@ -652,6 +645,8 @@ end = struct
     il_params
     |> List_.map (function
          | IL.Param { pname = { ident = s, _; _ }; _ } -> P s
+         (* functions signatures don't look into the shape of the argument. *)
+         | IL.ParamRest { pname = { ident = s, _; _ }; _ } -> PRest s
          | IL.ParamPattern pat -> (
              (* Extract parameter name from pattern for Rust function parameters *)
              match pat with
@@ -821,7 +816,7 @@ let lookup_signature (db : signature_database) (func_name : fn_id) (arity : int)
           let all_sigs = SignatureSet.elements sigs in
           let sig_details = all_sigs |> List.map (fun s ->
             Printf.sprintf "(arity=%d, params=%s)" s.arity
-              (s.sig_.params |> List.map (function Signature.P s -> "P(" ^ s ^ ")" | Signature.Other -> "Other") |> String.concat ",")
+              (s.sig_.params |> List.map Signature.show_param |> String.concat ",")
           ) |> String.concat "; " in
           m "LOOKUP_SIG: %s with arity=%d, found %d sigs: [%s]"
             (show_fn_id func_name) arity total_sigs_card sig_details);
@@ -852,7 +847,7 @@ let add_signature (db : signature_database) (func_name : fn_id)
     (signature : extended_sig) : signature_database =
   (* Debug logging for ALL signatures being added *)
   let fn_name_str = show_fn_id func_name in
-  let params_str = signature.sig_.params |> List.map (function Signature.P s -> "P(" ^ s ^ ")" | Signature.Other -> "Other") |> String.concat "," in
+  let params_str = signature.sig_.params |> List.map Signature.show_param |> String.concat "," in
   Log.debug (fun m ->
       m "ADD_SIG: fn=%s, arity=%d, params=%s"
         fn_name_str signature.arity params_str);

--- a/src/tainting/Taint_signature_extractor.ml
+++ b/src/tainting/Taint_signature_extractor.ml
@@ -134,7 +134,10 @@ let mk_param_assumptions ?taint_inst (params : IL.param list) : Taint_lval_env.t
     |> List.fold_left
          (fun (i, env) param ->
            match param with
-           | IL.Param { pname; _ } ->
+           | IL.Param { pname; _ }
+           (* NOTE: from the perspective of the function definition, a "rest" param is just *)
+           (* a param. The difference is only at the call site when instantiating the args. *)
+           | IL.ParamRest { pname; _ } ->
                let il_lval : IL.lval = { base = Var pname; rev_offset = [] } in
                let taint_arg : Taint.arg =
                  { name = fst pname.ident; index = i }

--- a/tests/rules/cross_function_tainting/test_csharp_variadic_function.cs
+++ b/tests/rules/cross_function_tainting/test_csharp_variadic_function.cs
@@ -1,0 +1,16 @@
+class C
+{
+    void test1(params T[] args)
+    {
+        for (i = 0; i <= 10; i++)
+        {
+            // ruleid: taint
+            sink(args[i]);
+        }
+    }
+
+    void runTest1()
+    {
+        test1("abc", source(), "xyz");
+    }
+}

--- a/tests/rules/cross_function_tainting/test_csharp_variadic_function.yaml
+++ b/tests/rules/cross_function_tainting/test_csharp_variadic_function.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: taint
+  languages: [csharp]
+  message: "tainted data reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        source()
+  pattern-sinks:
+    - pattern: |
+        sink(...)
+ 

--- a/tests/rules/cross_function_tainting/test_python_variadic_function.py
+++ b/tests/rules/cross_function_tainting/test_python_variadic_function.py
@@ -1,0 +1,31 @@
+def test1(*args):
+
+  for x in args.items():
+      # ruleid: taint
+      sink(x)
+
+  # ok:
+  sink(args[0])
+  # ruleid: taint
+  sink(args[1])
+
+  # ok:
+  sink(args[2])
+
+
+test1("abc", source(), "xyz")
+
+
+def test2(x, *args, y):
+
+  # ruleid: taint
+  sink(x)
+
+  # ruleid: taint
+  sink(y)
+
+  # ok:
+  sink(args)
+
+
+test2(source(), "abc", "uvw", "xyz", y=source())

--- a/tests/rules/cross_function_tainting/test_python_variadic_function.yaml
+++ b/tests/rules/cross_function_tainting/test_python_variadic_function.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: taint
+  languages: [python]
+  message: "tainted data reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        source()
+  pattern-sinks:
+    - pattern: |
+        sink(...)


### PR DESCRIPTION
We add tainting via "rest" params, as in:

```python
def test1(*args):
  for x in args.items():
      sink(x)

test1("abc", source(), "xyz")
```

This is done by adding a new kind of param (`ParamRest` in IL and `PRest` in function tainting signature) that corresponds to `ParamRest` in AST.

**NOTE**: In tainting signature db, the arity of a variadic function is still counted as if the "rest" param was a single param, so there might be problems when a variadic function is only one of possible overloads. But fixing that will be part of subsequent effort to upgrade naming and overloading resolution.