### PR TITLE
clojure: support string-key map destructuring

### DIFF
--- a/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
+++ b/languages/lisp/tree-sitter/Parse_clojure_tree_sitter.ml
@@ -1111,17 +1111,24 @@ and map_binding_form_map_lit (env : env) ((_meta, (lb, srcs, rb)) : CST.map_lit)
     in
     with_or_as s (token env tk) pats rest
 
-  (* Standard map binding, eg, {x :a, [y z] :b}. *)
-  | _bind_form :: `Kwd_lit _  :: _ ->
-    let rec keyval_and_rest acc = function
-      | bind_form :: `Kwd_lit kwd_lit  :: rest_forms  ->
-        let key = map_binding_form env bind_form in
-        (* TODO: PatRecord of (dotted_ident * pattern) list bracket *)
+  (* Standard map binding, eg, {x :a, [y z] :b, z "str-key"}. *)
+  | _bind_form :: (`Kwd_lit _ | `Str_lit _) :: _ ->
+    let map_value_key_pattern = function
+      | `Kwd_lit kwd_lit ->
         let atom_kind, tok_colon, atom_name =
           map_kwd_expr_aux env kwd_lit
         in
-        let value = G.OtherPat ((atom_kind, tok_colon), [G.Name atom_name]) in
-        (* let value = G.PatLiteral (map_kwd_lit env kwd_lit) in *)
+        G.OtherPat ((atom_kind, tok_colon), [G.Name atom_name])
+      | `Str_lit str_tok ->
+        let s, t = H.str env str_tok in
+        let s_no_quotes = String.sub s 1 (String.length s - 2) in
+        G.PatLiteral (G.String (Tok.unsafe_fake_bracket (s_no_quotes, t)))
+    in
+    let rec keyval_and_rest acc = function
+      | bind_form :: (`Kwd_lit _ | `Str_lit _ as kv) :: rest_forms ->
+        let key = map_binding_form env bind_form in
+        (* TODO: PatRecord of (dotted_ident * pattern) list bracket *)
+        let value = map_value_key_pattern kv in
         keyval_and_rest
           (G.PatKeyVal (key, value) :: acc)
           rest_forms

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -411,6 +411,11 @@ and pattern env pat : stmts * lval * stmts =
                                       [G.Name _atom_name]))
     when env.lang =*= Lang.Clojure ->
     pattern env key_pat
+  (* Clojure string-key destructuring, e.g. `(let [{x "a"} o] x)`. The value
+   * is a string literal used as the map lookup key; only `key_pat` binds. *)
+  | G.PatKeyVal (key_pat, G.PatLiteral (G.String _))
+    when env.lang =*= Lang.Clojure ->
+    pattern env key_pat
   (* Only seems to be used in Ruby, modulo the above case for Clojure. *)
   | G.PatKeyVal (_key_pat, val_pat) when env.lang =*= Lang.Ruby ->
     (* My understanding is that the new variables are introduced on the rhs. *)

--- a/src/call_graph/Call_graph.ml
+++ b/src/call_graph/Call_graph.ml
@@ -63,11 +63,6 @@ module Dot = Graph.Graphviz.Dot (Display)
 module Topo = Graph.Topological.Make (G)
 module SCC = Graph.Components.Make (G)
 
-let node_key (n : node) =
-  let name = Function_id.show n in 
-  let filename, line, col = Function_id.to_file_line_col n in
-  Printf.sprintf "%s|%s|%d|%d" name filename line col
-
 (** Helpers **)
 
 let pos_of_tok (tok : Tok.t) : Pos.t =

--- a/tests/parsing/clojure/map_destructuring_string_keys.clj
+++ b/tests/parsing/clojure/map_destructuring_string_keys.clj
@@ -1,0 +1,11 @@
+;; Parsing test: map destructuring with string keys.
+
+(defn f [{x "a"}] x)
+
+(defn g [{x "a" y "b"}] [x y])
+
+(defn h [{x :kw y "str"}] [x y])
+
+(let [{x "a"} {"a" 1}] x)
+
+(defn i [{x "a" :as opts :or {x 0}}] [x opts])

--- a/tests/tainting_rules/clojure/taint-propagation.clj
+++ b/tests/tainting_rules/clojure/taint-propagation.clj
@@ -101,6 +101,20 @@
   ;; ruleid: taint-call
   (sink y1))
 
+;; map destructuring with string keys
+(defn f [{x "a"}]
+  ;; ruleid: taint-call
+  (sink x))
+
+(defn f [{x "a" y "b"}]
+  ;; ruleid: taint-call
+  (sink y))
+
+;; mixed keyword and string keys
+(defn f [{x :kw y "str"}]
+  ;; ruleid: taint-call
+  (sink y))
+
 (defn f [{:syms [::x y] :as opts}]
   (if opts
     ;; ruleid: taint-call


### PR DESCRIPTION
## Summary

- Parser: accept `{sym "str-key"}` destructuring (and mixed with keywords) in function parameters and `let` bindings. Previously raised "Invalid map binding form" because only keyword values were matched.
- `AST_to_IL.ml`: add a Clojure-specific `PatKeyVal` case for `PatLiteral (String _)` values so the `PatId` binding is registered and taint propagates through the destructured variable.

New tests:
- `tests/parsing/clojure/map_destructuring_string_keys.clj` — string-only, mixed keyword/string, `let` context, and `:as`/`:or` with a string-keyed pair.
- Three cases added to `tests/tainting_rules/clojure/taint-propagation.clj` for taint through string-keyed and mixed destructuring.

The first commit is a small piggyback: removes the unused `Call_graph.node_key` function.