### PR TITLE
Exclude more synthetic identifiers from the PCRE prefilter

### DIFF
--- a/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
+++ b/languages/kotlin/generic/Parse_kotlin_tree_sitter.ml
@@ -1432,7 +1432,15 @@ and lambda_literal (env : env) ((v1, v2, v3, v4) : CST.lambda_literal) =
          * the dataflow engine to track taint into the lambda body.
         *)
         let fake_it_tok = Tok.fake_tok v1 "it" in
-        let it_param = G.Param (G.param_of_id ("it", fake_it_tok)) in
+        (* Mark the synthetic param's pinfo as hidden so the prefilter in
+         * Analyze_pattern.ml does not require 'it' to appear in the target
+         * source (e.g. when the source uses an explicit parameter name). *)
+        let it_pinfo =
+          G.basic_id_info ~hidden:true (G.Parameter, G.SId.unsafe_default)
+        in
+        let it_param =
+          G.Param { (G.param_of_id ("it", fake_it_tok)) with pinfo = it_pinfo }
+        in
         ([it_param], v1)
   in
   let v3 =

--- a/languages/scala/generic/scala_to_generic.ml
+++ b/languages/scala/generic/scala_to_generic.ml
@@ -43,7 +43,10 @@ let v_list = List_.map
 let v_option = Option.map
 
 let cases_to_lambda lb cases : G.function_definition =
-  let id = ("!hidden_scala_param!", lb) in
+  (* Use the generic implicit-param name so the prefilter exclusion in
+   * Pattern.is_special_identifier (via AST_generic.is_implicit_param)
+   * applies — otherwise rules over `{ case ... }` blocks are filtered out. *)
+  let id = G.implicit_param_id lb in
   let param = G.Param (G.param_of_id id) in
   let body =
     G.Switch (lb, Some (G.Cond (G.N (H.name_of_id id) |> G.e)), cases) |> G.s

--- a/src/optimizing/Analyze_pattern.ml
+++ b/src/optimizing/Analyze_pattern.ml
@@ -63,6 +63,24 @@ class ['self] extract_strings_and_mvars_visitor =
             ()
         | _ -> super#visit_name env x
 
+      (* Same rationale as [visit_name] above, but for parameters whose
+       * [pname] is synthesised by a *_to_generic converter (e.g. Kotlin's
+       * implicit `it` for parameterless lambdas): when [pinfo] is marked
+       * hidden the pname is not in the target source and must not appear
+       * in the prefilter regex. *)
+      method! visit_parameter_classic env p =
+        if IdFlags.is_hidden !(p.pinfo.id_flags) then ()
+        else super#visit_parameter_classic env p
+
+      (* Same rationale for pattern identifiers synthesised by a
+       * *_to_generic converter (e.g. Elixir's `__tmp` for the `^` pin
+       * operator): when [id_info] is marked hidden the ident must not
+       * leak into the prefilter regex. *)
+      method! visit_pattern env x =
+        match x with
+        | PatId (_, { id_flags; _ }) when IdFlags.is_hidden !id_flags -> ()
+        | _ -> super#visit_pattern env x
+
       method! visit_directive (strings, _mvars, _lang as env) x =
         match x with
         | { d = ImportFrom (_, FileName (str, _), _); _ }

--- a/tests/rules/elixir_caret_pattern_prefilter.ex
+++ b/tests/rules/elixir_caret_pattern_prefilter.ex
@@ -1,0 +1,10 @@
+defmodule CaretExample do
+  def check(x) do
+    y = 42
+    # ruleid: find-caret
+    case x do
+      ^y -> :match
+      _ -> :no_match
+    end
+  end
+end

--- a/tests/rules/elixir_caret_pattern_prefilter.yaml
+++ b/tests/rules/elixir_caret_pattern_prefilter.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: find-caret
+    patterns:
+      - pattern: |
+          case $X do
+            ^$Y -> :match
+            _ -> :no_match
+          end
+    languages: [elixir]
+    message: found caret pin match
+    severity: INFO

--- a/tests/rules/kotlin_implicit_it_prefilter.kt
+++ b/tests/rules/kotlin_implicit_it_prefilter.kt
@@ -1,0 +1,5 @@
+fun main() {
+    val xs = listOf(1, 2, 3)
+    // ruleid: find-kt-map-const
+    val ys = xs.map { 42 }
+}

--- a/tests/rules/kotlin_implicit_it_prefilter.yaml
+++ b/tests/rules/kotlin_implicit_it_prefilter.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: find-kt-map-const
+    patterns:
+      - pattern: |
+          $XS.map { $E }
+    languages: [kotlin]
+    message: found map with constant lambda
+    severity: INFO

--- a/tests/rules/scala_cases_prefilter.scala
+++ b/tests/rules/scala_cases_prefilter.scala
@@ -1,0 +1,5 @@
+object Example {
+  val xs = List(1, 2, 3)
+  // ruleid: find-scala-cases
+  val ys = xs.map { case 1 => "one"; case n => "other" }
+}

--- a/tests/rules/scala_cases_prefilter.yaml
+++ b/tests/rules/scala_cases_prefilter.yaml
@@ -1,0 +1,8 @@
+rules:
+  - id: find-scala-cases
+    patterns:
+      - pattern: |
+          $XS.map { case 1 => "one"; case $N => "other" }
+    languages: [scala]
+    message: found cases lambda
+    severity: INFO


### PR DESCRIPTION
Follow-up to #671. The same prefilter leak affected three other encodings of synthetic identifiers.

- **Scala** `cases_to_lambda` injected `!hidden_scala_param!` for `{ case … }` lambdas. Switched to the existing `AST_generic.implicit_param`, already excluded via `Pattern.is_special_identifier`.
- **Kotlin** injected `it` as a synthetic pname for parameterless lambdas. Marked its `pinfo` hidden.
- **Elixir** `^` pin operator already built a hidden `PatId "__tmp"`, but the prefilter visitor only consulted the hidden flag on `N (Id _)` names. Extended `Analyze_pattern.ml` to also honour it on `Param` and `PatId`.

Each case has a fixture under `tests/rules/` demonstrating a file the prior binary skipped entirely.