### PR TITLE
ci: skip init steps when cache was restored via restore-keys

### DIFF
--- a/.github/workflows/build-test-core-aarch64.yml
+++ b/.github/workflows/build-test-core-aarch64.yml
@@ -41,9 +41,10 @@ jobs:
           path: _opam
         
       - name: Set SHOULD_INIT_OPAM based on Cache
-        if: steps.cache-opam-linux-aarch64.outputs.cache-hit == 'true'
         run: |
-          echo "SHOULD_INIT_OPAM=false" >> $GITHUB_ENV
+          if [ -d _opam ]; then
+            echo "SHOULD_INIT_OPAM=false" >> $GITHUB_ENV
+          fi
 
       - name: Run build inside container
         run: |

--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -204,8 +204,7 @@ jobs:
           OPAMCOLOR: always
           # OPAMROOT: C:/Users/runneradmin/AppData/Local/opam
         shell: bash
-        if: steps.cache-opamroot-win32-64.outputs.cache-hit != 'true'
-        # if: steps.cache-opam-win32-64.outputs.cache-hit != 'true'
+        if: steps.cache-opamroot-win32-64.outputs.cache-matched-key == ''
         run: |
           opam init \
           --no-setup \
@@ -225,7 +224,7 @@ jobs:
           OPAMSOLVERTIMEOUT: 600
           OPAMCOLOR: always
         shell: bash
-        if: steps.cache-opam-win32-64.outputs.cache-hit != 'true'
+        if: steps.cache-opam-win32-64.outputs.cache-matched-key == ''
         run: |
           export OCAML_VERSION=${{ matrix.ocaml_version }}
           echo "Creating local switch with OCaml $OCAML_VERSION..."
@@ -245,7 +244,7 @@ jobs:
           # OPAMCONFIRMLEVEL: unsafe-yes
           OPAMCOLOR: always
         shell: bash
-        if: steps.cache-opam-win32-64.outputs.cache-hit != 'true'
+        if: steps.cache-opam-win32-64.outputs.cache-matched-key == ''
         run: |
           eval $(opam env)
 


### PR DESCRIPTION
Windows opam/OPAMROOT init steps and aarch64 SHOULD_INIT_OPAM guard were conditioned on cache-hit, which is false when a cache is restored via restore-keys. After PR #670 added restore-keys fallbacks, a fallback-restored _opam caused the init steps to run and fail with "switch already exists". Windows steps now guard on cache-matched-key == ''; aarch64 guards on [ -d _opam ] inside the shell, matching the x86 pattern.