### PR TITLE
ci(alpine): add curl to apk install

### DIFF
--- a/scripts/workflow-build-inside-alpine-container.sh
+++ b/scripts/workflow-build-inside-alpine-container.sh
@@ -17,7 +17,7 @@ SHOULD_INIT_OPAM=${SHOULD_INIT_OPAM:-true}
 apk add --no-cache \
     git build-base zip bash libffi-dev \
     libpsl-static zstd-static libidn2-static \
-    libunistring-static tar zstd gnupg
+    libunistring-static tar zstd gnupg curl
 
 # Install opam from the official upstream release. Alpine's packaged opam lags
 # behind, so we pin to OPAM_VERSION and fetch the matching static binary for


### PR DESCRIPTION
Follow-up to #674. Alpine's opam package lists `curl` as a direct dependency; dropping `apk add opam` in the 2.5.1 upgrade lost it. `libs/ocaml-tree-sitter-core/scripts/download-tree-sitter` calls `curl`, which broke the aarch64 build on main.