### PR TITLE
Ruby: Always translate `or` and `and` to expression

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -663,7 +663,7 @@ and expr_aux env ?(void = false) g_expr =
   | G.Call
       ( { e = G.IdSpecial (G.Op ((G.And | G.Or) as op), tok); _ },
         (_, arg0 :: args, _) )
-    when not void ->
+    when not void || env.lang =*= Lang.Ruby ->
       expr_lazy_op env op tok arg0 args eorig
   (* args_with_pre_stmts *)
   | G.Call ({ e = G.IdSpecial (G.Op op, tok); _ }, args) -> (

--- a/tests/tainting_rules/ruby/or_operator.rb
+++ b/tests/tainting_rules/ruby/or_operator.rb
@@ -1,0 +1,9 @@
+def foo()
+  src = source()
+
+  # testing that this is not considered always returning
+  src or return
+  
+  # ruleid: taint
+  sink(src)
+end

--- a/tests/tainting_rules/ruby/or_operator.yaml
+++ b/tests/tainting_rules/ruby/or_operator.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: taint
+  languages: [ruby]
+  message: "tainted data reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        source()
+  pattern-sinks:
+    - pattern: |
+        sink(...)


### PR DESCRIPTION
We fix a bug that makes dataflow tainting think the call of `sink` below is dead code and taint is not found.

```ruby
def foo()
  src = source()

  # testing that this is not considered always returning
  src or return
  
  sink(src)
end
```

The reason is that the translation wants to be smart, and, to avoid temporary variables, expressions that are not used anywhere (evaluated only for side-effects), are translated to statements, and `Or` is no longer lazy. This is a more general bug that should be fixed together with a big refactoring of AST_to_IL, but such naked `or` expressions like in the example above are idiomatic in Ruby, and should be fixed ASAP, hence this "special case" quick fix.