### PR TITLE
Taint expression vars in patterns that come from `ExprToPattern`

### DIFF
--- a/src/analyzing/Visit_pattern_ids.ml
+++ b/src/analyzing/Visit_pattern_ids.ml
@@ -15,10 +15,31 @@
 
 module G = AST_generic
 
-class ['self] pat_id_visitor =
+(* This one is used in OtherPattern(("ExprToPattern"),...) [E e]).
+ * In such a case variables in e should be understood as pattern variables.
+ * NOTE: we need two visitors, because not all expr-variables are
+ * pat-variables (e.g. in PatWhen(p,e), vars in e are not pat-vars). *)
+class ['self] expr_id_visitor =
   object (_self : 'self)
     inherit ['self] AST_generic.iter_no_id_info as super
 
+    method! visit_expr_kind store e =
+      match e with
+      | G.N (G.Id (id, id_info)) ->
+          super#visit_expr_kind store e;
+          Stack_.push (id, id_info) store
+      | _ -> super#visit_expr_kind store e
+
+    method! visit_pattern _store _pat =
+      ()
+  end
+
+let expr_id_visitor_instance = new expr_id_visitor
+
+class ['self] pat_id_visitor =
+  object (_self : 'self)
+    inherit ['self] AST_generic.iter_no_id_info as super
+    
     method! visit_pattern store pat =
       match pat with
       | PatAs (_, (id, id_info))
@@ -49,6 +70,10 @@ class ['self] pat_id_visitor =
                   Stack_.push (local_id, local_idinfo) store
               | _else_ -> ())
             fields
+      | G.OtherPat (("ExprToPattern", _), [ G.E { e; _ } ]) ->
+          let ids = ref [] in
+          expr_id_visitor_instance#visit_expr_kind ids e;
+          store := !ids @ !store
       | PatRecord _
       | PatLiteral _
       | PatConstructor _
@@ -67,6 +92,7 @@ class ['self] pat_id_visitor =
   end
 
 let pat_id_visitor_instance = new pat_id_visitor
+  
 let visit : AST_generic.any -> (G.ident * G.id_info) list =
   fun any ->
     let ids = ref [] in

--- a/tests/tainting_rules/elixir/taint-string-concat-pattern.ex
+++ b/tests/tainting_rules/elixir/taint-string-concat-pattern.ex
@@ -1,0 +1,4 @@
+def foo("a" <> x) do
+  #ruleid: taint
+  sink(x)
+end

--- a/tests/tainting_rules/elixir/taint-string-concat-pattern.yaml
+++ b/tests/tainting_rules/elixir/taint-string-concat-pattern.yaml
@@ -1,0 +1,17 @@
+rules:  
+- id: taint
+  languages: [elixir]
+  message: "tainted data reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - patterns:
+      - pattern-either:
+          - pattern-inside: |
+              def $_(..., $X, ...) do
+              ...
+              end
+      - focus-metavariable: $X
+  pattern-sinks:
+    - pattern: |
+        sink(...)


### PR DESCRIPTION
When collecting variables in `Visit_pattern_ids`, we now also collect variables from expressions that cannot be meaningfully converted to patterns, but are instead wrapped in `ExprToPattern`, i.e., patterns of the shape

```OCaml
G.OtherPat (("ExprToPattern", _), [ G.E { e; _ } ])
```

**Example:**

In Elixir, we have a pattern that splits a string into a prefix and suffix:

```Elixir
def foo("abc" <> x) do
  sink(x)
end
```

It is translated to a call with `<>` as the function and `"abc"` and `x` as the arguments.

I think this solution is better than:
- Having a special case in Elixir, and other languages
- Adding special language-dependent cases in `AST_generic_helpers.expr_to_pattern` (esp that `AST_generic` or the helpers are not language-dependent anywhere at the moment)