### PR TITLE
Add taint propagation via "for" comprehensions

### DIFF
--- a/tests/tainting_rules/python/comprehension.py
+++ b/tests/tainting_rules/python/comprehension.py
@@ -1,0 +1,49 @@
+s = source()
+
+
+## sink in comprehension collection
+
+# ruleid: taint
+do_sth([x + 1 for x in sink(s)])
+
+
+## taint in comprehension value
+
+# ruleid: taint
+do_sth([sink(s) for x in some_collection])
+
+
+## taint propagated from collection to result
+
+tainted_col = ["SELECT" + x for x in source()]
+# ruleid: taint
+sink(tainted_col)
+
+tainted_col2 = ["SELECT" + x for x in s]
+# ruleid: taint
+sink(tainted_col2)
+
+
+## taint propagated from collection to result's elements
+
+res2 = [x for x in s]
+for x in res2:
+  # ruleid: taint
+  sink(x)
+
+# ruleid: taint
+sink(res2[123])
+
+
+## taint sanitized in collection
+
+sanitized_col = [x for x in sanitize(s)]
+# ok: taint
+sink(sanitized_col)
+
+
+## taint sanitized in expression
+
+sanitized_col = [sanitize(x) for x in s]
+# ok: taint
+sink(sanitized_col)

--- a/tests/tainting_rules/python/comprehension.yaml
+++ b/tests/tainting_rules/python/comprehension.yaml
@@ -1,0 +1,16 @@
+rules:
+  
+- id: taint
+  languages: [python]
+  message: "tainted data reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        source()
+  pattern-sinks:
+    - pattern: |
+        sink(...)
+  pattern-sanitizers:
+    - pattern: |
+        sanitize(...)


### PR DESCRIPTION
Closes #554

## This PR

Before, taint was lost on comprehensions (which were translated to a "todo" in IL). We fix it by adding translation of comprehensions in AST_to_IL. A comprehension like

```python
foo([expr for x in col])
```

is translated to an equivalent of

```python
for x in col:
  tmp += x
foo(tmp)
```

The implementation is an adjusted version of the translation of `for each` loop.

## TODO for future

### Multiple "for"

As in:

```python
[x + y
  for x in list1
  for y in list2]
```

### The "if" part

As in:

```python
[x - 1 for x in list1 if x > 0] 
```



