### PR TITLE
fix: ensure perf scripts work in environments without a dev setup

### DIFF
--- a/perf/opengrep-scripts/bench.sh
+++ b/perf/opengrep-scripts/bench.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 # Copyright (c) 2026 Opengrep Authors
 #
 # SPDX-License-Identifier: LGPL-2.1-only
@@ -162,6 +162,18 @@ fi
 
 if [ -n "$output_dir" ] && [ -d "$output_dir" ]; then
   echo "Error: --output-dir '$output_dir' already exists" >&2
+  exit 1
+fi
+
+# Validate dependencies
+MIN_HYPERFINE_VERSION="1.20.0"
+if ! command -v hyperfine &>/dev/null; then
+  echo "Error: hyperfine not found. Install it from https://github.com/sharkdp/hyperfine" >&2
+  exit 1
+fi
+hf_version=$(hyperfine --version | awk '{print $2}')
+if printf '%s\n%s\n' "$MIN_HYPERFINE_VERSION" "$hf_version" | sort -V | head -1 | grep -qv "^${MIN_HYPERFINE_VERSION}$"; then
+  echo "Error: hyperfine >= $MIN_HYPERFINE_VERSION required (found $hf_version)" >&2
   exit 1
 fi
 

--- a/perf/opengrep-scripts/run-benchmarks.sh
+++ b/perf/opengrep-scripts/run-benchmarks.sh
@@ -81,7 +81,10 @@ echo "=== Running benchmarks: search rules (no intrafile) ==="
 echo
 
 echo "=== Running benchmarks: taint rules (intrafile) ==="
-./bench.sh --output-dir "$run_dir/intrafile_taint" --intrafile --taint-rules-only "$@"
+if ! ./bench.sh --output-dir "$run_dir/intrafile_taint" --intrafile --taint-rules-only "$@"; then
+  echo "Warning: intrafile benchmarks skipped (see above)" >&2
+  rm -rf "$run_dir/intrafile_taint"
+fi
 echo
 
 echo "=== All benchmarks complete ==="


### PR DESCRIPTION
## Summary

- **compare-outputs.sh**: gracefully skip `opengrep-diff` when not in PATH, showing a reduced table (totals only) with a warning and build instructions
- **bench.sh**: fix shebang (`sh` -> `bash`) for systems where `/bin/sh` is `dash`; add minimum hyperfine version check (>= 1.20.0)
- **run-benchmarks.sh**: gracefully skip intrafile benchmarks when `bench.sh` fails (e.g. semgrep not logged in for pro features)

## Test plan

- [x] Tested on Raspberry Pi (aarch64, Debian, `/bin/sh` = `dash`) via `--dry-run` and full run
- [x] Verified `compare-outputs.sh` prints warning and reduced table when `opengrep-diff` is absent
- [x] Verified `run-benchmarks.sh` continues past failed intrafile config
- [x] Verified `generate-reports.sh` produces correct reports with reduced findings table