### PR TITLE
python: parse PEP 634 match/case statements in the menhir parser

### DIFF
--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -130,6 +130,10 @@ let mk_str ii =
  NONE TRUE FALSE
  ASYNC AWAIT
  NONLOCAL
+ (* python3.10+: soft keywords, produced by Parsing_hacks_python
+  * out of NAME("match")/NAME("case") only in match-statement contexts
+  * so that plain identifiers "match"/"case" remain valid names. *)
+ MATCH CASE
  (* python2: *)
  PRINT EXEC
 
@@ -550,6 +554,7 @@ compound_stmt:
   | for_stmt    { $1 }
   | try_stmt    { $1 }
   | with_stmt   { $1 }
+  | match_stmt  { $1 }
 
   | funcdef     { $1 }
   | classdef    { $1 }
@@ -638,6 +643,32 @@ with_inner_in_parens:
   | test AS expr ","                      { fun (t, body) -> With (t, ($1, Some $3), body) }
   | test         "," with_inner_in_parens { fun (t, body) -> With (t, ($1, None), [$3 (t, body)]) }
   | test AS expr "," with_inner_in_parens { fun (t, body) -> With (t, ($1, Some $3), [$5 (t, body)]) }
+
+(* python3.10+ (PEP 634): structural pattern matching.
+ * `match` and `case` are *soft keywords* in Python — they are valid
+ * identifiers outside of match-statement contexts. The MATCH/CASE tokens
+ * used here are synthesized by Parsing_hacks_python only when the
+ * surrounding shape is unambiguously a match statement.
+ * Patterns are represented as plain expressions (AST_python.pattern = expr),
+ * which matches what the tree-sitter Python frontend already does.
+ * Note: `case pattern if guard:` is not accepted here — an unadorned `if`
+ * after a test would collide with the conditional-expression ternary
+ * (`a if b else c`) and introduce a shift/reduce conflict. Files that rely
+ * on case guards will fall back to the tree-sitter parser. *)
+match_stmt:
+  | MATCH tuple(namedexpr_test) ":" NEWLINE INDENT case_block+ DEDENT
+      { Switch ($1, tuple_expr $2, $6) }
+
+case_block:
+  | CASE tuple(test_or_star_expr) ":" suite
+      { CasesAndBody ([Case ($1, tuple_expr $2)], $4) }
+  (* PEP 634 as-pattern `case pattern as name:`. TODO: preserve the binding.
+   * Note: PEP 634 scopes `as` to the rightmost element of a comma-separated
+   * pattern list, but here `as` binds to the whole tuple — which is fine
+   * because we discard the name; revisit if the binding is ever preserved.
+   *)
+  | CASE tuple(test_or_star_expr) AS NAME ":" suite
+      { CasesAndBody ([Case ($1, tuple_expr $2)], $6) }
 
 (* python3-ext: *)
 async_stmt:

--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -88,6 +88,13 @@ let mk_str ii =
   let s = Tok.content_of_tok ii in
   Str (s, ii)
 
+(* Match the tree-sitter Python frontend's shape: a match-statement subject
+ * and each case pattern are always wrapped in a Tuple, even for a single
+ * element, so semgrep matching stays uniform across parser backends.
+ * The Param context mirrors `no_ctx` in Parse_python_tree_sitter.ml. *)
+let match_tuple xs =
+  Tuple (CompList (Tok.unsafe_fake_bracket xs), Param)
+
 %}
 
 (*************************************************************************)
@@ -649,26 +656,28 @@ with_inner_in_parens:
  * identifiers outside of match-statement contexts. The MATCH/CASE tokens
  * used here are synthesized by Parsing_hacks_python only when the
  * surrounding shape is unambiguously a match statement.
- * Patterns are represented as plain expressions (AST_python.pattern = expr),
- * which matches what the tree-sitter Python frontend already does.
+ * Patterns are represented as expressions (AST_python.pattern = expr) and
+ * the subject and case patterns are always wrapped in a Tuple via
+ * `match_tuple` (even single-element ones), mirroring the tree-sitter
+ * Python frontend so semgrep matching is uniform across parser backends.
  * Note: `case pattern if guard:` is not accepted here — an unadorned `if`
  * after a test would collide with the conditional-expression ternary
  * (`a if b else c`) and introduce a shift/reduce conflict. Files that rely
  * on case guards will fall back to the tree-sitter parser. *)
 match_stmt:
   | MATCH tuple(namedexpr_test) ":" NEWLINE INDENT case_block+ DEDENT
-      { Switch ($1, tuple_expr $2, $6) }
+      { Switch ($1, match_tuple (to_list $2), $6) }
 
 case_block:
   | CASE tuple(test_or_star_expr) ":" suite
