### PR TITLE
Fix lambda taint tracking in intrafile mode

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -873,19 +873,6 @@ and expr_aux env ?(void = false) g_expr : stmts * exp =
           (Tok.unbracket inner_args @ Tok.unbracket outer_args)
       in
       expr_aux env ~void (G.Call (callee, merged_args) |> G.e)
-  (* Ruby: when the callee is a plain identifier (G.N), evaluate it via
-     `lval` instead of `expr` to skip the `ident_function_call_hack` (see
-     the G.N arm below, ~line 892). That hack wraps bare identifiers in a
-     0-arg Call for Ruby (where `foo` can mean `foo()`), but here we already
-     have an explicit G.Call — going through `expr` would produce a spurious
-     nested Call(Call(f, []), args) instead of Call(f, args). *)
-  | G.Call (({ G.e = G.N _; _ } as e), args) when env.lang =*= Lang.Ruby ->
-      let tok = G.fake "call" in
-      let ss_callee, callee_lval = lval env e in
-      let callee_exp = mk_e (Fetch callee_lval) (related_exp e) in
-      let ss_args, il_args = arguments env (Tok.unbracket args) in
-      let ss_call, call_exp = call_instr tok eorig ~void (fun res -> Call (res, callee_exp, il_args)) in
-      (ss_callee @ ss_args @ ss_call, call_exp)
   | G.Call (e, args) ->
       let tok = G.fake "call" in
       call_generic env ~void tok eorig e args
@@ -902,23 +889,7 @@ and expr_aux env ?(void = false) g_expr : stmts * exp =
   | G.ArrayAccess (_, _)
   | G.DeRef (_, _) ->
       let ss_lv, lval = lval env g_expr in
-      let exp = mk_e (Fetch lval) eorig in
-      let ident_function_call_hack ss exp =
-        (* Taking into account Ruby's ability to allow function calls without
-         * parameters or parentheses, we are conducting a check to determine
-         * if a function with the same name as the identifier exists, specifically
-         * for Ruby. *)
-        match lval with
-        | { base = Var { ident; id_info; _ }; _ }
-          when env.lang =*= Lang.Ruby
-               && Option.is_none !(id_info.id_resolved)
-               && IdentSet.mem (H.str_of_ident ident) env.ctx.entity_names ->
-            let tok = G.fake "call" in
-            let call_ss, call_exp = call_instr tok eorig ~void (fun res -> Call (res, exp, [])) in
-            (ss @ call_ss, call_exp)
-        | _ -> (ss, exp)
-      in
-      ident_function_call_hack ss_lv exp
+      (ss_lv, mk_e (Fetch lval) eorig)
   (* x = ClassName(args ...) in Python *)
   (* ClassName has been resolved to __init__ by the pro engine. *)
   (* Identified and treated as x = New ClassName(args ...) to support

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -858,6 +858,34 @@ and expr_aux env ?(void = false) g_expr : stmts * exp =
                  |> G.e) ]
       in
       call_generic env ~void tok eorig e (Tok.unsafe_fake_bracket arg_container)
+  (* Ruby do-block flattening: `f(args) do |x| ... end` is parsed as
+     Call(Call(f, args), [Lambda]) but the block is semantically an argument
+     to f, not to its return value. Flatten into Call(f, args @ [Lambda]). *)
+  | G.Call ({ e = G.Call (callee, inner_args); _ }, outer_args)
+    when env.lang =*= Lang.Ruby
+         && List.exists
+              (function
+               | G.Arg { G.e = G.Lambda _; _ } -> true
+               | _ -> false)
+              (Tok.unbracket outer_args) ->
+      let merged_args =
+        Tok.unsafe_fake_bracket
+          (Tok.unbracket inner_args @ Tok.unbracket outer_args)
+      in
+      expr_aux env ~void (G.Call (callee, merged_args) |> G.e)
+  (* Ruby: when the callee is a plain identifier (G.N), evaluate it via
+     `lval` instead of `expr` to skip the `ident_function_call_hack` (see
+     the G.N arm below, ~line 892). That hack wraps bare identifiers in a
+     0-arg Call for Ruby (where `foo` can mean `foo()`), but here we already
+     have an explicit G.Call — going through `expr` would produce a spurious
+     nested Call(Call(f, []), args) instead of Call(f, args). *)
+  | G.Call (({ G.e = G.N _; _ } as e), args) when env.lang =*= Lang.Ruby ->
+      let tok = G.fake "call" in
+      let ss_callee, callee_lval = lval env e in
+      let callee_exp = mk_e (Fetch callee_lval) (related_exp e) in
+      let ss_args, il_args = arguments env (Tok.unbracket args) in
+      let ss_call, call_exp = call_instr tok eorig ~void (fun res -> Call (res, callee_exp, il_args)) in
+      (ss_callee @ ss_args @ ss_call, call_exp)
   | G.Call (e, args) ->
       let tok = G.fake "call" in
       call_generic env ~void tok eorig e args
@@ -988,7 +1016,7 @@ and expr_aux env ?(void = false) g_expr : stmts * exp =
   | G.Comprehension (_op, (_l, (er, clauses), _r)) ->
       comprehension env er clauses
   | G.Lambda fdef ->
