### PR TITLE
Guarding for `__p0__` in Elixir

### DIFF
--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2378,6 +2378,13 @@ let implicit_param = "!!_implicit_param!"
 let implicit_param_id tk = (implicit_param, tk)
 let is_implicit_param s = String.starts_with ~prefix:"!!_implicit_param!" s
 
+(* Synthetic positional parameters inserted by Elixir_to_generic for
+ * multi-clause function definitions (__p0__, __p1__, ...). These names
+ * are not present in source code, so the prefilter must not require
+ * them. Coupling: languages/elixir/generic/Elixir_to_generic.ml where
+ * these are generated, and src/rule/Pattern.ml is_special_identifier. *)
+let is_elixir_synthetic_param s = Common.(s =~ "^__p[0-9]+__$")
+
 (* ------------------------------------------------------------------------- *)
 (* Types *)
 (* ------------------------------------------------------------------------- *)

--- a/src/rule/Pattern.ml
+++ b/src/rule/Pattern.ml
@@ -77,3 +77,6 @@ let is_special_identifier ?lang str =
    * these identifiers are not expected to be found in the source files!
    * Else targets are skipped when they should not be. *)
   || AST_generic.is_implicit_param str
+  (* Elixir multi-clause functions are lowered to synthetic __pN__
+   * parameters in Elixir_to_generic; these are never present in source. *)
+  || (lang =*= Some Lang.Elixir && AST_generic.is_elixir_synthetic_param str)

--- a/tests/rules/elixir_multi_clause_prefilter.ex
+++ b/tests/rules/elixir_multi_clause_prefilter.ex
@@ -1,0 +1,5 @@
+defmodule Example do
+  # ruleid: find-multi-clause
+  def greet("hello"), do: "hi"
+  def greet("bye"), do: "goodbye"
+end

--- a/tests/rules/elixir_multi_clause_prefilter.yaml
+++ b/tests/rules/elixir_multi_clause_prefilter.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: find-multi-clause
+    patterns:
+      - pattern: |
+          def greet("hello"), do: "hi"
+          def greet("bye"), do: "goodbye"
+    languages: [elixir]
+    message: found multi-clause
+    severity: INFO


### PR DESCRIPTION
This fixes #636, the issue is that in Elixir we get "artificial" variables `__p0__` which are missed by the pcre filter and so the respective files are filtered out. This fixes that