### PR TITLE
Make switch usable as expression in IL (with applications to Elixir)

### DIFF
--- a/languages/elixir/ast/AST_elixir.ml
+++ b/languages/elixir/ast/AST_elixir.ml
@@ -312,6 +312,8 @@ and stmt =
       * tok (* 'end' *)
   | Try of tok (* 'try' *) * do_block
   | Throw of tok (* 'throw' *) * expr
+  (* https://hexdocs.pm/elixir/Kernel.SpecialForms.html#case/2 *)
+  | Case of tok (* 'case' *) * expr * clauses bracket (* do/end *)
   (* https://hexdocs.pm/elixir/Kernel.SpecialForms.html#for/1 *)
   | For of tok (* 'for' *) * for_clause list * stmts bracket (* do body *)
   | D of definition

--- a/languages/elixir/ast/Elixir_to_elixir.ml
+++ b/languages/elixir/ast/Elixir_to_elixir.ml
@@ -175,6 +175,14 @@ class ['self] visitor =
             }
           in
           S (D (ModuleDef def))
+      (* https://hexdocs.pm/elixir/Kernel.SpecialForms.html#case/2
+       * case expr do pattern -> body ... end *)
+      | ( I (Id ("case", tcase)),
+          (_, ([ e ], []), _),
+          Some (tdo, (Clauses clauses, []), tend) ) ->
+          let e = self#visit_expr env e in
+          let clauses = self#visit_clauses env clauses in
+          S (Case (tcase, e, (tdo, clauses, tend)))
       (* https://hexdocs.pm/elixir/Kernel.SpecialForms.html#throw/1 *)
       | ( I (Id ("throw", tthrow)), (_, ([ arg ], []), _), None ) ->
           let arg = self#visit_expr env arg in
@@ -271,6 +279,15 @@ and group_in_expr (e : expr) : expr =
           clauses
       in
       S (D (FuncDef clauses))
+  | S (Case (tcase, e, (tdo, clauses, tend))) ->
+      let e = group_in_expr e in
+      let clauses =
+        List_.map
+          (fun ((args, guard_opt), tarrow, body) ->
+            ((args, guard_opt), tarrow, group_in_program body))
+          clauses
+      in
+      S (Case (tcase, e, (tdo, clauses, tend)))
   | _ -> e
 
 (*****************************************************************************)

--- a/languages/elixir/generic/Elixir_to_generic.ml
+++ b/languages/elixir/generic/Elixir_to_generic.ml
@@ -151,7 +151,19 @@ let rec expr_to_pattern (e : G.expr) : G.pattern =
       end
   (* TODO: PatKeyVal and more *)
   | _ -> OtherPat (("ExprToPattern", Tok.unsafe_fake_tok ""), [ G.E e ])
-           
+
+let pats_of_args (args : G.argument list) : G.pattern list =
+  List_.map
+    (function
+      | G.OtherArg (("ArgKwdQuoted", _), [ G.E e ]) -> expr_to_pattern e
+      | arg -> H.argument_to_expr arg |> expr_to_pattern)
+    args
+
+let wrap_when (when_opt : (Tok.t * G.expr) option) (pat : G.pattern) : G.pattern =
+  match when_opt with
+  | None -> pat
+  | Some (_tok, e) -> G.PatWhen (pat, e)
+
 (* TODO: lots of work here to detect when args is really a single
  * pattern, or tuples *)
 let pat_of_args_and_when (args, when_opt) : G.pattern =
@@ -160,23 +172,13 @@ let pat_of_args_and_when (args, when_opt) : G.pattern =
        | None -> []
        | Some (_tok, e) -> [ G.E e ]
      in *)
-  let pats =
-    List_.map
-      (function
-        | G.OtherArg (("ArgKwdQuoted", _), [ G.E e ]) -> expr_to_pattern e
-        | arg -> H.argument_to_expr arg |> expr_to_pattern)
-      args
-  in
   let pat =
-    match pats with
+    match pats_of_args args with
     | [] -> G.PatLiteral (G.Null (G.fake "no_arg")) (* invalid syntax anyway. *)
-    | _ ->
-      G.PatTuple (fb pats)
+    | pats -> G.PatTuple (fb pats)
   in
   (* G.OtherPat (("ArgsAndWhenOpt", G.fake ""), G.Args args :: rest) |> G.p *)
-  match when_opt with
-    | None -> pat
-    | Some (_tok, e) -> G.PatWhen (pat, e)
+  wrap_when when_opt pat
 
 let case_and_body_of_stab_clause (x : stab_clause_generic) : G.case_and_body =
   (* body can be empty *)
@@ -184,6 +186,17 @@ let case_and_body_of_stab_clause (x : stab_clause_generic) : G.case_and_body =
   let pat = pat_of_args_and_when args_and_when in
   let stmt = G.stmt1 stmts in
   G.case_of_pat_and_stmt (pat, stmt)
+
+let case_and_body_of_case_clause (x : stab_clause_generic) : G.case_and_body =
+  let (args, when_opt), _tarrow, stmts = x in
+  let pat =
+    match pats_of_args args with
+    | [] -> G.PatLiteral (G.Null (G.fake "no_arg"))
+    | [ single ] -> single
+    | pats -> G.PatTuple (fb pats)
+  in
+  let pat = wrap_when when_opt pat in
+  G.case_of_pat_and_stmt (pat, G.stmt1 stmts)
 
 (* TODO: if the list contains just one element, can be a simple lambda
  * as in 'fn (x, y) -> x + y end'. Otherwise it can be a multiple-cases
@@ -553,7 +566,7 @@ and map_rescue_stab_to_catch env tok (stab : stab_clause) : G.catch =
         in
         pat
   in
-  let catch_pat =
+  let catch_pat = 
     match guard_opt with
     | Some (_tok, guard) -> G.PatWhen (catch_pat, map_expr env guard)
     | None -> catch_pat
@@ -958,15 +971,27 @@ and map_body env v : G.stmt list =
   xs |> List_.map exprstmt
 
 and map_call env (v1, v2, v3) : G.expr =
+  match (v1, v2, v3) with
+  (* https://hexdocs.pm/elixir/Kernel.SpecialForms.html#case/2
+   * case expr do pattern -> body end *)
+  | ( I (Id ("case", tcase)),
+    (_, ([ scrutinee ], []), _),
+    Some (_tdo, (Clauses clauses, []), _tend) ) ->
+      let e = map_expr env scrutinee in
+      let xs = map_clauses env clauses in
+      let cases = xs |> List_.map case_and_body_of_case_clause in
+      G.Switch (tcase, Some (G.Cond e), cases) |> G.s |> G.stmt_to_expr
+  | _ ->
   (* Special handling for DotAnon - extract the inner expression to use as callee *)
-  let e = match v1 with
-    | DotAnon (inner_expr, _tdot) -> map_expr env inner_expr
-    | _ -> map_expr env v1
-  in
-  let l, args, r = (map_bracket map_arguments) env v2 in
-  let v3 = (map_option map_do_block) env v3 in
-  let args' = args_of_do_block_opt v3 in
-  G.Call (e, (l, args @ args', r)) |> G.e
+    let e =
+      match v1 with
+      | DotAnon (inner_expr, _tdot) -> map_expr env inner_expr
+      | _ -> map_expr env v1
+    in
+    let l, args, r = (map_bracket map_arguments) env v2 in
+    let v3 = (map_option map_do_block) env v3 in
+    let args' = args_of_do_block_opt v3 in
+    G.Call (e, (l, args @ args', r)) |> G.e
 
 and map_remote_dot env (v1, tdot, v3) : G.expr =
   let e = map_expr env v1 in

--- a/languages/elixir/generic/Elixir_to_generic.ml
+++ b/languages/elixir/generic/Elixir_to_generic.ml
@@ -475,6 +475,11 @@ and map_stmt env (v : stmt) : G.stmt =
   | Throw (tthrow, e) ->
       let e = map_expr env e in
       G.Throw (tthrow, e, G.sc) |> G.s
+  | Case (tcase, e, (_tdo, clauses, _tend)) ->
+      let e = map_expr env e in
+      let xs = map_clauses env clauses in
+      let cases = xs |> List_.map case_and_body_of_case_clause in
+      G.Switch (tcase, Some (G.Cond e), cases) |> G.s
   | For (tfor, clauses, (tdo, body, tend)) ->
       let comp_clauses = List_.map (fun (clause : for_clause) ->
         match clause with
@@ -971,27 +976,16 @@ and map_body env v : G.stmt list =
   xs |> List_.map exprstmt
 
 and map_call env (v1, v2, v3) : G.expr =
-  match (v1, v2, v3) with
-  (* https://hexdocs.pm/elixir/Kernel.SpecialForms.html#case/2
-   * case expr do pattern -> body end *)
-  | ( I (Id ("case", tcase)),
-    (_, ([ scrutinee ], []), _),
-    Some (_tdo, (Clauses clauses, []), _tend) ) ->
-      let e = map_expr env scrutinee in
-      let xs = map_clauses env clauses in
-      let cases = xs |> List_.map case_and_body_of_case_clause in
-      G.Switch (tcase, Some (G.Cond e), cases) |> G.s |> G.stmt_to_expr
-  | _ ->
   (* Special handling for DotAnon - extract the inner expression to use as callee *)
-    let e =
-      match v1 with
-      | DotAnon (inner_expr, _tdot) -> map_expr env inner_expr
-      | _ -> map_expr env v1
-    in
-    let l, args, r = (map_bracket map_arguments) env v2 in
-    let v3 = (map_option map_do_block) env v3 in
-    let args' = args_of_do_block_opt v3 in
-    G.Call (e, (l, args @ args', r)) |> G.e
+  let e =
+    match v1 with
+    | DotAnon (inner_expr, _tdot) -> map_expr env inner_expr
+    | _ -> map_expr env v1
+  in
+  let l, args, r = (map_bracket map_arguments) env v2 in
+  let v3 = (map_option map_do_block) env v3 in
+  let args' = args_of_do_block_opt v3 in
+  G.Call (e, (l, args @ args', r)) |> G.e
 
 and map_remote_dot env (v1, tdot, v3) : G.expr =
   let e = map_expr env v1 in

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1747,6 +1747,42 @@ and stmt_expr env ?g_expr st : stmts * exp =
       let ss_lv, lv = lval_of_ent env ent in
       let instr = mk_s (Instr (mk_i (Assign (lv, e)) (Related (G.S st)))) in
       (ss_ty @ ss_e @ ss_lv @ [instr], mk_e (Fetch lv) (related_exp (G.e (G.StmtExpr st))))
+  | G.Switch (tok, switch_expr_opt, cases_and_bodies) ->
+      (* Switch used as an expression (e.g. Elixir `case`).
+       * Mirror the stmt-context Switch handler but lower each case body with
+       * stmt_expr so the branch value is captured into a fresh variable. *)
+      let ss, translate_cases, switch_expr_opt' =
+        match switch_expr_opt with
+        | Some switch_expr ->
+            let ss, switch_expr' = cond env switch_expr in
+            ( ss,
+              switch_expr_and_cases_to_exp tok
+                (H.cond_to_expr switch_expr)
+                switch_expr',
+              Some switch_expr' )
+        | None -> ([], cases_to_exp tok, None)
+      in
+      let break_label, break_label_s, switch_env =
+        switch_break_label env tok
+      in
+      let fresh = fresh_lval tok in
+      let lower_body body =
+        let pre_ss, e_val = stmt_expr switch_env body in
+        let assign =
+          mk_s (Instr (mk_i (Assign (fresh, e_val)) (related_tok tok)))
+        in
+        pre_ss @ [ assign ]
+      in
+      let jumps, bodies =
+        cases_and_bodies_to_stmts switch_env switch_expr_opt' tok break_label
+          translate_cases lower_body cases_and_bodies
+      in
+      let eorig =
+        match g_expr with
+        | None -> related_exp (G.e (G.StmtExpr st))
+        | Some e_gen -> SameAs e_gen
+      in
+      (ss @ jumps @ bodies @ break_label_s, mk_e (Fetch fresh) eorig)
   | __else__ ->
       (* In any case, let's make sure the statement is in the IL translation
        * so that e.g. taint can do its job. *)
@@ -2199,7 +2235,7 @@ and stmt_aux env st : stmts =
 
       let jumps, bodies =
         cases_and_bodies_to_stmts switch_env switch_expr_opt' tok break_label translate_cases
-          cases_and_bodies
+          (stmt switch_env) cases_and_bodies
       in
       ss @ jumps @ bodies @ break_label_s
   | G.While (tok, e, st) ->
@@ -2467,18 +2503,19 @@ and cases_to_exp tok env cases : stmts * exp =
   ( ss,
     { e = Operator ((Or, tok), mk_unnamed_args es); eorig = related_tok tok } )
 
-and cases_and_bodies_to_stmts env switch_expr_opt tok break_label translate_cases : G.case_and_body list -> stmts * stmts = function
+and cases_and_bodies_to_stmts env switch_expr_opt tok break_label translate_cases
+    lower_body : G.case_and_body list -> stmts * stmts = function
   | [] -> ([ mk_s (Goto (tok, break_label)) ], [])
   | G.CaseEllipsis tok :: _ -> sgrep_construct (G.Tk tok)
   | [ G.CasesAndBody ([ G.Default dtok ], body) ] ->
       let label = fresh_label ~label:"__switch_default" tok in
 
-      let new_stmts = stmt env body in
+      let new_stmts = lower_body body in
       ([ mk_s (Goto (dtok, label)) ], mk_s (Label label) :: new_stmts)
   | G.CasesAndBody (cases, body) :: xs ->
       let jumps, bodies =
         cases_and_bodies_to_stmts env switch_expr_opt tok break_label translate_cases
-          xs (* TODO this is not tail recursive *)
+          lower_body xs (* TODO this is not tail recursive *)
       in
       let label = fresh_label ~label:"__switch_case" tok in
       let case_ss, case = translate_cases env cases in
@@ -2503,7 +2540,7 @@ and cases_and_bodies_to_stmts env switch_expr_opt tok break_label translate_case
         | _ -> []
       in
 
-      let new_stmts = stmt env body in
+      let new_stmts = lower_body body in
 
       let body = [ mk_s (Label label) ] @ pat_stmts @ new_stmts in
       (* Maybe lang has no_fallthrough in general but here we have PatWhen

--- a/tests/tainting_rules/elixir/taint-case.ex
+++ b/tests/tainting_rules/elixir/taint-case.ex
@@ -1,0 +1,11 @@
+def foo() do
+  a = source()
+
+  b = case a do
+    0 -> a
+    x -> x
+  end
+
+  # ruleid: case_taint_rule
+  sink(b)
+end

--- a/tests/tainting_rules/elixir/taint-case.yaml
+++ b/tests/tainting_rules/elixir/taint-case.yaml
@@ -1,0 +1,12 @@
+rules:
+- id: case_taint_rule
+  languages: [elixir]
+  message: "tainted data reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - pattern: |
+        source()
+  pattern-sinks:
+    - pattern: |
+        sink(...)


### PR DESCRIPTION
For some reason `Switch` is a statement in AST, which makes it hard to meaningfully translate code such as this in Elixir:

```elixir
def foo() do
  a = source ()
  b = case a do
        0 -> a
        x -> x
      end
  sink(b)
end
```

In this PR:
- We add an additional case to `stmt_expr` for when `Switch` is used as expression `StmtExpr(Switch((), ...))`
- We add a proper translation of `case` expressions in Elixir to make use of this change