-      let lval = fresh_lval (snd fdef.fkind) in
+      let lval = fresh_lval ~str:"_tmp_lambda" (snd fdef.fkind) in
       let final_fdef =
         (* NOTE: Reset control-flow labels so that break/continue/recur from
          * the enclosing scope don't bleed into the lambda body. *)
@@ -1408,7 +1436,7 @@ and record env ((_tok, origfields, _) as record_def) : stmts * exp =
               (* Some languages such as javascript allow function
                  definitions in object literal syntax. *)
               | G.FuncDef fdef ->
-                  let lval = fresh_lval (snd fdef.fkind) in
+                  let lval = fresh_lval ~str:"_tmp_lambda" (snd fdef.fkind) in
                   (* See NOTE about resetting control-flow labels for lambdas. *)
                   let fdef =
                     function_definition

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -852,16 +852,12 @@ and expr_aux env ?(void = false) g_expr : stmts * exp =
   (* Ruby do-block flattening: `f(args) do |x| ... end` is parsed as
      Call(Call(f, args), [Lambda]) but the block is semantically an argument
      to f, not to its return value. Flatten into Call(f, args @ [Lambda]). *)
-  | G.Call ({ e = G.Call (callee, inner_args); _ }, outer_args)
-    when env.lang =*= Lang.Ruby
-         && List.exists
-              (function
-               | G.Arg { G.e = G.Lambda _; _ } -> true
-               | _ -> false)
-              (Tok.unbracket outer_args) ->
+  | G.Call ({ e = G.Call (callee, inner_args); _ },
+            (_, ([ G.Arg { G.e = G.Lambda _; _ } ] as outer_arg), _ ))
+    when env.lang =*= Lang.Ruby ->
       let merged_args =
         Tok.unsafe_fake_bracket
-          (Tok.unbracket inner_args @ Tok.unbracket outer_args)
+          (Tok.unbracket inner_args @ outer_arg)
       in
       expr_aux env ~void (G.Call (callee, merged_args) |> G.e)
   | G.Call (e, args) ->

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -45,9 +45,6 @@ let log_error ?tok msg : unit = Log.err (fun m -> m "%s" (locate ?tok msg))
 (*****************************************************************************)
 (* Types *)
 (*****************************************************************************)
-module IdentSet = Set.Make (String)
-
-type ctx = { entity_names : IdentSet.t }
 type stmts = stmt list
 
 type rec_point_lvals =
@@ -63,18 +60,14 @@ type env = {
   break_labels : label list;
   cont_label : label option;
   rec_point_label : label option;
-  ctx : ctx;
   rec_point_lvals : rec_point_lvals option;
   inside_function : bool;
 }
-
-let empty_ctx : ctx = { entity_names = IdentSet.empty }
 
 let empty_env (lang : Lang.t) : env =
   { break_labels = [];
     cont_label = None;
     rec_point_label = None;
-    ctx = empty_ctx;
     rec_point_lvals = None;
     inside_function = false;
     lang }
@@ -257,8 +250,6 @@ let mk_class_constructor_name (ty : G.type_) cons_id_info : G.name option =
       Some (G.Id (id, cons_id_info))
   | __else__ -> None
 
-let add_entity_name ctx ident : ctx =
-  { entity_names = IdentSet.add (H.str_of_ident ident) ctx.entity_names }
 
 let def_expr_evaluates_to_value (lang : Lang.t) : bool =
   match lang with
@@ -2614,8 +2605,8 @@ and function_definition env fdef : function_definition =
 (* Entry points *)
 (****************************************************************************)
 
-let function_definition lang ?ctx fdef : function_definition =
-  let env = { (empty_env lang) with ctx = ctx ||| empty_ctx } in
+let function_definition lang fdef : function_definition =
+  let env = empty_env lang in
   function_definition env fdef
 
 let stmt lang st : stmts =

--- a/src/analyzing/AST_to_IL.mli
+++ b/src/analyzing/AST_to_IL.mli
@@ -1,11 +1,5 @@
-type ctx
-
-val empty_ctx : ctx
-val add_entity_name : ctx -> AST_generic.ident -> ctx
-
 val function_definition :
   Lang.t ->
-  ?ctx:ctx ->
   AST_generic.function_definition ->
   IL.function_definition
 

--- a/src/analyzing/CFG_build.ml
+++ b/src/analyzing/CFG_build.ml
@@ -456,6 +456,6 @@ and cfg_of_fdef fdef =
   mark_at_exit_nodes cfg;
   IL.{ params = fdef.fparams; cfg; lambdas }
 
-let cfg_of_gfdef lang ?ctx fdef =
-  let fdef_il = AST_to_IL.function_definition lang ?ctx fdef in
+let cfg_of_gfdef lang fdef =
+  let fdef_il = AST_to_IL.function_definition lang fdef in
   cfg_of_fdef fdef_il

--- a/src/analyzing/CFG_build.mli
+++ b/src/analyzing/CFG_build.mli
@@ -9,5 +9,5 @@ val cfg_of_fdef : IL.function_definition -> IL.fun_cfg
 (** Compute the control flow graph of an IL function definition. *)
 
 val cfg_of_gfdef :
-  Lang.t -> ?ctx:AST_to_IL.ctx -> AST_generic.function_definition -> IL.fun_cfg
+  Lang.t -> AST_generic.function_definition -> IL.fun_cfg
 (** Same as 'cfg_of_fdef' but takes a Generic function definition. *)

--- a/src/analyzing/Visit_function_defs.ml
+++ b/src/analyzing/Visit_function_defs.ml
@@ -251,6 +251,7 @@ class ['self] visitor_with_parent_path =
                   self#visit_stmt f body)
           | G.DefStmt
               (ent, G.VarDef { vinit = Some { e = G.Lambda fdef; _ }; _ }) ->
+              (* Handle lambda assignments in class fields *)
               let class_il = Option.bind !current_class g_name_to_il_name in
               let func_il = entity_to_il_name ent in
               let visitor_parent_path, current_fn_id =

--- a/src/call_graph/Function_id.ml
+++ b/src/call_graph/Function_id.ml
@@ -20,8 +20,21 @@ let normalize_file (file : Fpath.t) : string =
   Fpath.to_string (Fpath.normalize file)
 
 let key ((id, tok) : t) =
+  (* For lambda names (starting with "_tmp_lambda"), extract position even from
+   * fake tokens that have position info. This is important for distinguishing
+   * different lambdas that would otherwise all collide on the same name.
+   * For regular functions with fake tokens, use empty key
+   * to preserve the original matching behavior. *)
+  let is_lambda_name = String.starts_with ~prefix:"_tmp_lambda" id in
   if Tok.is_fake tok then
-    (id, "", 0, 0)
+    if is_lambda_name then
+      match Tok.loc_of_tok tok with
+      | Ok loc ->
+          (id, normalize_file loc.Tok.pos.file, loc.Tok.pos.line, loc.Tok.pos.column)
+      | _ ->
+          (id, "", 0, 0)
+    else
+      (id, "", 0, 0)
   else
     let file = Tok.file_of_tok tok in
     let line = Tok.line_of_tok tok in
@@ -64,6 +77,12 @@ let show_debug (id, tok) : string =
 let of_il_name (n : IL.name) : t =
   n.IL.ident
 
+(* Unlike [key], we don't gate on is_lambda_name here: this is only used for
+   display/serialization, not identity, so extracting position from any fake
+   token that has it is strictly better than returning "unknown". *)
 let to_file_line_col ((_, tok) : t) : string * int * int =
-  if Tok.is_fake tok then ("unknown", 0, 0)
+  if Tok.is_fake tok then
+    match Tok.loc_of_tok tok with
+    | Ok loc -> (normalize_file loc.Tok.pos.file, loc.Tok.pos.line, loc.Tok.pos.column)
+    | _ -> ("unknown", 0, 0)
   else (normalize_file (Tok.file_of_tok tok), Tok.line_of_tok tok, Tok.col_of_tok tok)

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -241,9 +241,9 @@ let pms_of_effect ~match_on (effect_ : Effect.t) =
 (* Main entry points *)
 (*****************************************************************************)
 
-let check_fundef (taint_inst : Taint_rule_inst.t) (name : IL.name) ctx ?glob_env ?class_name
+let check_fundef (taint_inst : Taint_rule_inst.t) (name : IL.name) ?glob_env ?class_name
     ?signature_db ?builtin_signature_db ?call_graph fdef =
-  let fdef = AST_to_IL.function_definition taint_inst.lang ~ctx fdef in
+  let fdef = AST_to_IL.function_definition taint_inst.lang fdef in
   let fcfg = CFG_build.cfg_of_fdef fdef in
   let in_env, env_effects =
     Taint_input_env.mk_fun_input_env taint_inst ?glob_env fdef.fparams
@@ -428,16 +428,6 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
   with
   | None -> (None, None)
   | Some (taint_inst, spec_matches, expls) ->
-      (* FIXME: This is no longer needed, now we can just check the type 'n'. *)
-      let ctx = ref AST_to_IL.empty_ctx in
-      Visit_function_defs.visit
-        (fun opt_ent _fdef ->
-          match opt_ent with
-          | Some { name = EN (Id (n, _)); _ } ->
-              ctx := AST_to_IL.add_entity_name !ctx n
-          | __else__ -> ())
-        ast;
-
       let glob_env, glob_effects = Taint_input_env.mk_file_env taint_inst ast in
       record_matches glob_effects;
 
@@ -483,7 +473,7 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
                             in
                             let fdef_il =
                               AST_to_IL.function_definition taint_inst.lang
-                                ~ctx:!ctx fdef
+                                fdef
                             in
                             let cfg = CFG_build.cfg_of_fdef fdef_il in
                             let info =
@@ -530,8 +520,7 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
                               []
                         in
                         let fdef_il =
-                          AST_to_IL.function_definition taint_inst.lang ~ctx:!ctx
-                            fdef
+                          AST_to_IL.function_definition taint_inst.lang                            fdef
                         in
                         let cfg = CFG_build.cfg_of_fdef fdef_il in
                         let info =
@@ -636,7 +625,7 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
             if info.is_lambda_assignment then updated_db
             else begin
               let _flow, fdef_effects, _mapping =
-                check_fundef taint_inst info.name !ctx ~glob_env
+                check_fundef taint_inst info.name ~glob_env
                   ?class_name:info.class_name_str ~signature_db:updated_db
                   ?builtin_signature_db
                   ?call_graph:(Some relevant_graph) info.fdef
@@ -662,8 +651,7 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
                         }
                       in
                       let fdef_il =
-                        AST_to_IL.function_definition lang ~ctx:!ctx
-                          synthetic_fdef
+                        AST_to_IL.function_definition lang                          synthetic_fdef
                       in
                       let cfg = CFG_build.cfg_of_fdef fdef_il in
                       let db', _sig =
@@ -776,7 +764,7 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
                              --------------------"
                             (IL.str_of_name name));
                       let _flow, fdef_effects, _mapping =
