### PR TITLE
Fix taint propagation through Rust variable shadowing

### DIFF
--- a/tests/tainting_rules/rust/variable_shadowing.rs
+++ b/tests/tainting_rules/rust/variable_shadowing.rs
@@ -1,0 +1,51 @@
+// Test: Rust variable shadowing taint propagation
+// Verifies that taint correctly propagates through `let x = x;` patterns
+
+fn test_no_shadowing(tainted: String) {
+    let url = tainted;
+    // ruleid: taint
+    sink(url);
+}
+
+fn test_single_shadowing(tainted: String) {
+    let url = tainted;
+    let url = url;  // Variable shadowing
+    // ruleid: taint
+    sink(url);
+}
+
+fn test_multiple_shadowing(tainted: String) {
+    let url = tainted;
+    let url = url;
+    let url = url;
+    let url = url;
+    // ruleid: taint
+    sink(url);
+}
+
+fn test_shadowing_with_rename(tainted: String) {
+    let url = tainted;
+    let url2 = url;  // Different variable name (not shadowing)
+    // ruleid: taint
+    sink(url2);
+}
+
+fn test_shadowing_in_nested_scope(tainted: String) {
+    let url = tainted;
+    {
+        let url = url;  // Shadowing in inner scope
+        // ruleid: taint
+        sink(url);
+    }
+}
+
+fn test_clean_not_tainted(clean: String) {
+    let url = clean;
+    let url = url;
+    // ok: taint
+    sink(url);
+}
+
+fn sink(data: String) {
+    println!("{}", data);
+}

--- a/tests/tainting_rules/rust/variable_shadowing.yaml
+++ b/tests/tainting_rules/rust/variable_shadowing.yaml
@@ -1,0 +1,16 @@
+rules:
+- id: taint
+  mode: taint
+  languages: [rust]
+  message: "tainted data flows to sink through variable shadowing"
+  severity: INFO
+  pattern-sources:
+    - patterns:
+        - pattern-inside: |
+            fn $F(..., $P: $_, ...){...}
+        - metavariable-regex:
+            metavariable: $P
+            regex: ^tainted$
+        - focus-metavariable: $P
+  pattern-sinks:
+    - pattern: sink(...)


### PR DESCRIPTION
## Summary

- Fix false negatives in taint analysis caused by Rust variable shadowing (`let x = x;`)
- The name resolution was visiting the entity pattern (declaring the new variable) before visiting the initialiser expression, causing the RHS to incorrectly resolve to the newly declared variable instead of the outer binding

## Changes

- Modified `Naming_AST.ml` to visit `vinit` before declaring the variable for VarDef with patterns
- Added test case for Rust variable shadowing taint propagation