### PR TITLE
unconditional taints in lambdas

### DIFF
--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -635,35 +635,31 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
                Effects whose taint is purely parameterized (BArg) still ride
                through the signature at resolved call sites; effects mixing
                both get an Src-only slice surfaced here. *)
+            let keep_src_toSink_only (eff : Effect.t) : Effect.t option =
+              match eff with
+              | Effect.ToSink si ->
+                  let items, precond = si.taints_with_precondition in
+                  let src_items =
+                    List.filter
+                      (fun (i : Effect.taint_to_sink_item) ->
+                        match i.taint.orig with
+                        | Taint.Src _ -> true
+                        | _ -> false)
+                      items
+                  in
+                  if List_.null src_items then None
+                  else
+                    Some
+                      (Effect.ToSink
+                         {
+                           si with
+                           taints_with_precondition = (src_items, precond);
+                         })
+              | _ -> None
+            in
             let effects_to_record =
               if info.is_lambda_assignment then
-                fdef_effects
-                |> Effects.elements
-                |> List.filter_map (fun eff ->
-                       match eff with
-                       | Effect.ToSink sink_info ->
-                           let items, _ =
-                             sink_info.taints_with_precondition
-                           in
-                           let src_items =
-                             List.filter
-                               (fun (item : Effect.taint_to_sink_item) ->
-                                 match item.taint.orig with
-                                 | Taint.Src _ -> true
-                                 | _ -> false)
-                               items
-                           in
-                           if List_.null src_items then None
-                           else
-                             Some
-                               (Effect.ToSink
-                                  {
-                                    sink_info with
-                                    taints_with_precondition =
-                                      (src_items, Rule.PBool true);
-                                  })
-                       | _ -> None)
-                |> Effects.of_list
+                Effects.filter_map keep_src_toSink_only fdef_effects
               else fdef_effects
             in
             record_matches effects_to_record;

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -622,17 +622,52 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
           let run_check_fundef_if_needed (info : fun_info)
               (updated_db : Shape_and_sig.signature_database) :
               Shape_and_sig.signature_database =
-            if info.is_lambda_assignment then updated_db
-            else begin
-              let _flow, fdef_effects, _mapping =
-                check_fundef taint_inst info.name ~glob_env
-                  ?class_name:info.class_name_str ~signature_db:updated_db
-                  ?builtin_signature_db
-                  ?call_graph:(Some relevant_graph) info.fdef
-              in
-              record_matches fdef_effects;
-              updated_db
-            end
+            let _flow, fdef_effects, _mapping =
+              check_fundef taint_inst info.name ~glob_env
+                ?class_name:info.class_name_str ~signature_db:updated_db
+                ?builtin_signature_db
+                ?call_graph:(Some relevant_graph) info.fdef
+            in
+            (* For lambda assignments we only record "unconditional" ToSink
+               effects — those where the taint at the sink comes from a
+               concrete pattern-source match (e.g. a parameter declared as a
+               source via `pattern-inside: function $X(..., $RES, ...) {...}`).
+               Effects whose taint is purely parameterized (BArg) still ride
+               through the signature at resolved call sites; effects mixing
+               both get an Src-only slice surfaced here. *)
+            let effects_to_record =
+              if info.is_lambda_assignment then
+                fdef_effects
+                |> Effects.elements
+                |> List.filter_map (fun eff ->
+                       match eff with
+                       | Effect.ToSink sink_info ->
+                           let items, _ =
+                             sink_info.taints_with_precondition
+                           in
+                           let src_items =
+                             List.filter
+                               (fun (item : Effect.taint_to_sink_item) ->
+                                 match item.taint.orig with
+                                 | Taint.Src _ -> true
+                                 | _ -> false)
+                               items
+                           in
+                           if List_.null src_items then None
+                           else
+                             Some
+                               (Effect.ToSink
+                                  {
+                                    sink_info with
+                                    taints_with_precondition =
+                                      (src_items, Rule.PBool true);
+                                  })
+                       | _ -> None)
+                |> Effects.of_list
+              else fdef_effects
+            in
+            record_matches effects_to_record;
+            updated_db
           in
 
           let process_fun_info info db =

--- a/tests/rules/cross_function_tainting/test_lambda_in_object_literal.js
+++ b/tests/rules/cross_function_tainting/test_lambda_in_object_literal.js
@@ -1,0 +1,15 @@
+// Lambda assigned as a property of an object literal, then called via
+// unresolved property access. The parameter `data` matches the source
+// pattern (concrete source), so `sink(data)` should fire regardless of
+// whether the call graph can resolve `x.success(a)` back to the lambda.
+
+function test1(a) {
+    var x = {
+        url: '/api/settings',
+        success: function(data) {
+            // ruleid: taint-func-param
+            sink(data);
+        }
+    };
+    x.success(a);
+}

--- a/tests/rules/cross_function_tainting/test_lambda_in_object_literal.yaml
+++ b/tests/rules/cross_function_tainting/test_lambda_in_object_literal.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: taint-func-param
+    message: Tainted parameter reaches sink
+    languages: [javascript]
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-inside: |
+              function $X(..., $RES, ...) {...}
+          - focus-metavariable: $RES
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_same_name_functions.go
+++ b/tests/rules/cross_function_tainting/test_same_name_functions.go
@@ -11,6 +11,7 @@ func test(input string) {
 func test(input string) {
 	var fn = func(s string) {
 		// ok: taint-func-param
-		sink(s)
+		safe(s)
 	}
+	fn("")
 }


### PR DESCRIPTION
## Summary

Under `--taint-intrafile`, a rule that matches a concrete source inside
a lambda produced no finding when the lambda was not called. For example

```javascript
function test1(a) {
    var x = function(data) {
        var t = source();
        sink(t); };
}
```

is not found, but

```javascript
function test1(a) {
    var x = function(data) {
        var t = source();
        sink(t); };
    x(a);
}
```

is found.

## Cause

`run_check_fundef_if_needed` in `Match_tainting_mode.ml` skipped
`check_fundef` for `is_lambda_assignment` entries; the lambda's effects
were stored in the signature but never materialised as findings when no
caller site could be resolved.

## Change

`run_check_fundef_if_needed` now always runs `check_fundef`. For lambda
assignments the returned effects are filtered to keep only `ToSink`
effects whose taint has a concrete `Src` origin, preserving the sink's
original precondition. Parameterised (`BArg`) taints remain in the
signature and fire at resolved call sites as before, via signature
instantiation.

## Tests

- New `tests/rules/cross_function_tainting/test_lambda_in_object_literal.{yaml,js}`
  covers the object-literal case above.
- Updated `tests/rules/cross_function_tainting/test_same_name_functions.go`;
  the #615 regression test previously conflated "same-name confusion"
  with the uncalled-lambda case.

## Known gaps

### Closures over outer-scoped taint

If the lambda closes over a tainted variable, the taint is still not
propagated through unless the lambda is called. For example

```javascript
function test1() {
    var t = source();
    var x = function() { sink(t); };
}
```

is not found, but

```javascript
function test1() {
    var t = source();
    var x = function() { sink(t); };
    x();
}
```

is.