-                        check_fundef taint_inst name !ctx ~glob_env
+                        check_fundef taint_inst name ~glob_env
                           ?builtin_signature_db fdef
                       in
                       record_matches fdef_effects)

--- a/src/engine/Match_tainting_mode.mli
+++ b/src/engine/Match_tainting_mode.mli
@@ -17,7 +17,6 @@ val hook_setup_hook_function_taint_signature :
 val check_fundef :
   Taint_rule_inst.t ->
   IL.name (** entity being analyzed *) ->
-  AST_to_IL.ctx ->
   ?glob_env:Taint_lval_env.t ->
   ?class_name:string ->
   ?signature_db:Shape_and_sig.signature_database ->

--- a/src/engine/tests/Test_dataflow_tainting.ml
+++ b/src/engine/tests/Test_dataflow_tainting.ml
@@ -32,7 +32,7 @@ let test_tainting taint_inst def =
   let fcfg, _effects_IGNORED, mapping =
     Match_tainting_mode.check_fundef taint_inst
       test_name
-      AST_to_IL.empty_ctx def
+      def
   in
   DataflowX.display_mapping fcfg.cfg mapping Taint_lval_env.to_string
 

--- a/src/parsing/Disambiguate_ruby_calls.ml
+++ b/src/parsing/Disambiguate_ruby_calls.ml
@@ -23,8 +23,16 @@ class ['self] visitor =
 
     method! visit_expr_kind env ek =
       match ek with
-      (* Do not recurse into the callee of a Call -- only visit arguments. *)
+      (* Do not recurse into the direct callee of a Call, but DO visit
+         the receiver of a DotAccess callee — in `helper.process()`,
+         `helper` may be an unresolved method call that needs wrapping. *)
       | Call (callee, args) ->
+          let callee = match callee.e with
+            | DotAccess (receiver, tok, field) ->
+                let receiver = self#visit_expr env receiver in
+                { callee with e = DotAccess (receiver, tok, field) }
+            | _ -> callee
+          in
           let args = self#visit_arguments env args in
           Call (callee, args)
       (* Bare unresolved lowercase identifier -- wrap in a zero-arg Call. *)

--- a/src/parsing/Disambiguate_ruby_calls.ml
+++ b/src/parsing/Disambiguate_ruby_calls.ml
@@ -23,16 +23,16 @@ class ['self] visitor =
 
     method! visit_expr_kind env ek =
       match ek with
-      (* Do not recurse into the direct callee of a Call, but DO visit
-         the receiver of a DotAccess callee — in `helper.process()`,
-         `helper` may be an unresolved method call that needs wrapping. *)
+      (* Visit the callee of a Call unless it is a bare N(Id(...)) —
+         visiting that would wrap it in another Call, producing a spurious
+         Call(Call(f, []), args). For compound callees (DotAccess,
+         ArrayAccess, etc.) we DO recurse so that nested bare identifiers
+         like `helper` in `helper.process()` get properly wrapped. *)
+      | Call ({ e = N (Id _); _ } as callee, args) ->
+          let args = self#visit_arguments env args in
+          Call (callee, args)
       | Call (callee, args) ->
-          let callee = match callee.e with
-            | DotAccess (receiver, tok, field) ->
-                let receiver = self#visit_expr env receiver in
-                { callee with e = DotAccess (receiver, tok, field) }
-            | _ -> callee
-          in
+          let callee = self#visit_expr env callee in
           let args = self#visit_arguments env args in
           Call (callee, args)
       (* Bare unresolved lowercase identifier -- wrap in a zero-arg Call. *)

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1544,14 +1544,22 @@ let check_function_call env fun_exp args
       | Some _ -> from_db
       | None ->
           (* lookup_signature failed - check if callee has a Fun shape in lval_env.
-           * This handles the case where a lambda is assigned to a variable like:
-           *   callback := func(x) { sink(x) }
-           *   callback(source())
-           * The signature is stored under the lambda's internal name (_tmp_lambda:N),
-           * but the variable 'callback' has the Fun shape from the assignment. *)
+           * This handles two cases:
+           *   callback(source())       -- direct call, lval = callback
+           *   callback.run(source())   -- invoke method, lval = callback.run
+           * For invoke methods (e.g. Java Runnable.run), strip the method offset
+           * and look up the base variable. *)
           (match fun_exp.e with
           | Fetch lval ->
-              (match Lval_env.find_lval env.lval_env lval with
+              let lval_to_check =
+                let invoke_methods = (Lang_config.get env.taint_inst.lang).invoke_methods in
+                match lval.rev_offset with
+                | [{ o = Dot method_name; _ }]
+                  when List.mem (fst method_name.ident) invoke_methods ->
+                    { lval with rev_offset = [] }
+                | _ -> lval
+              in
+              (match Lval_env.find_lval env.lval_env lval_to_check with
               | Some (S.Cell (_, S.Fun fun_sig)) ->
                   Log.debug (fun m ->
                       m "SIG_FROM_SHAPE: Found Fun shape for %s"
@@ -2123,16 +2131,12 @@ let call_with_intrafile lval_opt e env args instr =
                    * In this case we return empty taints - the callback's return will be handled
                    * when the ToSinkInCall effect is instantiated. *)
                   let is_method_callback_invoke =
-                    (* Check if this is a method call pattern on a callback parameter *)
-                    match env.taint_inst.lang, e_obj, e.e with
-                    | Lang.Java, `Obj (_, S.Arg _), Fetch { rev_offset = { o = Dot name; _ } :: _; _ } ->
-                        (* Java Function.apply or similar callback invocation methods *)
-                        let method_name = fst name.ident in
-                        method_name = "apply" || method_name = "accept" || method_name = "test" || method_name = "get"
-                    | Lang.Ruby, `Obj (_, S.Arg _), Fetch { rev_offset = { o = Dot name; _ } :: _; _ } ->
-                        (* Ruby proc/lambda.call invocation *)
-                        let method_name = fst name.ident in
-                        method_name = "call"
+                    (* Check if this is a method call on a callback parameter
+                     * via a configured invoke method (e.g. .apply, .call, .run). *)
+                    match e_obj, e.e with
+                    | `Obj (_, S.Arg _), Fetch { rev_offset = { o = Dot name; _ } :: _; _ } ->
+                        let invoke_methods = (Lang_config.get env.taint_inst.lang).invoke_methods in
+                        List.mem (fst name.ident) invoke_methods
                     | _ -> false
                   in
                   let callee_is_callback =

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -773,6 +773,17 @@ let lambdas_to_analyze_in_node env lambdas node =
   in
   Option.to_list unused_lambda_def @ lambdas_used_in_node lambdas node
 
+(* Collect ALL lambdas recursively from a fun_cfg, in innermost-first order.
+   This ensures nested lambda signatures are extracted before their parents. *)
+let rec collect_all_lambdas_innermost_first (fun_cfg : IL.fun_cfg)
+    : (IL.name * IL.fun_cfg) list =
+  IL.NameMap.fold (fun name lcfg results ->
+    (* First collect nested lambdas from this lambda *)
+    let nested = collect_all_lambdas_innermost_first lcfg in
+    (* Then add this lambda after its nested ones *)
+    results @ nested @ [(name, lcfg)]
+  ) fun_cfg.lambdas []
+
 (*****************************************************************************)
 (* Miscellaneous *)
 (*****************************************************************************)
@@ -1527,7 +1538,27 @@ let check_function_call env fun_exp args
         (Display_IL.string_of_exp fun_exp) arity
         env.taint_inst.options.taint_intrafile);
   let sig_result =
-    if env.taint_inst.options.taint_intrafile then lookup_signature env fun_exp arity
+    if env.taint_inst.options.taint_intrafile then
+      let from_db = lookup_signature env fun_exp arity in
+      match from_db with
+      | Some _ -> from_db
+      | None ->
+          (* lookup_signature failed - check if callee has a Fun shape in lval_env.
+           * This handles the case where a lambda is assigned to a variable like:
+           *   callback := func(x) { sink(x) }
+           *   callback(source())
+           * The signature is stored under the lambda's internal name (_tmp:N),
+           * but the variable 'callback' has the Fun shape from the assignment. *)
+          (match fun_exp.e with
+          | Fetch lval ->
+              (match Lval_env.find_lval env.lval_env lval with
+              | Some (S.Cell (_, S.Fun fun_sig)) ->
+                  Log.debug (fun m ->
+                      m "SIG_FROM_SHAPE: Found Fun shape for %s"
+                        (Display_IL.string_of_exp fun_exp));
+                  Some fun_sig
+              | _ -> None)
+          | _ -> None)
     else None
   in
   match sig_result with
@@ -2303,20 +2334,10 @@ let check_tainted_instr env instr : Taints.t * S.shape * Lval_env.t =
                       (* Check if this is a call to a function parameter (either direct or via method) *)
                       (match e_obj with
                       | `Obj (_obj_taints, S.Arg _fun_arg) ->
-                          (* This is a method call on a function parameter (e.g., callback.apply in Java).
-                           * Treat it as invoking the callback.
-                           * EXCEPTION: Ruby's .call method should NOT be treated this way during signature
-                           * extraction, as it creates infinite recursion. Ruby blocks are handled via
-                           * implicit lambda detection instead. *)
-                          let is_ruby_call_method =
-                            match (e.e, env.taint_inst.lang) with
-                            | Fetch { base = _; rev_offset = [{ o = Dot method_name; _ }] }, lang
-                              when Lang.(lang =*= Ruby) && fst method_name.ident = "call" -> true
-                            | _ -> false
-                          in
-                          if not is_ruby_call_method then
-                            effects_of_call_func_arg e (match e_obj with `Obj (_, shape) -> shape | `Fun -> e_shape) args_taints
-                            |> record_effects { env with lval_env }
+                          (* This is a method call on a function parameter (e.g., callback.apply in Java,
+                           * callback.call in Ruby). Treat it as invoking the callback. *)
+                          effects_of_call_func_arg e (match e_obj with `Obj (_, shape) -> shape | `Fun -> e_shape) args_taints
+                          |> record_effects { env with lval_env }
                       | _ ->
                           effects_of_call_func_arg e e_shape args_taints
                           |> record_effects { env with lval_env });
@@ -2879,13 +2900,17 @@ and (fixpoint :
       | None -> in_env
     else in_env
   in
-  (* Extract signatures for all lambdas in the function for HOF support *)
+  (* Extract signatures for all lambdas in the function for HOF support.
+     We collect ALL lambdas (including nested ones) in innermost-first order,
+     so nested lambda signatures are available when processing their parents. *)
   let signature_db_with_lambdas =
     if taint_inst.options.taint_intrafile then
       match signature_db with
       | Some db ->
-          IL.NameMap.fold
-            (fun lambda_name lambda_cfg acc_db ->
+          (* Collect all lambdas recursively, innermost first *)
+          let all_lambdas_list = collect_all_lambdas_innermost_first fun_cfg in
+          List.fold_left
+            (fun acc_db (lambda_name, lambda_cfg) ->
               try
                    Log.debug (fun m ->
                        m "Extracting signature for lambda %s"
@@ -2982,7 +3007,7 @@ and (fixpoint :
                            (IL.str_of_name lambda_name)
                            (Printexc.to_string e));
                      acc_db)
-            fun_cfg.lambdas db
+            db all_lambdas_list
           |> Option.some
       | None -> signature_db
     else signature_db

--- a/src/tainting/Dataflow_tainting.ml
+++ b/src/tainting/Dataflow_tainting.ml
@@ -1547,7 +1547,7 @@ let check_function_call env fun_exp args
            * This handles the case where a lambda is assigned to a variable like:
            *   callback := func(x) { sink(x) }
            *   callback(source())
-           * The signature is stored under the lambda's internal name (_tmp:N),
+           * The signature is stored under the lambda's internal name (_tmp_lambda:N),
            * but the variable 'callback' has the Fun shape from the assignment. *)
           (match fun_exp.e with
           | Fetch lval ->

--- a/src/tainting/Graph_from_AST.ml
+++ b/src/tainting/Graph_from_AST.ml
@@ -702,10 +702,11 @@ let extract_hof_callbacks ?(_object_mappings = []) ?(all_funcs = [])
         (match e.G.e with
         (* Ruby/Scala block pattern: f(args) { block } is Call(Call(callee, inner_args), [block]).
            Merge inner_args and block args so the HOF detection sees all arguments together. *)
-        | G.Call ({ e = G.Call (callee, inner_args); _ }, outer_args)
+        | G.Call ({ e = G.Call (callee, inner_args); _ },
+                  (_, ([ G.Arg { G.e = G.Lambda _; _ } ] as outer_arg), _))
           when Lang.(lang =*= Ruby || lang =*= Scala) ->
             let merged_args = Tok.unsafe_fake_bracket
-              (Tok.unbracket inner_args @ Tok.unbracket outer_args) in
+              (Tok.unbracket inner_args @ outer_arg) in
             let found = extract_hof_callbacks_from_call
               ~method_hofs ~function_hofs ~all_funcs ~caller_parent_path
               callee merged_args

--- a/src/tainting/Graph_from_AST.ml
+++ b/src/tainting/Graph_from_AST.ml
@@ -437,7 +437,26 @@ let extract_calls ~(lang : Lang.t) ?(object_mappings = []) ?(all_funcs = []) ?(c
                       | [] -> Tok.unsafe_fake_tok "")
                 in
                 calls := (fn_id, tok) :: !calls
-            | None -> ());
+            | None ->
+                (* Invoke-method pattern: var.run() where var is a lambda.
+                   If the method name is a configured invoke method, look for
+                   a lambda with the receiver's name in the current scope. *)
+                let invoke_methods = (Lang_config.get lang).invoke_methods in
+                (match callee.G.e with
+                | G.DotAccess ({ e = G.N (G.Id ((var_name, _), _)); _ }, _,
+                               G.FN (G.Id ((method_name, method_tok), _)))
+                  when List.mem method_name invoke_methods ->
+                    let lambda_match = List.find_opt (fun (f : func_info) ->
+                      match List_.init_and_last_opt f.fn_id with
+                      | Some (f_parent, Some name)
+                        when String.equal (fst name.IL.ident) var_name ->
+                          equal_with_pos f_parent caller_parent_path
+                      | _ -> false
+                    ) all_funcs in
+                    (match lambda_match with
+                    | Some f -> calls := (f.fn_id, method_tok) :: !calls
+                    | None -> ())
+                | _ -> ()));
             (* Check arguments for unresolved function calls (Ruby-style) *)
             List.iter check_arg_for_unresolved_function_call args_list;
             (* Visit callee expression for nested calls (e.g., Ruby's File.open(path_for(x)) do ... end

--- a/src/tainting/Graph_from_AST.ml
+++ b/src/tainting/Graph_from_AST.ml
@@ -702,7 +702,8 @@ let extract_hof_callbacks ?(_object_mappings = []) ?(all_funcs = [])
         (match e.G.e with
         (* Ruby/Scala block pattern: f(args) { block } is Call(Call(callee, inner_args), [block]).
            Merge inner_args and block args so the HOF detection sees all arguments together. *)
-        | G.Call ({ e = G.Call (callee, inner_args); _ }, outer_args) ->
+        | G.Call ({ e = G.Call (callee, inner_args); _ }, outer_args)
+          when Lang.(lang =*= Ruby || lang =*= Scala) ->
             let merged_args = Tok.unsafe_fake_bracket
               (Tok.unbracket inner_args @ Tok.unbracket outer_args) in
             let found = extract_hof_callbacks_from_call

--- a/src/tainting/Graph_from_AST.ml
+++ b/src/tainting/Graph_from_AST.ml
@@ -121,12 +121,12 @@ let fn_id_of_entity ~(lang : Lang.t) (opt_ent : G.entity option)
           Some (adjusted_parent_path @ [Some name])
       | None -> None)
   | None ->
-      (* Anonymous function - use _tmp with fake token to match AST_to_IL behavior.
-         AST_to_IL.fresh_var creates fake tokens for _tmp variables. *)
+      (* Anonymous function - use _tmp_lambda with fake token to match AST_to_IL behavior.
+         AST_to_IL.fresh_var creates fake tokens for lambda variables. *)
       let tok = match fdef.fkind with (_, tok) -> tok in
-      let fake_tok = Tok.fake_tok tok "_tmp" in
+      let fake_tok = Tok.fake_tok tok "_tmp_lambda" in
       let tmp_name = IL.{
-        ident = ("_tmp", fake_tok);
+        ident = ("_tmp_lambda", fake_tok);
         sid = G.SId.unsafe_default;
         id_info = G.empty_id_info ();
       } in
@@ -557,10 +557,10 @@ let extract_callback_from_arg (arg_expr : G.expr) : (IL.name * Tok.t * IL.name o
       | G.Call ({ e = G.N (G.Id (id, id_info))
                     | G.DotAccess (_, _, G.FN (G.Id (id, id_info))); _ }, _) ->
           let callback_name = AST_to_IL.var_of_id_info id id_info in
-          (* Create _tmp IL.name using Tok.fake_tok like AST_to_IL.fresh_var does *)
-          let tmp_tok = Tok.fake_tok shortlambda_tok "_tmp" in
+          (* Create _tmp_lambda IL.name using Tok.fake_tok like AST_to_IL.fresh_var does *)
+          let tmp_tok = Tok.fake_tok shortlambda_tok "_tmp_lambda" in
           let tmp_name = IL.{
-            ident = ("_tmp", tmp_tok);
+            ident = ("_tmp_lambda", tmp_tok);
             sid = G.SId.unsafe_default;
             id_info = G.empty_id_info ();
           } in
@@ -700,6 +700,16 @@ let extract_hof_callbacks ?(_object_mappings = []) ?(all_funcs = [])
       inherit [_] G.iter as super
       method! visit_expr env e =
         (match e.G.e with
+        (* Ruby/Scala block pattern: f(args) { block } is Call(Call(callee, inner_args), [block]).
+           Merge inner_args and block args so the HOF detection sees all arguments together. *)
+        | G.Call ({ e = G.Call (callee, inner_args); _ }, outer_args) ->
+            let merged_args = Tok.unsafe_fake_bracket
+              (Tok.unbracket inner_args @ Tok.unbracket outer_args) in
+            let found = extract_hof_callbacks_from_call
+              ~method_hofs ~function_hofs ~all_funcs ~caller_parent_path
+              callee merged_args
+            in
+            callbacks := found @ !callbacks
         | G.Call (callee, args) ->
             let found = extract_hof_callbacks_from_call
               ~method_hofs ~function_hofs ~all_funcs ~caller_parent_path

--- a/src/tainting/Lang_config.ml
+++ b/src/tainting/Lang_config.ml
@@ -51,6 +51,10 @@ type t = {
   collection_configs : collection_model_kind list;
   constructor_names : string list;
   uses_new_keyword : bool;
+  (* Methods that invoke `self` as a function.  E.g. Runnable.run() in Java,
+     Proc#call in Ruby.  When a variable with Fun shape is the receiver of one
+     of these methods, the call is treated as a direct lambda invocation. *)
+  invoke_methods : string list;
 }
 
 (* ========================================================================== *)
@@ -62,6 +66,7 @@ let empty = {
   collection_configs = [];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let python = {
@@ -84,6 +89,7 @@ let python = {
   ];
   constructor_names = ["__init__"];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let ruby = {
@@ -111,6 +117,7 @@ let ruby = {
   ];
   constructor_names = ["initialize"];
   uses_new_keyword = false;
+  invoke_methods = ["call"];
 }
 
 let javascript = {
@@ -139,6 +146,7 @@ let javascript = {
   ];
   constructor_names = ["constructor"];
   uses_new_keyword = true;
+  invoke_methods = [];
 }
 
 let typescript = {
@@ -171,6 +179,7 @@ let java = {
   ];
   constructor_names = ["<init>"];
   uses_new_keyword = true;
+  invoke_methods = ["run"; "call"; "apply"; "accept"; "invoke"];
 }
 
 let kotlin = {
@@ -201,6 +210,7 @@ let kotlin = {
   ];
   constructor_names = ["<init>"; "init"; "constructor"];
   uses_new_keyword = false;
+  invoke_methods = ["invoke"];
 }
 
 let scala = {
@@ -223,6 +233,7 @@ let scala = {
   ];
   constructor_names = ["<init>"];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let csharp = {
@@ -247,6 +258,7 @@ let csharp = {
   ];
   constructor_names = [".ctor"];
   uses_new_keyword = true;
+  invoke_methods = ["Invoke"];
 }
 
 let go = {
@@ -258,6 +270,7 @@ let go = {
   ];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let rust = {
@@ -280,6 +293,7 @@ let rust = {
   ];
   constructor_names = ["new"];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let swift = {
@@ -303,6 +317,7 @@ let swift = {
   ];
   constructor_names = ["init"];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let php = {
@@ -313,6 +328,7 @@ let php = {
   collection_configs = [];  (* PHP collections are mostly handled via builtin functions *)
   constructor_names = ["__construct"];
   uses_new_keyword = true;
+  invoke_methods = [];
 }
 
 let cpp = {
@@ -323,6 +339,7 @@ let cpp = {
   collection_configs = [];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let c = {
@@ -335,6 +352,7 @@ let ocaml_lang = {
   collection_configs = [];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let lua = {
@@ -342,6 +360,7 @@ let lua = {
   collection_configs = [];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let dart = {
@@ -349,6 +368,7 @@ let dart = {
   collection_configs = [];
   constructor_names = ["constructor"];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let elixir = {
@@ -364,6 +384,7 @@ let elixir = {
   collection_configs = [];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let julia = {
@@ -373,6 +394,7 @@ let julia = {
   collection_configs = [];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let clojure = {
@@ -394,6 +416,7 @@ let clojure = {
   collection_configs = [];
   constructor_names = [];
   uses_new_keyword = false;
+  invoke_methods = [];
 }
 
 let apex = {
@@ -401,6 +424,7 @@ let apex = {
   collection_configs = [];
   constructor_names = ["<init>"];
   uses_new_keyword = true;
+  invoke_methods = [];
 }
 
 let vb = {
@@ -408,6 +432,7 @@ let vb = {
   collection_configs = [];
   constructor_names = ["New"];
   uses_new_keyword = true;
+  invoke_methods = [];
 }
 
 (* ========================================================================== *)

--- a/tests/rules/cross_function_tainting/test_hof_callback_taint_ruby.rb
+++ b/tests/rules/cross_function_tainting/test_hof_callback_taint_ruby.rb
@@ -22,8 +22,7 @@ end
 # === Callback-only HOF tests ===
 
 def test_callback_only_propagating_lambda()
-  # todoruleid: test-hof-callback-taint
-  # TODO: Ruby lambda callback not yet working
+  # ruleid: test-hof-callback-taint
   sink(app_callback_only(->(x) { x }, source()))
 end
 
@@ -37,14 +36,12 @@ end
 # === Direct flow HOF tests (taint always flows via + x) ===
 
 def test_direct_flow_propagating_lambda()
-  # todoruleid: test-hof-callback-taint
-  # TODO: Ruby lambda callback not yet working
+  # ruleid: test-hof-callback-taint
   sink(app_with_direct_flow(->(x) { x }, source()))
 end
 
 def test_direct_flow_sanitizing_lambda()
-  # todoruleid: test-hof-callback-taint
-  # TODO: Ruby lambda callback not yet working - but taint should flow via + x
+  # ruleid: test-hof-callback-taint
   sink(app_with_direct_flow(->(x) { "3" }, source()))
 end
 

--- a/tests/rules/cross_function_tainting/test_invoke_methods_csharp.cs
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_csharp.cs
@@ -1,0 +1,31 @@
+// C#: nested lambdas invoked via .Invoke()
+class TestInvokeMethods {
+
+    static void test_invoke() {
+        var x = source();
+        Action outer = () => {
+            Action inner = () => {
+                // ruleid: test-invoke-methods-csharp
+                sink(x);
+            };
+            inner.Invoke();
+        };
+        outer.Invoke();
+    }
+
+    // Negative: no taint
+    static void test_no_taint() {
+        var x = "clean";
+        Action outer = () => {
+            Action inner = () => {
+                // ok: test-invoke-methods-csharp
+                sink(x);
+            };
+            inner.Invoke();
+        };
+        outer.Invoke();
+    }
+
+    static string source() { return "tainted"; }
+    static void sink(string x) {}
+}

--- a/tests/rules/cross_function_tainting/test_invoke_methods_csharp.yaml
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_csharp.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-invoke-methods-csharp
+    message: Taint flows through lambda invoked via .Invoke()
+    languages:
+      - csharp
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_invoke_methods_java.java
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_java.java
@@ -1,0 +1,72 @@
+class TestInvokeMethods {
+
+    // Function.apply: nested lambdas invoked via apply
+    static void test_apply() {
+        String x = source();
+        Function outer = (a) -> {
+            Function inner = (b) -> {
+                // ruleid: test-invoke-methods-java
+                sink(b);
+                return b;
+            };
+            return inner.apply(a);
+        };
+        outer.apply(x);
+    }
+
+    // Consumer.accept: nested lambdas invoked via accept
+    static void test_accept() {
+        String x = source();
+        Consumer outer = (a) -> {
+            Consumer inner = (b) -> {
+                // ruleid: test-invoke-methods-java
+                sink(b);
+            };
+            inner.accept(a);
+        };
+        outer.accept(x);
+    }
+
+    // Runnable.run: nested lambdas capturing tainted variable
+    static void test_run() {
+        String x = source();
+        Runnable outer = () -> {
+            Runnable inner = () -> {
+                // ruleid: test-invoke-methods-java
+                sink(x);
+            };
+            inner.run();
+        };
+        outer.run();
+    }
+
+    // Callable.call: nested lambdas capturing tainted variable
+    static void test_call() {
+        String x = source();
+        Callable outer = () -> {
+            Callable inner = () -> {
+                // ruleid: test-invoke-methods-java
+                sink(x);
+                return x;
+            };
+            return inner.call();
+        };
+        outer.call();
+    }
+
+    // Negative: no taint source, nested
+    static void test_no_taint() {
+        String x = "clean";
+        Runnable outer = () -> {
+            Runnable inner = () -> {
+                // ok: test-invoke-methods-java
+                sink(x);
+            };
+            inner.run();
+        };
+        outer.run();
+    }
+
+    static String source() { return "tainted"; }
+    static void sink(String x) {}
+}

--- a/tests/rules/cross_function_tainting/test_invoke_methods_java.yaml
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_java.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-invoke-methods-java
+    message: Taint flows through lambda invoked via functional interface method
+    languages:
+      - java
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_invoke_methods_kotlin.kt
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_kotlin.kt
@@ -1,0 +1,28 @@
+// Kotlin: nested lambdas invoked via .invoke()
+fun test_invoke() {
+    val x = source()
+    val outer: () -> Unit = {
+        val inner: () -> Unit = {
+            // ruleid: test-invoke-methods-kotlin
+            sink(x)
+        }
+        inner.invoke()
+    }
+    outer.invoke()
+}
+
+// Negative: no taint
+fun test_no_taint() {
+    val x = "clean"
+    val outer: () -> Unit = {
+        val inner: () -> Unit = {
+            // ok: test-invoke-methods-kotlin
+            sink(x)
+        }
+        inner.invoke()
+    }
+    outer.invoke()
+}
+
+fun source(): String = "tainted"
+fun sink(x: String) {}

--- a/tests/rules/cross_function_tainting/test_invoke_methods_kotlin.yaml
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_kotlin.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-invoke-methods-kotlin
+    message: Taint flows through lambda invoked via .invoke()
+    languages:
+      - kotlin
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_invoke_methods_ruby.rb
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_ruby.rb
@@ -1,0 +1,32 @@
+# Ruby: nested lambdas invoked via .call()
+def test_call()
+  x = source()
+  outer = ->(a) {
+    inner = ->(b) {
+      # ruleid: test-invoke-methods-ruby
+      sink(b)
+    }
+    inner.call(a)
+  }
+  outer.call(x)
+end
+
+# Negative: no taint
+def test_no_taint()
+  x = "clean"
+  outer = ->() {
+    inner = ->() {
+      # ok: test-invoke-methods-ruby
+      sink(x)
+    }
+    inner.call()
+  }
+  outer.call()
+end
+
+def source()
+  "tainted"
+end
+
+def sink(x)
+end

--- a/tests/rules/cross_function_tainting/test_invoke_methods_ruby.yaml
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_ruby.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-invoke-methods-ruby
+    message: Taint flows through lambda invoked via .call()
+    languages:
+      - ruby
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested.go
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested.go
@@ -1,0 +1,37 @@
+package main
+
+// Test: Deeply nested lambdas (3 levels)
+func test4() {
+	x := source()
+	level1 := func() {
+		level2 := func() {
+			level3 := func() {
+				// ruleid: test-lambda-deeply-nested
+				sink(x)
+			}
+			level3()
+		}
+		level2()
+	}
+	level1()
+}
+
+// Test: Deeply nested lambdas split across functions
+func test4_level1(x string) {
+	level2 := func() {
+		level3 := func() {
+			// ruleid: test-lambda-deeply-nested
+			sink(x)
+		}
+		level3()
+	}
+	level2()
+}
+
+func test4_caller() {
+	x := source()
+	test4_level1(x)
+}
+
+func source() string { return "tainted" }
+func sink(s string) {}

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-deeply-nested
+    message: Tainted data flows to sink through deeply nested lambdas
+    languages:
+      - go
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_java.java
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_java.java
@@ -1,0 +1,38 @@
+// Test: Deeply nested lambdas (3 levels)
+class TestLambdaDeeplyNested {
+
+    static void test4() {
+        String x = source();
+        Runnable level1 = () -> {
+            Runnable level2 = () -> {
+                Runnable level3 = () -> {
+                    // ruleid: test-lambda-deeply-nested-java
+                    sink(x);
+                };
+                level3();
+            };
+            level2();
+        };
+        level1();
+    }
+
+    // Test: Deeply nested lambdas split across functions
+    static void test4_level1(String x) {
+        Runnable level2 = () -> {
+            Runnable level3 = () -> {
+                // ruleid: test-lambda-deeply-nested-java
+                sink(x);
+            };
+            level3();
+        };
+        level2();
+    }
+
+    static void test4_caller() {
+        String x = source();
+        test4_level1(x);
+    }
+
+    static String source() { return "tainted"; }
+    static void sink(String x) {}
+}

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_java.java
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_java.java
@@ -9,11 +9,11 @@ class TestLambdaDeeplyNested {
                     // ruleid: test-lambda-deeply-nested-java
                     sink(x);
                 };
-                level3();
+                level3.run();
             };
-            level2();
+            level2.run();
         };
-        level1();
+        level1.run();
     }
 
     // Test: Deeply nested lambdas split across functions
@@ -23,9 +23,9 @@ class TestLambdaDeeplyNested {
                 // ruleid: test-lambda-deeply-nested-java
                 sink(x);
             };
-            level3();
+            level3.run();
         };
-        level2();
+        level2.run();
     }
 
     static void test4_caller() {

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_java.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_java.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-deeply-nested-java
+    message: Tainted data flows to sink through deeply nested lambdas
+    languages:
+      - java
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_js.js
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_js.js
@@ -1,0 +1,35 @@
+// Test: Deeply nested lambdas (3 levels)
+function test4() {
+    let x = source();
+    let level1 = () => {
+        let level2 = () => {
+            let level3 = () => {
+                // ruleid: test-lambda-deeply-nested-js
+                sink(x);
+            };
+            level3();
+        };
+        level2();
+    };
+    level1();
+}
+
+// Test: Deeply nested lambdas split across functions
+function test4_level1(x) {
+    let level2 = () => {
+        let level3 = () => {
+            // ruleid: test-lambda-deeply-nested-js
+            sink(x);
+        };
+        level3();
+    };
+    level2();
+}
+
+function test4_caller() {
+    let x = source();
+    test4_level1(x);
+}
+
+function source() { return "tainted"; }
+function sink(x) {}

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_js.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_js.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-deeply-nested-js
+    message: Tainted data flows to sink through deeply nested lambdas
+    languages:
+      - javascript
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_php.php
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_php.php
@@ -1,0 +1,37 @@
+<?php
+
+// Test: Deeply nested lambdas (3 levels)
+function test4() {
+    $x = source();
+    $level1 = function($x) {
+        $level2 = function($x) {
+            $level3 = function($x) {
+                // ruleid: test-lambda-deeply-nested-php
+                sink($x);
+            };
+            $level3($x);
+        };
+        $level2($x);
+    };
+    $level1($x);
+}
+
+// Test: Deeply nested lambdas split across functions
+function test4_level1($x) {
+    $level2 = function($x) {
+        $level3 = function($x) {
+            // ruleid: test-lambda-deeply-nested-php
+            sink($x);
+        };
+        $level3($x);
+    };
+    $level2($x);
+}
+
+function test4_caller() {
+    $x = source();
+    test4_level1($x);
+}
+
+function source() { return "tainted"; }
+function sink($x) {}

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_php.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_php.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-deeply-nested-php
+    message: Tainted data flows to sink through deeply nested lambdas
+    languages:
+      - php
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_py.py
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_py.py
@@ -1,0 +1,25 @@
+# Test: Deeply nested lambdas (3 levels)
+def test4():
+    x = source()
+    # ruleid: test-lambda-deeply-nested-py
+    level3 = lambda: sink(x)
+    level2 = lambda: level3()
+    level1 = lambda: level2()
+    level1()
+
+# Test: Deeply nested lambdas split across functions
+def test4_level1(x):
+    # ruleid: test-lambda-deeply-nested-py
+    level3 = lambda: sink(x)
+    level2 = lambda: level3()
+    level2()
+
+def test4_caller():
+    x = source()
+    test4_level1(x)
+
+def source():
+    return "tainted"
+
+def sink(x):
+    pass

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_py.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_py.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-deeply-nested-py
+    message: Tainted data flows to sink through deeply nested lambdas
+    languages:
+      - python
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_rust.rs
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_rust.rs
@@ -1,0 +1,35 @@
+// Test: Deeply nested lambdas (3 levels)
+fn test4() {
+    let x = source();
+    let level1 = || {
+        let level2 = || {
+            let level3 = || {
+                // ruleid: test-lambda-deeply-nested-rust
+                sink(&x);
+            };
+            level3();
+        };
+        level2();
+    };
+    level1();
+}
+
+// Test: Deeply nested lambdas split across functions
+fn test4_level1(x: String) {
+    let level2 = || {
+        let level3 = || {
+            // ruleid: test-lambda-deeply-nested-rust
+            sink(&x);
+        };
+        level3();
+    };
+    level2();
+}
+
+fn test4_caller() {
+    let x = source();
+    test4_level1(x);
+}
+
+fn source() -> String { String::from("tainted") }
+fn sink(_s: &String) {}

--- a/tests/rules/cross_function_tainting/test_lambda_deeply_nested_rust.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_deeply_nested_rust.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-deeply-nested-rust
+    message: Tainted data flows to sink through deeply nested lambdas
+    languages:
+      - rust
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_nested_captured.go
+++ b/tests/rules/cross_function_tainting/test_lambda_nested_captured.go
@@ -1,0 +1,16 @@
+package main
+
+// Test: Nested lambda capturing parent lambda's parameter
+func test2() {
+	outer := func(a string) {
+		inner := func() {
+			// ruleid: test-lambda-nested-captured
+			sink(a)
+		}
+		inner()
+	}
+	outer(source())
+}
+
+func source() string { return "tainted" }
+func sink(s string) {}

--- a/tests/rules/cross_function_tainting/test_lambda_nested_captured.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_nested_captured.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-nested-captured
+    message: Tainted data flows to sink via captured variable from outer lambda
+    languages:
+      - go
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_nested_param.go
+++ b/tests/rules/cross_function_tainting/test_lambda_nested_param.go
@@ -1,0 +1,16 @@
+package main
+
+// Test: Nested lambda with param at each level
+func test5() {
+	outer := func(a string) {
+		inner := func(b string) {
+			// ruleid: test-lambda-nested-param
+			sink(b)
+		}
+		inner(a)
+	}
+	outer(source())
+}
+
+func source() string { return "tainted" }
+func sink(s string) {}

--- a/tests/rules/cross_function_tainting/test_lambda_nested_param.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_nested_param.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-nested-param
+    message: Tainted data flows to sink through nested lambda parameters
+    languages:
+      - go
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_no_taint.go
+++ b/tests/rules/cross_function_tainting/test_lambda_no_taint.go
@@ -1,0 +1,14 @@
+package main
+
+// Test: No taint - should have NO findings
+func test6() {
+	x := "clean"
+	callback := func() {
+		// ok: test-lambda-no-taint
+		sink(x)
+	}
+	callback()
+}
+
+func source() string { return "tainted" }
+func sink(s string) {}

--- a/tests/rules/cross_function_tainting/test_lambda_no_taint.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_no_taint.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-no-taint
+    message: Tainted data flows to sink
+    languages:
+      - go
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_param_flow.go
+++ b/tests/rules/cross_function_tainting/test_lambda_param_flow.go
@@ -1,0 +1,13 @@
+package main
+
+// Test: Lambda parameter receives taint at call site
+func test3() {
+	callback := func(x string) {
+		// ruleid: test-lambda-param-flow
+		sink(x)
+	}
+	callback(source())
+}
+
+func source() string { return "tainted" }
+func sink(s string) {}

--- a/tests/rules/cross_function_tainting/test_lambda_param_flow.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_param_flow.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-param-flow
+    message: Tainted data flows to sink via lambda parameter
+    languages:
+      - go
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_lambda_simple_captured.go
+++ b/tests/rules/cross_function_tainting/test_lambda_simple_captured.go
@@ -1,0 +1,14 @@
+package main
+
+// Test: Simple lambda with captured variable
+func test1() {
+	x := source()
+	callback := func() {
+		// ruleid: test-lambda-simple-captured
+		sink(x)
+	}
+	callback()
+}
+
+func source() string { return "tainted" }
+func sink(s string) {}

--- a/tests/rules/cross_function_tainting/test_lambda_simple_captured.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_simple_captured.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-lambda-simple-captured
+    message: Tainted data flows to sink via captured variable in lambda
+    languages:
+      - go
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink($X)

--- a/tests/rules/cross_function_tainting/test_ruby_chained_method.rb
+++ b/tests/rules/cross_function_tainting/test_ruby_chained_method.rb
@@ -1,0 +1,20 @@
+# Test that taint flows through chained method calls where the receiver
+# is itself a method call: get_data.strip should call get_data() first.
+
+class Controller
+  def show
+    # ruleid: test-ruby-chained-method
+    sink(get_data.strip)
+  end
+
+  def get_data
+    source()
+  end
+end
+
+def source()
+  "tainted"
+end
+
+def sink(x)
+end

--- a/tests/rules/cross_function_tainting/test_ruby_chained_method.yaml
+++ b/tests/rules/cross_function_tainting/test_ruby_chained_method.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-ruby-chained-method
+    message: taint through chained method call
+    languages:
+      - ruby
+    severity: WARNING
+    mode: taint
+    options:
+      taint_intrafile: true
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
## Summary

Fix taint tracking through nested lambdas in intrafile mode. Clean up Ruby call disambiguation. Add support for functional interface invoke methods.

## Changes

### Nested lambda taint tracking (all languages)

- **Function_id.ml**: For lambda names (prefixed `_tmp_lambda`), extract position from fake tokens to distinguish different lambdas that would otherwise collide on the same name.
- **AST_to_IL.ml**: Use `_tmp_lambda` prefix for lambda fresh variables (instead of generic `_tmp`).
- **Dataflow_tainting.ml**: Collect all lambdas recursively in innermost-first order so nested lambda signatures are available when processing their parents. Add signature lookup fallback via `Fun` shape in `lval_env` for variable-assigned lambdas.
- **Graph_from_AST.ml**: Update `_tmp` to `_tmp_lambda` to match AST_to_IL.

### Ruby cleanup: remove `ident_function_call_hack`

- **AST_to_IL.ml**: Remove the `ident_function_call_hack` and all associated dead code (`IdentSet`, `ctx`, `empty_ctx`, `add_entity_name`, `?ctx` parameter). This is now handled by `Disambiguate_ruby_calls` at the AST level.
- **Disambiguate_ruby_calls.ml**: Visit Call callees for all non-`N(Id(...))` cases (not just DotAccess), so unresolved method calls like `helper` in `helper.process()` get properly wrapped.
- **Match_tainting_mode.ml**: Remove `ctx` parameter from `check_fundef` and the visitor that populated `entity_names`.

### Ruby/Scala do-block flattening

- **AST_to_IL.ml**: Flatten `Call(Call(f, args), [Lambda])` into `Call(f, args @ [Lambda])` for Ruby. Pattern-matches exactly a singleton Lambda argument.
- **Graph_from_AST.ml**: Same flattening for HOF callback extraction, gated by `lang = Ruby || Scala`.

### Functional interface invoke methods

- **Lang_config.ml**: Add `invoke_methods` field. Configured for Java (`run`, `call`, `apply`, `accept`, `invoke`), Kotlin (`invoke`), C# (`Invoke`), Ruby (`call`).
- **Graph_from_AST.ml**: When a call like `r.run()` has no callee match and the method is in `invoke_methods`, add a call graph edge to the matching lambda in scope.
- **Dataflow_tainting.ml**: In the signature lookup fallback, strip invoke method offsets to find the base variable's `Fun` shape. Consolidate the hardcoded callback invoke method checks to use `Lang_config.invoke_methods`.

### Tests

- Nested lambda tests for Go (5 patterns + 1 negative), Java, JS, PHP, Python, Rust
- Invoke method tests for Java (`apply`, `accept`, `run`, `call`), Kotlin (`invoke`), C# (`Invoke`), Ruby (`call`)
- Ruby: chained method taint test, updated HOF callback tests