### PR TITLE
Fix: pin nuitka to 2.8.9

### DIFF
--- a/.github/workflows/build-manylinux-binary.yml
+++ b/.github/workflows/build-manylinux-binary.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install nuitka
         run: |
-          python3 -m pip install nuitka
+          python3 -m pip install nuitka==2.8.9
           # /opt/python/cp39-cp39/bin/pip install pyinstaller
 
       - name: Install opengrep

--- a/.github/workflows/build-musllinux-binary.yml
+++ b/.github/workflows/build-musllinux-binary.yml
@@ -87,7 +87,7 @@ jobs:
               unzip dist.zip &&
               python3 -m venv venv &&
               . venv/bin/activate &&
-              python3 -m pip install nuitka &&
+              python3 -m pip install nuitka==2.8.9 &&
               python3 -m pip install dist/*.whl &&
               unzip dist/*.whl -d _wheel &&
               export OPENGREP_VERSION=\$(opengrep --version) &&

--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Install setuptools with --upgrade
         run: pip3 install --upgrade setuptools
       - name: Install nuitka
-        run: pip3 install nuitka protobuf
+        run: pip3 install nuitka==2.8.9 protobuf
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
An accidental bump to 4.0 gave binaries that are much larger, we need to
investigate if this is worth it.