### PR TITLE
ruby: remove redundant Call wrapping in expr_as_stmt

### DIFF
--- a/languages/ruby/generic/ruby_to_generic.ml
+++ b/languages/ruby/generic/ruby_to_generic.ml
@@ -569,21 +569,10 @@ and expr_as_stmt = function
   | D x -> definition x
   | e -> (
       let e = expr e in
-      match e.G.e with
-      (* targets only: a single name on its own line is probably an hidden fun call,
-         * unless it's a metavariable
-      *)
-      | G.N (G.Id ((s, _), _)) ->
-          if AST_generic.is_metavar_name s || (Domain.DLS.get Flag_parsing.sgrep_mode) then
-            G.exprstmt e
-          else
-            let call = G.Call (e, fb []) |> G.e in
-            G.exprstmt call
-      | _ -> (
-          match expr_special_cases e with
-          | G.S s -> s
-          | G.E e -> G.exprstmt e
-          | _ -> raise Impossible))
+      match expr_special_cases e with
+      | G.S s -> s
+      | G.E e -> G.exprstmt e
+      | _ -> raise Impossible)
 
 and stmt st =
   match st with

--- a/tests/patterns/ruby/misc_hidden_call.rb
+++ b/tests/patterns/ruby/misc_hidden_call.rb
@@ -1,12 +1,21 @@
 #ERROR: match
 foo(1,2,3)
 
-# an identifier on its own as a statement is probably an hidden funcall
-# which is why ruby_to_generic.ml convert that in a Call
+# A bare identifier with no prior assignment is a method call in Ruby.
+# Disambiguate_ruby_calls wraps it in Call() after naming.
 #ERROR: match
 foo
 
 a = bar
-# In Ruby, a bare identifier with no prior assignment is a method call.
 #ERROR: match
 b = foo
+
+# A bare identifier WITH a prior assignment is a local variable,
+# not a method call. It should NOT match foo(...).
+foo = 42
+c = foo
+
+# A parameter is also not a method call.
+def use_param(foo)
+  d = foo
+end


### PR DESCRIPTION
## Summary

- Remove the pre-naming `Call` wrapping of bare identifiers in `ruby_to_generic.ml:expr_as_stmt`, which is superseded by `Disambiguate_ruby_calls` (#626)
- Add test cases for local variables and parameters not matching `foo(...)`

## Context

`expr_as_stmt` wrapped every bare identifier in `Call(N(Id(x)), [])` before naming ran. This made it impossible for downstream code to distinguish local variables from method calls -- pattern `foo()` incorrectly matched local variable and parameter references.

`Disambiguate_ruby_calls` (introduced in #626) already handles this correctly: it runs after naming and only wraps identifiers that remain unresolved.