### PR TITLE
Release v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.19.0](https://github.com/opengrep/opengrep/releases/tag/v1.19.0) - 09-04-2026
+
+### Improvements
+
+* Elixir: fix taint propagation through for comprehensions and pipes by @dimitris-m in #650
+* Ruby: remove redundant Call wrapping in `expr_as_stmt` by @dimitris-m in #651
+* Fix `obj[key]` parsing in ruby by @corneliuhoffman in #649
+
+**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.18.0...v1.19.0
+
+
 ## [1.18.0](https://github.com/opengrep/opengrep/releases/tag/v1.18.0) - 07-04-2026
 
 ### Improvements

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -124,7 +124,7 @@ install_requires = [
 
 setuptools.setup(
     name="opengrep",
-    version="1.18.0",
+    version="1.19.0",
     author="Semgrep Inc., Opengrep",
     author_email="support@opengrep.dev",
     description="Lightweight static analysis for many languages. Find bug variants with patterns that look like source code.",

--- a/cli/src/semgrep/__init__.py
+++ b/cli/src/semgrep/__init__.py
@@ -1,2 +1,2 @@
-__VERSION__ = "1.18.0"
+__VERSION__ = "1.19.0"
 __SEMGREP_VERSION__ = "1.100.0"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 setup(
     name="semgrep_pre_commit_package",
-    version="1.18.0",
+    version="1.19.0",
     # install_requires=["opengrep==1.2.0"], # Commented out since we're not on pypi.
     packages=[],
 )

--- a/src/core/Version.ml
+++ b/src/core/Version.ml
@@ -3,5 +3,5 @@
 
   Automatically modified by scripts/release/bump.
 *)
-let version = "1.18.0"
+let version = "1.19.0"
 let version_semgrep = "1.100.0"


### PR DESCRIPTION
## Improvements

* Elixir: fix taint propagation through for comprehensions and pipes by @dimitris-m in #650
* Ruby: remove redundant Call wrapping in `expr_as_stmt` by @dimitris-m in #651
* Fix `obj[key]` parsing in ruby by @corneliuhoffman in #649

**Full Changelog**: https://github.com/opengrep/opengrep/compare/v1.18.0...v1.19.0