### PR TITLE
Elixir: distinguish field access from zero-arity remote call

### DIFF
--- a/languages/elixir/ast/AST_elixir.ml
+++ b/languages/elixir/ast/AST_elixir.ml
@@ -209,6 +209,10 @@ and expr =
   | DotAnon of expr * tok
   (* only inside Call *)
   | DotRemote of remote_dot
+  (* Elixir map/struct field access: `foo.bar` with no parens, no args,
+   * no do-block. Distinct from `foo.bar(...)` which is a remote call
+   * (encoded as `Call (DotRemote _, _, _)`). *)
+  | FieldAccess of remote_dot
   | ModuleVarAccess of tok (* @ *) * expr
   | ArrayAccess of expr * expr bracket
   (* a Call can be a thousand things, including function and module definitions

--- a/languages/elixir/generic/Elixir_to_generic.ml
+++ b/languages/elixir/generic/Elixir_to_generic.ml
@@ -878,6 +878,10 @@ and map_expr env v : G.expr =
       G.OtherExpr (("DotAnon", tdot), [ G.E e ]) |> G.e
   (* only inside a Call *)
   | DotRemote v -> map_remote_dot env v
+  (* Elixir field access: `foo.bar` (no parens). Translate to a plain
+   * DotAccess so downstream analysis treats it as field access, not a
+   * zero-arity function call. *)
+  | FieldAccess v -> map_remote_dot env v
   | ModuleVarAccess (tat, v2) ->
       let e = map_expr env v2 in
       G.OtherExpr (("AttrExpr", tat), [ G.E e ]) |> G.e

--- a/languages/elixir/tree-sitter/Parse_elixir_tree_sitter.ml
+++ b/languages/elixir/tree-sitter/Parse_elixir_tree_sitter.ml
@@ -674,7 +674,7 @@ and map_capture_expression (env : env) (x : CST.capture_expression) =
               | other -> other
             in
             (match actual_fun_name with
-            | I _ | Alias _ | DotAlias _ | DotRemote _ ->
+            | I _ | Alias _ | DotAlias _ | DotRemote _ | FieldAccess _ ->
                 (* Convert &fun/arity to &(fun(&1, &2, ...)) *)
                 let arity_int = Int64.to_int arity in
                 (* Create PlaceHolder arguments: &1, &2, ... *)

--- a/languages/elixir/tree-sitter/Parse_elixir_tree_sitter.ml
+++ b/languages/elixir/tree-sitter/Parse_elixir_tree_sitter.ml
@@ -546,10 +546,10 @@ and map_body (env : env) ((v1, v2, v3, v4) : CST.body) : body =
   let _v4 = map_terminator_opt env v4 in
   v2 :: v3
 
-and map_call (env : env) (x : CST.call) : call =
+and map_call (env : env) (x : CST.call) : expr =
   match x with
   | `Call_with_parens_b98484c x -> map_call_without_parentheses env x
-  | `Call_with_parens_403315d x -> map_call_with_parentheses env x
+  | `Call_with_parens_403315d x -> Call (map_call_with_parentheses env x)
 
 and map_call_arguments_with_parentheses (env : env)
     ((v1, v2, v3) : CST.call_arguments_with_parentheses) : arguments bracket =
@@ -627,26 +627,32 @@ and map_call_with_parentheses (env : env) (x : CST.call_with_parentheses) : call
       mk_call_parens (Call call1) args blopt
 
 and map_call_without_parentheses (env : env) (x : CST.call_without_parentheses)
-    : call =
+    : expr =
   match x with
   | `Local_call_with_parens (v1, v2, v3) ->
       let id = map_identifier env v1 in
       let args = map_call_arguments_without_parentheses env v2 in
       let blopt = map_anon_opt_opt_nl_before_do_do_blk_3eff85f env v3 in
-      mk_call_no_parens (Left id) args blopt
+      Call (mk_call_no_parens (Left id) args blopt)
   | `Local_call_just_do_blk (v1, v2) ->
       let id = map_identifier env v1 in
       let bl = map_do_block env v2 in
-      mk_call_no_parens (Left id) ([], []) (Some bl)
+      Call (mk_call_no_parens (Left id) ([], []) (Some bl))
   | `Remote_call_with_parens (v1, v2, v3) ->
       let rdot = map_remote_dot env v1 in
-      let args : arguments =
-        match v2 with
-        | Some x -> map_call_arguments_without_parentheses env x
-        | None -> ([], [])
-      in
       let blopt = map_anon_opt_opt_nl_before_do_do_blk_3eff85f env v3 in
-      mk_call_no_parens (Right rdot) args blopt
+      (match v2, blopt with
+       | None, None ->
+           (* Elixir map/struct field access: `foo.bar` with no parens,
+            * no args, no do-block. Not a function call. *)
+           FieldAccess rdot
+       | _ ->
+           let args : arguments =
+             match v2 with
+             | Some x -> map_call_arguments_without_parentheses env x
+             | None -> ([], [])
+           in
+           Call (mk_call_no_parens (Right rdot) args blopt))
 
 and map_capture_expression (env : env) (x : CST.capture_expression) =
   match x with
@@ -884,9 +890,7 @@ and map_expression (env : env) (x : CST.expression) : expr =
   | `Un_op x -> map_unary_operator env x
   | `Bin_op x -> map_binary_operator env x
   | `Dot x -> map_dot env x
-  | `Call x ->
-      let c = map_call env x in
-      Call c
+  | `Call x -> map_call env x
   (* semantic: transformed in Access.get/2 *)
   | `Access_call (v1, v2, v3, v4) ->
       let v1 = map_expression env v1 in

--- a/src/tainting/Graph_from_AST.ml
+++ b/src/tainting/Graph_from_AST.ml
@@ -546,13 +546,16 @@ let extract_callback_from_arg (arg_expr : G.expr) : (IL.name * Tok.t * IL.name o
   | G.DotAccess (_, _, G.FN (G.Id (id, id_info))) ->
       let callback_name = AST_to_IL.var_of_id_info id id_info in
       Some (callback_name, snd id, None)
-  (* Elixir: &func/n - ShortLambda wrapping a call to the named function.
-     Structure: OtherExpr("ShortLambda", [Params[&1,...]; S(ExprStmt(Call(func, args)))])
+  (* Elixir: &func/n or &Mod.func/n - ShortLambda wrapping a call to the
+     named (local or remote) function. Structure:
+     OtherExpr("ShortLambda", [Params[&1,...]; S(ExprStmt(Call(func, args)))])
+     where func is either a plain Id or a DotAccess(..., FN(Id)).
      Create a _tmp node to match what AST_to_IL creates for the anonymous wrapper. *)
   | G.OtherExpr (("ShortLambda", shortlambda_tok),
                  [G.Params _; G.S { G.s = G.ExprStmt (inner_e, _); _ }]) ->
       (match inner_e.G.e with
-      | G.Call ({ e = G.N (G.Id (id, id_info)); _ }, _) ->
+      | G.Call ({ e = G.N (G.Id (id, id_info))
+                    | G.DotAccess (_, _, G.FN (G.Id (id, id_info))); _ }, _) ->
           let callback_name = AST_to_IL.var_of_id_info id id_info in
           (* Create _tmp IL.name using Tok.fake_tok like AST_to_IL.fresh_var does *)
           let tmp_tok = Tok.fake_tok shortlambda_tok "_tmp" in

--- a/tests/rules/cross_function_tainting/test_hof_comprehensive_elixir.ex
+++ b/tests/rules/cross_function_tainting/test_hof_comprehensive_elixir.ex
@@ -248,6 +248,27 @@ defmodule TestHOF do
     # Top-level user-defined HOF
     custom_for_each(toplevel_items, &toplevel_handler/1)
   end
+
+  # Remote-capture short lambdas `&Mod.fun/arity`: the left of `/` is a
+  # dot expression, exercising the ShortLambda conversion path for
+  # remote dots (FieldAccess) -- local captures `&fn/arity` do not.
+  def test_remote_capture_builtin() do
+    arr = [source()]
+    mapped = Enum.map(arr, &RemoteHelper.process_remote/1)
+  end
+
+  def test_remote_capture_custom() do
+    arr = [source()]
+    mapped = custom_map_builtin(arr, &RemoteHelper.process_remote/1)
+  end
+end
+
+defmodule RemoteHelper do
+  def process_remote(x) do
+    # ruleid: test-hof-taint
+    sink(x)
+    x
+  end
 end
 
  def toplevel_handler(x) do

--- a/tests/tainting_rules/elixir/taint-field-access.ex
+++ b/tests/tainting_rules/elixir/taint-field-access.ex
@@ -1,0 +1,42 @@
+defmodule TaintFieldAccess do
+  # Field access `x.y` (no parens, no args, no do-block) must propagate
+  # taint even when `taint_assume_safe_functions: true`, because it is
+  # map/struct field access, not a zero-arity function call.
+  def field(upload) do
+    # ruleid: taint-field-access
+    sink(upload.path)
+  end
+
+  # Chained field access.
+  def chained(conn) do
+    # ruleid: taint-field-access
+    sink(conn.assigns.current_user)
+  end
+
+  # Zero-arity remote call `x.y()` IS a function call; under
+  # `taint_assume_safe_functions: true` the taint is dropped.
+  def zero_arity_call(upload) do
+    # ok: taint-field-access
+    sink(upload.path())
+  end
+
+  # Remote call with args — also a call, taint dropped.
+  def call_with_args(upload) do
+    # ok: taint-field-access
+    sink(upload.compute(1, 2))
+  end
+
+  # Remote call without parens but with args — still a call.
+  def call_no_parens_args(upload) do
+    # ok: taint-field-access
+    sink(upload.compute 1, 2)
+  end
+
+  # Remote call with do-block — a call.
+  def call_do_block(upload) do
+    # ok: taint-field-access
+    sink(upload.with_block do
+      :ok
+    end)
+  end
+end

--- a/tests/tainting_rules/elixir/taint-field-access.yaml
+++ b/tests/tainting_rules/elixir/taint-field-access.yaml
@@ -1,0 +1,17 @@
+rules:
+- id: taint-field-access
+  mode: taint
+  languages: [elixir]
+  message: "tainted field access reaches sink"
+  severity: INFO
+  options:
+    taint_assume_safe_functions: true
+  pattern-sources:
+    - patterns:
+        - pattern-inside: |
+            def $_(..., $P, ...) do
+            ...
+            end
+        - focus-metavariable: $P
+  pattern-sinks:
+    - pattern: sink(...)


### PR DESCRIPTION
## Summary

Elixir's `foo.bar` (no parens, no args, no do-block) is map/struct field access; `foo.bar(...)` is a remote function call. The parser was collapsing both into `Call(DotAccess, [])`, so `taint_assume_safe_functions: true` silently dropped taint at every field access on a tainted receiver (e.g. `conn.params`, `upload.path`).

- Add `FieldAccess of remote_dot` in `AST_elixir.ml` alongside `DotRemote`.
- In `Parse_elixir_tree_sitter.ml`, emit `FieldAccess rdot` when the `_remote_call_without_parentheses` CST case has no args and no do-block; keep `Call (...)` otherwise. The tree-sitter grammar already separates the two non-terminals, so no token introspection is needed.
- In `Elixir_to_generic.ml`, translate `FieldAccess` to `G.DotAccess` -- the same shape used by other languages for field access. Explicit `foo.bar()` still becomes `Call(DotAccess, [])` and remains subject to `taint_assume_safe_functions`.

New test: `tests/tainting_rules/elixir/taint-field-access.{yaml,ex}` covers field access (must propagate) and the four call forms -- zero-arity `.path()`, `.compute(1,2)`, no-parens-with-args `.compute 1, 2`, and do-block `.with_block do ... end` (all should drop taint under `taint_assume_safe_functions: true`).