-      { CasesAndBody ([Case ($1, tuple_expr $2)], $4) }
+      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $4) }
   (* PEP 634 as-pattern `case pattern as name:`. TODO: preserve the binding.
    * Note: PEP 634 scopes `as` to the rightmost element of a comma-separated
    * pattern list, but here `as` binds to the whole tuple — which is fine
    * because we discard the name; revisit if the binding is ever preserved.
    *)
   | CASE tuple(test_or_star_expr) AS NAME ":" suite
-      { CasesAndBody ([Case ($1, tuple_expr $2)], $6) }
+      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $6) }
 
 (* python3-ext: *)
 async_stmt:

--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -660,24 +660,37 @@ with_inner_in_parens:
  * the subject and case patterns are always wrapped in a Tuple via
  * `match_tuple` (even single-element ones), mirroring the tree-sitter
  * Python frontend so semgrep matching is uniform across parser backends.
- * Note: `case pattern if guard:` is not accepted here — an unadorned `if`
- * after a test would collide with the conditional-expression ternary
- * (`a if b else c`) and introduce a shift/reduce conflict. Files that rely
- * on case guards will fall back to the tree-sitter parser. *)
+ * The case-pattern non-terminal is `test_nocond` (no conditional ternary)
+ * so that an `if` after the pattern is unambiguously a guard, not the
+ * `else`-less head of `a if b else c`. Starred patterns (`*rest`) are
+ * not allowed at the top of a case pattern in PEP 634 — they only appear
+ * inside sequence patterns (`case [a, *rest]:`), parsed via the list-
+ * literal atom — so dropping `star_expr` here also tightens the grammar.
+ * The `if guard` clause is parsed-and-discarded, matching the tree-sitter
+ * frontend (Parse_python_tree_sitter.ml:1433-1443 computes a `cond` value
+ * and never uses it because AST_python.case has no guard slot).
+ * TODO: extend AST_python.case with an `expr option` for the guard, plumb
+ * through both parsers, and emit `G.PatWhen (pat, guard)` in
+ * Python_to_generic.case — see ocaml_to_generic, scala_to_generic, and
+ * Parse_rust_tree_sitter for prior art. The same TODO applies to the
+ * as-pattern's bound name, which is also currently dropped. *)
 match_stmt:
   | MATCH tuple(namedexpr_test) ":" NEWLINE INDENT case_block+ DEDENT
       { Switch ($1, match_tuple (to_list $2), $6) }
 
 case_block:
-  | CASE tuple(test_or_star_expr) ":" suite
+  | CASE tuple(test_nocond) ":" suite
       { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $4) }
-  (* PEP 634 as-pattern `case pattern as name:`. TODO: preserve the binding.
-   * Note: PEP 634 scopes `as` to the rightmost element of a comma-separated
-   * pattern list, but here `as` binds to the whole tuple — which is fine
-   * because we discard the name; revisit if the binding is ever preserved.
-   *)
-  | CASE tuple(test_or_star_expr) AS NAME ":" suite
+  | CASE tuple(test_nocond) IF test ":" suite
       { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $6) }
+  (* PEP 634 as-pattern: `case pattern as name [if guard]:`. Note that PEP
+   * 634 scopes `as` to the rightmost element of a comma-separated pattern
+   * list, but here `as` binds to the whole tuple — which is fine because
+   * we discard the name; revisit when the binding is preserved. *)
+  | CASE tuple(test_nocond) AS NAME ":" suite
+      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $6) }
+  | CASE tuple(test_nocond) AS NAME IF test ":" suite
+      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $8) }
 
 (* python3-ext: *)
 async_stmt:

--- a/languages/python/menhir/Parsing_hacks_python.ml
+++ b/languages/python/menhir/Parsing_hacks_python.ml
@@ -61,9 +61,117 @@ let add_dedent num ii xs =
   else T.NEWLINE ii :: add_dedent_aux num ii xs
 
 (*****************************************************************************)
