### PR TITLE
Refactoring of AST-to-IL, Step 1

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -2532,9 +2532,9 @@ and function_definition env fdef : function_definition =
   let fbody = rec_point_label_stmts @ fbody in
   { fkind = fdef.fkind; fparams; frettype = fdef.G.frettype; fbody }
 
-(*****************************************************************************)
+(****************************************************************************)
 (* Entry points *)
-(*****************************************************************************)
+(****************************************************************************)
 
 let function_definition lang ?ctx fdef : function_definition =
   let env = { (empty_env lang) with ctx = ctx ||| empty_ctx } in


### PR DESCRIPTION
In this step, we:
- Remove stmts from exceptions' payload (no use for them anyway),
- Replace the accumulation of emitted statements in `env` with  returning statements directly from each function, and combining them explicitly. This means that `env` needs to travel only inside the recursive calls and the functions don't return a modified `env` any longer. This way the entire process is now a proper parameterised fold, and we don't have `env` passed around as a piece of state,
- Code readability: We rename some functions and make sure that every function definition explicitly mention the returned type.

In next steps:
- Produce fewer temporary variables (we now generate a lot of `temp = x; y = temp;` chains),
- Maybe remove exceptions. However, now that the algorithm is not stateful and exceptions don't carry the `stmts` payload, they do not obfuscate the control flow that much), maybe we can split them into separate exceptions for separate kinds of translations (`lval`, `expr`, etc.) for readability.