### PR TITLE
Fix text encoding in python CLI

### DIFF
--- a/cli/src/semgrep/commands/wrapper.py
+++ b/cli/src/semgrep/commands/wrapper.py
@@ -26,6 +26,10 @@ def handle_command_errors(func: Callable) -> Callable:
 
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> NoReturn:
+        # Ensure stdout uses UTF-8 with replacement characters so that scan
+        # results containing non-UTF-8 file content never cause a crash.
+        if hasattr(sys.stdout, "reconfigure"):
+            sys.stdout.reconfigure(encoding="utf-8", errors="replace")
         # When running semgrep as a command line tool
         # silence root level logger otherwise logs higher
         # than warning are handled twice

--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -48,6 +48,7 @@ def git_check_output(command: Sequence[str], cwd: Optional[str] = None) -> str:
             command,
             stderr=subprocess.PIPE,
             encoding="utf-8",
+            errors="replace",
             timeout=env.git_command_timeout,
             cwd=cwd,
         ).strip()
@@ -215,6 +216,7 @@ class BaselineHandler:
                 timeout=env.git_command_timeout,
                 capture_output=True,
                 encoding="utf-8",
+                errors="replace",
                 check=True,
             ).stdout
 
@@ -231,6 +233,7 @@ class BaselineHandler:
                     timeout=env.git_command_timeout,
                     capture_output=True,
                     encoding="utf-8",
+                    errors="replace",
                     check=True,
                 ).stdout
             else:

--- a/cli/src/semgrep/output.py
+++ b/cli/src/semgrep/output.py
@@ -519,7 +519,7 @@ class OutputHandler:
             save_path = Path(destination)
             # create the folders if not exists
             save_path.parent.mkdir(parents=True, exist_ok=True)
-            with save_path.open(mode="w") as fout:
+            with save_path.open(mode="w", encoding="utf-8") as fout:
                 fout.write(output)
 
     def _post_output(self, output_url: str, output: str) -> None:

--- a/cli/src/semgrep/rpc.py
+++ b/cli/src/semgrep/rpc.py
@@ -62,7 +62,7 @@ def _really_read(io: IO[str], size: int) -> str:
             logger.error(f"0 bytes read from RPC input stream")
             break
         out = out + new.encode(ENCODING)
-    return out.decode(ENCODING)
+    return out.decode(ENCODING, errors="replace")
 
 
 def _read_packet(io: IO[str]) -> Optional[str]:
@@ -117,6 +117,7 @@ def rpc_call(call: out.FunctionCall, cls: Type[T]) -> Optional[T]:
         stdout=subprocess.PIPE,
         text=True,
         encoding=ENCODING,
+        errors="replace",
     ) as proc:
         try:
             # These need to be local variables because otherwise mypy doesn't


### PR DESCRIPTION
When encountering an incorrect UTF-8 character, an exception was raised, now we use the "replace" policy everywhere, which skips incorrect characters.

Closes #560 

See the comment section in the issue for the reproduction pack (tested on macos arm + debian in docker) that can be also used to test the fix