### PR TITLE
Fix Windows install: bundle charset_normalizer, don't treat stderr as fatal

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -333,9 +333,26 @@ function Main {
             }
 
             Write-Host "Testing binary..."
-            # Test by calling --version on the downloaded binary
-            $testOutput = & $binaryPath --version 2>&1
-            if (-not $testOutput -or $LASTEXITCODE -ne 0) {
+            # Test by calling --version on the downloaded binary.
+            # We route stderr through a temp file rather than using `2>&1`, so
+            # that harmless runtime warnings (e.g. requests' RequestsDependency-
+            # Warning) are not surfaced by PowerShell as NativeCommandError
+            # records and misinterpreted as failures. We still surface them to
+            # the user via Write-Host, and rely on $LASTEXITCODE to decide
+            # whether the binary actually ran.
+            $stderrFile = New-TemporaryFile
+            try {
+                $testOutput = & $binaryPath --version 2>$stderrFile
+                $testExit   = $LASTEXITCODE
+                $testStderr = (Get-Content -Raw -ErrorAction SilentlyContinue $stderrFile)
+            }
+            finally {
+                Remove-Item -Force -ErrorAction SilentlyContinue $stderrFile
+            }
+            if ($testStderr) {
+                Write-Host $testStderr
+            }
+            if ($testExit -ne 0 -or -not $testOutput) {
                 throw "Failed to execute installed binary: $binaryPath"
             }
 

--- a/scripts/build-nuitka.sh
+++ b/scripts/build-nuitka.sh
@@ -60,6 +60,7 @@ pushd cli
   --include-data-dir="$SRC_SEMGREP_DIR/templates=semgrep/templates" \
   --include-data-file="$SRC_SEMGREP_DIR/semgrep_interfaces/lang.json=semgrep/semgrep_interfaces/lang.json" \
   --include-data-file="$SRC_SEMGREP_DIR/semgrep_interfaces/rule_schema_v1.yaml=semgrep/semgrep_interfaces/rule_schema_v1.yaml" \
+  --include-package=charset_normalizer \
   --no-deployment-flag=self-execution \
   --windows-icon-from-ico=spec/opengrep.ico \
   --linux-icon=spec/opengrep.ico \


### PR DESCRIPTION
Fixes #656.

- **nuitka**: a0b26ed13 dropped chardet without replacing it; Nuitka does not follow the try/except import in `requests/__init__.py`, so Windows builds since 1.17.0 emit `RequestsDependencyWarning` on every run. Bundle `charset_normalizer` explicitly via `--include-package`.
- **install.ps1**: `2>&1` surfaced the warning as a `NativeCommandError`, aborting install under `$ErrorActionPreference=Stop`. Route stderr through a temp file, print via `Write-Host`, gate only on `$LASTEXITCODE`.