+(* Soft keywords: match / case (PEP 634)                                      *)
+(*****************************************************************************)
+(* `match` and `case` are *soft* keywords in Python 3.10+: they are normal
+ * identifiers except at the head of a structural-pattern-matching statement.
+ * The lexer therefore tokenizes them as plain NAMEs. This pass rewrites those
+ * NAMEs into dedicated MATCH / CASE tokens only when the surrounding shape is
+ * unambiguously a match-statement, leaving ordinary uses (a variable,
+ * function, or attribute called `match` or `case`) untouched.
+ *)
+
+let is_trivia = function
+  | T.TCommentSpace _
+  | T.TComment _ ->
+      true
+  | _ -> false
+
+(* True if the next non-trivia token starts a new statement.
+ * Start-of-file is also a boundary (the caller seeds the flag with true).
+ *)
+let is_stmt_boundary = function
+  | T.NEWLINE _
+  | T.INDENT _
+  | T.DEDENT _
+  | T.SEMICOL _ ->
+      true
+  | _ -> false
+
+let rec skip_trivia = function
+  | t :: xs when is_trivia t -> skip_trivia xs
+  | xs -> xs
+
+(* True iff [xs], the tokens right after the colon of a candidate match
+ * statement header, begins with NEWLINE INDENT NAME("case") (modulo trivia).
+ *)
+let block_starts_with_case xs =
+  match skip_trivia xs with
+  | T.NEWLINE _ :: xs -> (
+      match skip_trivia xs with
+      | T.INDENT _ :: xs -> (
+          match skip_trivia xs with
+          | T.NAME ("case", _) :: _ -> true
+          | _ -> false)
+      | _ -> false)
+  | _ -> false
+
+(* Scan forward at paren depth [depth] looking for a match-header COLON.
+ * Returns [Some xs] where [xs] are the tokens after the colon, or [None]
+ * if we reach a top-level NEWLINE / EOF first (i.e. not a header line).
+ *)
+let rec find_header_after_colon depth = function
+  | [] -> None
+  | (T.LPAREN _ | T.LBRACK _ | T.LBRACE _) :: xs ->
+      find_header_after_colon (depth + 1) xs
+  | (T.RPAREN _ | T.RBRACK _ | T.RBRACE _) :: xs when depth > 0 ->
+      find_header_after_colon (depth - 1) xs
+  (* unbalanced closer at top level: malformed, bail out *)
+  | (T.RPAREN _ | T.RBRACK _ | T.RBRACE _) :: _ -> None
+  | T.COLON _ :: xs when depth = 0 -> Some xs
+  | T.NEWLINE _ :: _ when depth = 0 -> None
+  | T.EOF _ :: _ -> None
+  | _ :: xs -> find_header_after_colon depth xs
+
+(* True iff the current indent [depth] is exactly one level under the
+ * innermost active match body, which is where a statement-start
+ * NAME("case") should be rewritten.
+ *)
+let at_case_level depth = function
+  | d :: _ -> depth = d + 1
+  | [] -> false
+
+(* Walk the token stream once, rewriting soft-keyword NAMEs in place.
+ *   - [depth]: current absolute INDENT depth (0 at top level);
+ *   - [match_depths]: stack of depths at which each enclosing active match
+ *     body was opened (innermost first). Frames are popped when we DEDENT
+ *     back to or below their opening depth, which transparently handles
+ *     nested match statements.
+ *   - [prev_bound]: whether the next non-trivia token starts a statement.
+ *)
+let rec rewrite depth match_depths prev_bound = function
+  | [] -> []
+  | T.INDENT ii :: xs ->
+      T.INDENT ii :: rewrite (depth + 1) match_depths true xs
+  | T.DEDENT ii :: xs ->
+      let depth' = depth - 1 in
+      let match_depths' =
+        match match_depths with
+        | d :: ds when depth' <= d -> ds
+        | _ -> match_depths
+      in
+      T.DEDENT ii :: rewrite depth' match_depths' true xs
+  | (T.NAME ("match", ii) as t) :: xs when prev_bound -> (
+      match find_header_after_colon 0 xs with
+      | Some after when block_starts_with_case after ->
+          T.MATCH ii :: rewrite depth (depth :: match_depths) false xs
+      | _ -> t :: rewrite depth match_depths false xs)
+  | T.NAME ("case", ii) :: xs
+    when prev_bound && at_case_level depth match_depths ->
+      T.CASE ii :: rewrite depth match_depths false xs
+  | t :: xs ->
+      let prev_bound' =
+        if is_trivia t then prev_bound else is_stmt_boundary t
+      in
+      t :: rewrite depth match_depths prev_bound' xs
+
+let rewrite_match_case toks = rewrite 0 [] true toks
+
+(*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
 let fix_tokens toks =
+  let toks = rewrite_match_case toks in
   let rec aux indent xs =
     match xs with
     | [ T.NEWLINE ii; T.EOF _ ] -> add_dedent indent ii xs

--- a/languages/python/menhir/Token_helpers_python.ml
+++ b/languages/python/menhir/Token_helpers_python.ml
@@ -54,6 +54,8 @@ let visitor_info_of_tok f = function
   | ASYNC ii -> ASYNC (f ii)
   | AWAIT ii -> AWAIT (f ii)
   | NONLOCAL ii -> NONLOCAL (f ii)
+  | MATCH ii -> MATCH (f ii)
+  | CASE ii -> CASE (f ii)
   | ELLIPSES ii -> ELLIPSES (f ii)
   | LDots ii -> LDots (f ii)
   | RDots ii -> RDots (f ii)

--- a/tests/patterns/python/match_cross_parser.py
+++ b/tests/patterns/python/match_cross_parser.py
@@ -1,0 +1,5 @@
+def f(x):
+    # ERROR:
+    match x:
+        case 1:
+            print("a")

--- a/tests/patterns/python/match_cross_parser.sgrep
+++ b/tests/patterns/python/match_cross_parser.sgrep
@@ -1,0 +1,3 @@
+match $X:
+    case 1:
+        $Y

--- a/tests/patterns/python/match_cross_parser_fallback.py
+++ b/tests/patterns/python/match_cross_parser_fallback.py
@@ -1,0 +1,11 @@
+def f(x):
+    # ERROR:
+    match x:
+        case 1:
+            print("a")
+
+def g(x):
+    # ERROR:
+    match x:
+        case 1 if x > 0:
+            print("b")

--- a/tests/patterns/python/match_cross_parser_fallback.sgrep
+++ b/tests/patterns/python/match_cross_parser_fallback.sgrep
@@ -1,0 +1,3 @@
+match $X:
+    case 1:
+        $Y


### PR DESCRIPTION
## Summary

The menhir-based Python parser (`languages/python/menhir/`) had no grammar rules for PEP 634 `match`/`case` statements. When it failed to parse such a file, the tree-sitter fallback would parse most of it but lose findings around the `match` block and emit a "partially analyzed" warning. This is the symptom reported in #657.

This PR adds native `match`/`case` support to the menhir parser. The tree-sitter fallback is no longer required for the common forms.

## Changes — three files in `languages/python/menhir/`

- **`Parsing_hacks_python.ml`** — adds a soft-keyword pre-pass (`rewrite_match_case`, called from `fix_tokens`) that rewrites `NAME("match")` / `NAME("case")` into dedicated `MATCH` / `CASE` tokens **only when the surrounding shape is unambiguously a match statement**. Plain identifiers (`match = 1`, `def case(x):`, `obj.match()`, dict keys, parameter names, decorator targets, etc.) keep working. Uses an indent-depth stack so nested `match` statements and `case`-as-identifier inside a case body are handled correctly.
- **`Parser_python.mly`** — declares `MATCH` / `CASE` tokens and adds `match_stmt` / `case_block` grammar rules. Patterns are represented as plain expressions (`AST_python.pattern = expr`), mirroring the tree-sitter frontend. Reuses the existing `Switch` / `Case` / `CasesAndBody` AST nodes — no AST changes. **Zero new grammar conflicts** (still 2 s/r, 4 r/r, identical to baseline). Also accepts `case pattern as name:` (PEP 634 as-pattern).
- **`Token_helpers_python.ml`** — visitor arms for the two new tokens.

## Validation

Built locally with OCaml 5.3.0 (`make minimal-build`) and exercised via the freshly built `opengrep` binary:

- Both repros from #657 now scan cleanly via the menhir parser, no tree-sitter fallback, no "partially analyzed" warning, all `return`/`raise` findings inside `case` bodies surfaced.
- Custom test harness covering: nested `match`, multi-element subjects (`match a, b:`), multi-pattern cases (`case 1, 2:`), `case _:` wildcard, `case _ as error:` as-pattern, `case [x] as pair:` sequence-with-as, `case 1 | 2 as n:` or-with-as, and `case` used as a variable name inside an `if` nested in a case body — all behave correctly.
- No-regression check on the existing `as` keyword usages: `import x as y`, `with x as y:`, `except E as e:` all still parse.
- Across the 435 `.py` files under `tests/`: **432 parse via menhir** (vs 430 on `main`). The 3 remaining failures are the same 3 pre-existing intentional ones (`tests/TODO/bad.py`, `tests/parsing_errors/unbalanced_brace.py`, `tests/patterns/python/cp_label.py`).
- Ran the patched binary against a ~1 MM LoC internal Python codebase — works as expected, no parse regressions observed.

## Known limitations (still routed to tree-sitter fallback)

- **`case pattern if guard:`** — would require non-trivial grammar reshuffling because an unadorned `if` after a `test` collides with the conditional-expression ternary `a if b else c`. Documented inline.
- **`as`-binding name dropped from AST** — preserving it would need an `AST_python.case` extension and a re-think of the as-scoping (PEP 634 scopes `as` to the rightmost element of a comma-separated pattern list, not the whole tuple). TODO noted in the rule.
