### PR TITLE
added functionality to add the security-severity property to sarif file

### DIFF
--- a/cli/tests/default/e2e/snapshots/test_output_sarif/test_sarif_output/False-rule_and_target1/results.sarif
+++ b/cli/tests/default/e2e/snapshots/test_output_sarif/test_sarif_output/False-rule_and_target1/results.sarif
@@ -87,6 +87,7 @@
               "name": "rules.rule-with-cwe-tag",
               "properties": {
                 "precision": "very-high",
+                "security-severity": "8.0",
                 "tags": [
                   "CWE-88888888: Another fake CWE",
                   "CWE-99999999: Fake CWE",

--- a/cli/tests/default/e2e/snapshots/test_output_sarif/test_sarif_output/True-rule_and_target1/results.sarif
+++ b/cli/tests/default/e2e/snapshots/test_output_sarif/test_sarif_output/True-rule_and_target1/results.sarif
@@ -87,6 +87,7 @@
               "name": "rules.rule-with-cwe-tag",
               "properties": {
                 "precision": "very-high",
+                "security-severity": "8.0",
                 "tags": [
                   "CWE-88888888: Another fake CWE",
                   "CWE-99999999: Fake CWE",

--- a/cli/tests/default/e2e/snapshots/test_output_sarif/test_sarif_output_with_source_edit/results.sarif
+++ b/cli/tests/default/e2e/snapshots/test_output_sarif/test_sarif_output_with_source_edit/results.sarif
@@ -87,6 +87,7 @@
               "name": "rules.assert-eqeq-is-ok",
               "properties": {
                 "precision": "very-high",
+                "security-severity": "8.0",
                 "tags": [
                   "security",
                   "sometag"
@@ -111,6 +112,7 @@
               "name": "rules.eqeq-is-bad",
               "properties": {
                 "precision": "very-high",
+                "security-severity": "8.0",
                 "tags": [
                   "security",
                   "sometag"
@@ -135,6 +137,7 @@
               "name": "rules.javascript-basic-eqeq-bad",
               "properties": {
                 "precision": "very-high",
+                "security-severity": "8.0",
                 "tags": [
                   "cwe te",
                   "security",
@@ -160,6 +163,7 @@
               "name": "rules.python37-compatability-os-module",
               "properties": {
                 "precision": "very-high",
+                "security-severity": "8.0",
                 "tags": [
                   "security",
                   "sometag"

--- a/src/osemgrep/reporting/Sarif_output.ml
+++ b/src/osemgrep/reporting/Sarif_output.ml
@@ -123,23 +123,12 @@ let tags_of_metadata metadata =
   List.sort_uniq String.compare all_tags
 
 (* Check if a rule is security-related based on its metadata.
- * A rule is considered security-related if it has CWE, OWASP tags, or
- * an explicit "security" tag in its metadata.
+ * A rule is considered security-related if metadata.category = "security".
  *)
 let is_security_rule metadata =
-  let has_cwe = JSON.member "cwe" metadata <> None in
-  let has_owasp = JSON.member "owasp" metadata <> None in
-  let has_security_tag =
-    match JSON.member "tags" metadata with
-    | Some (JSON.Array tags) ->
-        List.exists
-          (function
-            | JSON.String s -> String.lowercase_ascii s = "security"
-            | _ -> false)
-          tags
-    | _ -> false
-  in
-  has_cwe || has_owasp || has_security_tag
+  match JSON.member "category" metadata with
+  | Some (JSON.String s) -> String.lowercase_ascii s = "security"
+  | _ -> false
 
 (* We want to produce a json object? with the following shape:
    { id; name;


### PR DESCRIPTION
This pull request improves how SARIF output represents security severity for rules, particularly for compatibility with GitHub Code Scanning. The main change is that SARIF results now include a `security-severity` property for security-related rules, either from explicit metadata or computed from the rule's severity. This ensures findings are categorized correctly (Critical/High/Medium/Low) in downstream tools.

**SARIF Output Enhancements (Security Severity):**

* Added logic in `Sarif_output.ml` to compute and include a `security-severity` property for rules that are security-related, based on metadata or severity. This supports proper severity mapping for GitHub Code Scanning.
* Introduced a helper function `security_severity_of_severity` to map internal severities to GitHub's numerical severity scores.
* Added a function `is_security_rule` to detect if a rule is security-related by checking for CWE, OWASP, or explicit "security" tags in rule metadata.

**Test and Snapshot Updates:**

* Updated SARIF test snapshots (`results.sarif`) to include the new `security-severity` property for relevant rules, reflecting the new logic. [[1]](diffhunk://#diff-2df6d60497dfe48518acf33eaa53164dc2881fd0d2ba34b6904ea802852802a3R90) [[2]](diffhunk://#diff-a029d0775d9a04cb42c5eb9cd0c6b87aaad276aca0b83975d02f23485d38370cR90) [[3]](diffhunk://#diff-a029d0775d9a04cb42c5eb9cd0c6b87aaad276aca0b83975d02f23485d38370cR115) [[4]](diffhunk://#diff-a029d0775d9a04cb42c5eb9cd0c6b87aaad276aca0b83975d02f23485d38370cR140) [[5]](diffhunk://#diff-a029d0775d9a04cb42c5eb9cd0c6b87aaad276aca0b83975d02f23485d38370cR166)