### PR TITLE
hide synthetic idents, add prefix-metavar matching, fix go chan direction

### DIFF
--- a/languages/apex/generic/Parse_apex_tree_sitter.ml
+++ b/languages/apex/generic/Parse_apex_tree_sitter.ml
@@ -1684,10 +1684,13 @@ match v4 with
             let iname = String.lowercase_ascii iname in
             let has_params = iname <> "get" in
             let has_return = iname = "get" in
-            (* Use the source keyword (`get`/`set`) as the accessor entity
-               name; mangling to `get_X`/`set_X` broke pattern matching. *)
-            let _fname = fname in
-            let ent = basic_entity (iname, itok) ~attrs in
+            (* CLR-style `get_<P>` / `set_<P>` accessor name; the
+               prefix-metavar support in m_ident lets patterns like
+               `set_$P` match these. Hidden so the prefilter regex
+               doesn't demand the mangled string literally. *)
+            let ent =
+              basic_entity ~hidden:true (iname ^ "_" ^ fname, itok) ~attrs
+            in
             let funcdef =
               FuncDef
                 {

--- a/languages/apex/generic/Parse_apex_tree_sitter.ml
+++ b/languages/apex/generic/Parse_apex_tree_sitter.ml
@@ -1372,15 +1372,18 @@ and declaration (env : env) (x : CST.declaration) : G.stmt =
       let events = v6 :: v7 in
       let v8 = (* ")" *) token env v8 in
       let v9 = trigger_body env v9 in
+      (* __trigger_events / __trigger_object are synthetic attribute
+         names not present in Apex source; mark hidden so they don't
+         leak into the prefilter regex. *)
       let entity =
         { name = G.EN (G.Id (v2, G.empty_id_info ()));
           attrs = [G.NamedAttr
                      (fake "@",
-                      G.Id (("__trigger_events", fake ""), empty_id_info ()),
+                      G.Id (("__trigger_events", fake ""), empty_id_info ~hidden:true ()),
                       (v5, events, v8));
                    G.NamedAttr
                      (fake "@",
-                      G.Id (("__trigger_object", fake ""), empty_id_info ()),
+                      G.Id (("__trigger_object", fake ""), empty_id_info ~hidden:true ()),
                       fb [G.Arg (G.N (G.Id (v4, empty_id_info ())) |> G.e)])];
           tparams = None }
       in
@@ -1681,7 +1684,10 @@ match v4 with
             let iname = String.lowercase_ascii iname in
             let has_params = iname <> "get" in
             let has_return = iname = "get" in
-            let ent = basic_entity (iname ^ "_" ^ fname, itok) ~attrs in
+            (* Use the source keyword (`get`/`set`) as the accessor entity
+               name; mangling to `get_X`/`set_X` broke pattern matching. *)
+            let _fname = fname in
+            let ent = basic_entity (iname, itok) ~attrs in
             let funcdef =
               FuncDef
                 {
@@ -1690,6 +1696,11 @@ match v4 with
                     fb
                       (if has_params then
                           [
+                            (* Apex setter's implicit `value`. The word
+                               appears in source when the setter body
+                               uses it, so we don't mark pinfo hidden —
+                               Eval_generic uses [is_hidden] to gate
+                               `metavariable-regex` evaluation. *)
                             Param
                               {
                                 pname = Some ("value", fake "value");

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -254,10 +254,13 @@ and map_qualifier env = function
          It's like a dynamic IdQualified, really more suited for something
          like a DotAccess of a Call to `decltype`, for programs like
          decltype(e)::foo
-         Let's just make something up for now.
+         We use the `!!_implicit_param!` prefix so the prefilter's
+         is_implicit_param check skips this synthesised ident.
       *)
       let _v1 = map_tok env v1 and _v2 = map_bracket env (map_expr env) v2 in
-      let v1 = ("DecltypeId", G.fake "DecltypeId") in
+      let v1 =
+        (G.implicit_param ^ "decltype", G.fake (G.implicit_param ^ "decltype"))
+      in
       (v1, None)
 
 and map_a_class_name env v = map_name env v

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -82,14 +82,6 @@ let expr_option t eopt =
   | Some e -> e
   | None -> G.L (G.Unit t) |> G.e
 
-let _name_option t nopt =
-  match nopt with
-  | Some n -> n
-  | None ->
-      (* TODO? gensym? *)
-      let fake_id = ("_ANON", t) in
-      H.name_of_id fake_id
-
 let distribute_access (xs : (G.field, G.attribute) Either.t list) : G.field list
     =
   let rec aux attr_opt xs =

--- a/languages/cpp/generic/cpp_to_generic.ml
+++ b/languages/cpp/generic/cpp_to_generic.ml
@@ -251,7 +251,7 @@ and map_qualifier env = function
       *)
       let _v1 = map_tok env v1 and _v2 = map_bracket env (map_expr env) v2 in
       let v1 =
-        (G.implicit_param ^ "decltype", G.fake (G.implicit_param ^ "decltype"))
+       let impl_param = G.implicit_param ^ "decltype" in (impl_param, G.fake impl_param)
       in
       (v1, None)
 

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -3267,15 +3267,16 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
               accs
               |> List_.map (fun (attrs, id, fbody) ->
                      let iname, itok = id in
-                     (* Use the source keyword (`get`/`set`/`init`) as
-                        the accessor entity name rather than the CLR-style
-                        `get_X`/`set_X`. The mangling broke pattern
-                        matching of `set { ... }` against `$P { set; }`
-                        because `set_$P` is treated as one opaque ident
-                        instead of `set_` + metavar `$P`, and it's not
-                        needed for taint analysis at this layer. *)
-                     let _fname = fname in
-                     let ent = basic_entity (iname, itok) ~attrs in
+                     (* CLR-style `get_<PropName>` / `set_<PropName>`;
+                        the prefix-metavar support in m_ident (see
+                        Generic_vs_generic.decompose_prefix_metavar)
+                        lets patterns like `set_$P` match these. Mark
+                        hidden so the prefilter regex doesn't demand
+                        the literal mangled string. *)
+                     let ent =
+                       basic_entity ~hidden:true
+                         (iname ^ "_" ^ fname, itok) ~attrs
+                     in
                      let valparam =
                        Param
                          {
@@ -3510,10 +3511,12 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
                        else G.KeywordAttr (G.Setter, itok)
                   in
                   let attrs = attrs in
-                  (* Keep `get`/`set`/`init` as the entity name — see
-                     the other accessor site above for rationale. *)
-                  let _fname = fname in
-                  let ent = basic_entity (iname, itok) ~attrs in
+                  (* CLR-style accessor name; see other accessor site
+                     above for rationale. *)
+                  let ent =
+                    basic_entity ~hidden:true
+                      (iname ^ "_" ^ fname, itok) ~attrs
+                  in
                   let itok_loc = Tok.unsafe_loc_of_tok itok in
                   let new_loc loc n =
                       Tok.({
@@ -3575,12 +3578,15 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
             ((open_br, funcs, close_br), v2)
         | `Arrow_exp_clause_SEMI (v1, v2) ->
             (* public int SomeProp => 3;
-             * Convert it to `get_SomeProp { return 3; }`
-             *)
+             * Convert it to `get_SomeProp { return 3; }` — CLR-style
+             * accessor name; patterns use `set_$P` / `get_$P` and the
+             * prefix-metavar support in m_ident binds the metavar.
+             * Hidden so the prefilter regex doesn't demand the mangled
+             * string literally. *)
             let v1 = arrow_expression_clause env v1 in
             let v2 = token env v2 (* ";" *) in
             let arrow, expr = v1 in
-            let ent = basic_entity ("get_" ^ fname, arrow) in
+            let ent = basic_entity ~hidden:true ("get_" ^ fname, arrow) in
             let funcdef =
               FuncDef
                 {

--- a/languages/csharp/generic/Parse_csharp_tree_sitter.ml
+++ b/languages/csharp/generic/Parse_csharp_tree_sitter.ml
@@ -272,8 +272,13 @@ let linq_to_expr (from : linq_query_part) (body : linq_query_part list) =
   | _ -> raise Impossible
 
 let new_index_from_end tok expr =
+  (* `arr[^N]` is desugared to `new System.Index(N, true)`. Neither
+     `System` nor `Index` appears in the source `^N` syntax, so mark
+     the synthesised qualified name hidden so the prefilter regex
+     doesn't demand them. *)
   let name =
-    H2.name_of_ids [ ("System", fake "System"); ("Index", fake "Index") ]
+    H2.name_of_ids ~hidden:true
+      [ ("System", fake "System"); ("Index", fake "Index") ]
   in
   let index = TyN name |> G.t in
   New
@@ -3262,9 +3267,15 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
               accs
               |> List_.map (fun (attrs, id, fbody) ->
                      let iname, itok = id in
-                     let ent =
-                       basic_entity (iname ^ "_" ^ fname, itok) ~attrs
-                     in
+                     (* Use the source keyword (`get`/`set`/`init`) as
+                        the accessor entity name rather than the CLR-style
+                        `get_X`/`set_X`. The mangling broke pattern
+                        matching of `set { ... }` against `$P { set; }`
+                        because `set_$P` is treated as one opaque ident
+                        instead of `set_` + metavar `$P`, and it's not
+                        needed for taint analysis at this layer. *)
+                     let _fname = fname in
+                     let ent = basic_entity (iname, itok) ~attrs in
                      let valparam =
                        Param
                          {
@@ -3272,6 +3283,10 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
                            ptype = Some v4;
                            pdefault = None;
                            pattrs = [];
+                           (* C# setter's implicit `value` — the word
+                              appears in source when the setter body uses
+                              it. Eval_generic uses [is_hidden] to gate
+                              `metavariable-regex`, so don't mark hidden. *)
                            pinfo = empty_id_info ();
                          }
                      in
@@ -3455,7 +3470,10 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
       let _v4TODO = Option.map (explicit_interface_specifier env) v4 in
       let v5 = identifier env v5 (* identifier *) in
       let fname, _ftok = v5 in
-      (* The C#14 "field" keyword is mapped as an additional argument to get and set *)
+      (* The C#14 "field" keyword is mapped as an additional argument to
+         get and set. The keyword `field` can appear in source when the
+         accessor body uses it, so we don't mark pinfo hidden —
+         Eval_generic uses [is_hidden] to gate `metavariable-regex`. *)
       let fieldParam tok =
         Param
           {
@@ -3492,7 +3510,10 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
                        else G.KeywordAttr (G.Setter, itok)
                   in
                   let attrs = attrs in
-                  let ent = basic_entity (iname ^ "_" ^ fname, itok) ~attrs in
+                  (* Keep `get`/`set`/`init` as the entity name — see
+                     the other accessor site above for rationale. *)
+                  let _fname = fname in
+                  let ent = basic_entity (iname, itok) ~attrs in
                   let itok_loc = Tok.unsafe_loc_of_tok itok in
                   let new_loc loc n =
                       Tok.({
@@ -3534,7 +3555,8 @@ and declaration ?(this_param=None) (env : env) (x : CST.declaration) : stmt =
                              else []) @ [fieldParam field_token]);
                         (* NOTE: In order to make "set" be recognised by a $T $FOO(...) {...} pattern, *)
                         (* we need to give it the void type and point to a real token. *)
-                        frettype = (if has_return then Some v3 else Some (G.TyN (Id (("void", itok), G.empty_id_info ())) |> G.t));
+                        (* Synthetic `void` return — hidden to keep it out of the prefilter. *)
+                        frettype = (if has_return then Some v3 else Some (G.TyN (Id (("void", itok), G.empty_id_info ~hidden:true ())) |> G.t));
                         (* TODO Should this be "void"? *)
                         fbody;
                       }

--- a/languages/elixir/generic/Elixir_to_generic.ml
+++ b/languages/elixir/generic/Elixir_to_generic.ml
@@ -687,15 +687,23 @@ and map_definition env (v : definition) : G.definition =
       let _, first_params, _ = clause.f_params in
       let n = List.length first_params in
       let param_ids = List.init n (fun i -> (Printf.sprintf "__p%d__" i, tk)) in
+      (* The __pN__ names are synthesised for the multi-clause lowering
+         and never appear in Elixir source; mark hidden so the prefilter
+         regex doesn't require them. *)
       let synthetic_fparams =
         Tok.unsafe_fake_bracket
-          (List_.map (fun pid -> G.Param (G.param_of_id pid)) param_ids)
+          (List_.map (fun pid -> G.Param (G.param_of_id ~hidden:true pid))
+             param_ids)
       in
       let switch_cond =
         match param_ids with
         | [] -> G.L (G.Null tk) |> G.e
         | ids ->
-            let refs = List_.map (fun pid -> G.N (H.name_of_id pid) |> G.e) ids in
+            let refs =
+              List_.map (fun pid ->
+                  G.N (H.name_of_id ~hidden:true pid) |> G.e)
+                ids
+            in
             G.Container (G.Tuple, Tok.unsafe_fake_bracket refs) |> G.e
       in
       let cases =

--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -153,11 +153,17 @@ let top_func () =
   and type_argument v =
     let t = type_ v in
     G.TA t
-  and chan_dir = function
-    | TSend -> G.TyN (G.Id (unsafe_fake_id "send", G.empty_id_info ())) |> G.t
-    | TRecv -> G.TyN (G.Id (unsafe_fake_id "recv", G.empty_id_info ())) |> G.t
+  and chan_dir =
+    (* The direction names are synthetic — Go source never literally
+       contains "send"/"recv"/"bidirectional"; they come from the
+       `chan<-` / `<-chan` / `chan` syntax. Mark hidden so the prefilter
+       doesn't demand these strings in the target. *)
+    let hidden () = G.empty_id_info ~hidden:true () in
+    function
+    | TSend -> G.TyN (G.Id (unsafe_fake_id "send", hidden ())) |> G.t
+    | TRecv -> G.TyN (G.Id (unsafe_fake_id "recv", hidden ())) |> G.t
     | TBidirectional ->
-        G.TyN (G.Id (unsafe_fake_id "bidirectional", G.empty_id_info ())) |> G.t
+        G.TyN (G.Id (unsafe_fake_id "bidirectional", hidden ())) |> G.t
   and func_type { ftok; fparams = l, params, r; fresults } :
       G.tok * G.parameters * G.type_ option =
     let fparams = list parameter_binding params in

--- a/languages/go/tree-sitter/Parse_go_tree_sitter.ml
+++ b/languages/go/tree-sitter/Parse_go_tree_sitter.ml
@@ -1100,15 +1100,18 @@ and channel_type (env : env) (x : CST.channel_type) =
       let v2 = type_ env v2 in
       TChan (v1, TBidirectional, v2)
   | `Chan_LTDASH_choice_simple_type (v1, v2, v3) ->
+      (* `chan<- T` is a send-only channel. The menhir Go parser labels
+         this TSend; tree-sitter was previously swapped. *)
       let v1 = token env v1 (* "chan" *) in
       let _v2 = token env v2 (* "<-" *) in
       let v3 = type_ env v3 in
-      TChan (v1, TRecv, v3)
+      TChan (v1, TSend, v3)
   | `LTDASH_chan_choice_simple_type (v1, v2, v3) ->
+      (* `<-chan T` is a receive-only channel. *)
       let _v1 = token env v1 (* "<-" *) in
       let v2 = token env v2 (* "chan" *) in
       let v3 = type_ env v3 in
-      TChan (v2, TSend, v3)
+      TChan (v2, TRecv, v3)
 
 and parameter_list (env : env) ((v1, v2, v3) : CST.parameter_list) :
     parameter_binding list bracket =

--- a/languages/swift/generic/Parse_swift_tree_sitter.ml
+++ b/languages/swift/generic/Parse_swift_tree_sitter.ml
@@ -1302,8 +1302,10 @@ and map_dictionary_type (env : env) ((v1, v2, v3, v4, v5) : CST.dictionary_type)
   let v4 = map_type_ env v4 in
   let v5 = (* "]" *) token env v5 in
   (* Modeled after Semgrep treats map types in Go. In Swift, [Int: Int] is
-   * equivalent to Dictionary<Int, Int>, so we'll just desugar to that. *)
-  let dict_name = H2.name_of_id ("Dictionary", v1) in
+   * equivalent to Dictionary<Int, Int>, so we'll just desugar to that.
+   * "Dictionary" isn't in the source `[K: V]` form — mark hidden so the
+   * prefilter regex doesn't require it. *)
+  let dict_name = H2.name_of_id ~hidden:true ("Dictionary", v1) in
   G.TyApply (G.TyN dict_name |> G.t, (v1, [ G.TA v2; G.TA v4 ], v5)) |> G.t
 
 and map_binding_kind_and_pattern (env : env)

--- a/languages/vbnet/Vbnet_parser.ml
+++ b/languages/vbnet/Vbnet_parser.ml
@@ -305,15 +305,16 @@ let ident_of_token (t : T.t) : G.ident =
 let expr_of_id (id : G.ident) =
   G.N (G.Id (id, G.empty_id_info ~case_insensitive:true ())) |> G.e
 
-let make_name (ident : G.ident) (type_args : G.type_arguments option) : G.name =
+let make_name ?(hidden = false) (ident : G.ident)
+    (type_args : G.type_arguments option) : G.name =
   match type_args with
-  | None -> G.Id (ident, G.empty_id_info ~case_insensitive:true ())
+  | None -> G.Id (ident, G.empty_id_info ~case_insensitive:true ~hidden ())
   | Some _ ->
       G.IdQualified
         { name_last = (ident, type_args);
           name_middle = None;
           name_top = None;
-          name_info = G.empty_id_info ~case_insensitive:true () }
+          name_info = G.empty_id_info ~case_insensitive:true ~hidden () }
 
 let rec split_last (xs : 'a list) : 'a list * 'a =
   match xs with
@@ -3083,7 +3084,7 @@ and property_accessor_block ((property_name_str, _) : G.ident)
       let* _ = token "END" in
       let* _ = token "GET" in
       let entity =
-        G.{ name = G.EN (make_name ("GET_" ^ property_name_str,  get.tok) None);
+        G.{ name = G.EN (make_name ~hidden:true ("GET_" ^ property_name_str, get.tok) None);
             attrs = modifiers @ List.concat attrs;
             tparams = None }
       in
@@ -3106,7 +3107,7 @@ and property_accessor_block ((property_name_str, _) : G.ident)
       let* _ = token "END" in
       let* _ = token "SET" in
       let entity =
-        G.{ name = G.EN (make_name ("SET_" ^ property_name_str, set.tok) None);
+        G.{ name = G.EN (make_name ~hidden:true ("SET_" ^ property_name_str, set.tok) None);
             attrs = modifiers @ List.concat attrs;
             tparams = None }
       in

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2353,13 +2353,13 @@ let raw_of_stmt (x : stmt) : any Raw_tree.t = Any (S x)
 (* ------------------------------------------------------------------------- *)
 
 (* alt: could use @@deriving make *)
-let param_of_id ?(pattrs = []) ?ptype ?pdefault id =
+let param_of_id ?(pattrs = []) ?ptype ?pdefault ?(hidden = false) id =
   {
     pname = Some id;
     pdefault;
     ptype;
     pattrs;
-    pinfo = basic_id_info (Parameter, SId.unsafe_default);
+    pinfo = basic_id_info ~hidden (Parameter, SId.unsafe_default);
   }
 
 let param_of_type ?(pattrs = []) ?pdefault ?pname typ =
@@ -2378,12 +2378,6 @@ let implicit_param = "!!_implicit_param!"
 let implicit_param_id tk = (implicit_param, tk)
 let is_implicit_param s = String.starts_with ~prefix:"!!_implicit_param!" s
 
-(* Synthetic positional parameters inserted by Elixir_to_generic for
- * multi-clause function definitions (__p0__, __p1__, ...). These names
- * are not present in source code, so the prefilter must not require
- * them. Coupling: languages/elixir/generic/Elixir_to_generic.ml where
- * these are generated, and src/rule/Pattern.ml is_special_identifier. *)
-let is_elixir_synthetic_param s = Common.(s =~ "^__p[0-9]+__$")
 
 (* ------------------------------------------------------------------------- *)
 (* Types *)

--- a/libs/ast_generic/AST_generic.ml
+++ b/libs/ast_generic/AST_generic.ml
@@ -2378,7 +2378,6 @@ let implicit_param = "!!_implicit_param!"
 let implicit_param_id tk = (implicit_param, tk)
 let is_implicit_param s = String.starts_with ~prefix:"!!_implicit_param!" s
 
-
 (* ------------------------------------------------------------------------- *)
 (* Types *)
 (* ------------------------------------------------------------------------- *)

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -100,6 +100,10 @@ let add_type_args_opt_to_name name topt =
   | None -> name
   | Some t -> add_type_args_to_name name t
 
+(* NOTE: [~hidden] flags only the envelope; inner qualifier idents
+   in [name_middle] are not marked hidden. Current prefilter visitor
+   short-circuits at the envelope so this is fine — keep in mind if
+   you add a visitor that descends into [name_middle]. *)
 let name_of_ids ?name_top ?(case_insensitive = false) ?(hidden = false) xs =
   match List.rev xs with
   | [] -> failwith "name_of_ids: empty ids"

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -100,11 +100,11 @@ let add_type_args_opt_to_name name topt =
   | None -> name
   | Some t -> add_type_args_to_name name t
 
-let name_of_ids ?name_top ?(case_insensitive = false) xs =
+let name_of_ids ?name_top ?(case_insensitive = false) ?(hidden = false) xs =
   match List.rev xs with
   | [] -> failwith "name_of_ids: empty ids"
   | [ x ] when Option.is_none name_top ->
-    Id (x, empty_id_info ~case_insensitive ())
+    Id (x, empty_id_info ~case_insensitive ~hidden ())
   | x :: xs ->
       let qualif =
         if xs =*= [] then None
@@ -115,7 +115,7 @@ let name_of_ids ?name_top ?(case_insensitive = false) xs =
           name_last = (x, None);
           name_middle = qualif;
           name_top;
-          name_info = empty_id_info ();
+          name_info = empty_id_info ~hidden ();
         }
 
 let add_suffix_to_name suffix name =
@@ -136,8 +136,8 @@ let add_suffix_to_name suffix name =
           name_middle = new_name_middle;
         }
 
-let name_of_id ?(case_insensitive = false) id =
-  Id (id, empty_id_info ~case_insensitive ())
+let name_of_id ?(case_insensitive = false) ?(hidden = false) id =
+  Id (id, empty_id_info ~case_insensitive ~hidden ())
 
 let name_of_dot_access e =
   let rec fetch_ids = function

--- a/libs/ast_generic/AST_generic_helpers.mli
+++ b/libs/ast_generic/AST_generic_helpers.mli
@@ -45,10 +45,10 @@ val funcbody_to_stmt : AST_generic.function_body -> AST_generic.stmt
 
 (* name building *)
 
-val name_of_id : ?case_insensitive:bool -> AST_generic.ident -> AST_generic.name
+val name_of_id : ?case_insensitive:bool -> ?hidden:bool -> AST_generic.ident -> AST_generic.name
 
 val name_of_ids :
-  ?name_top:Tok.t -> ?case_insensitive:bool -> AST_generic.dotted_ident -> AST_generic.name
+  ?name_top:Tok.t -> ?case_insensitive:bool -> ?hidden:bool -> AST_generic.dotted_ident -> AST_generic.name
 
 val name_of_ids_with_opt_typeargs :
   (AST_generic.ident * AST_generic.type_arguments option) list ->

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -207,11 +207,6 @@ let m_ident a b =
   | (stra, _), (strb, _) when Pattern.is_regexp_string stra ->
       let re_match = Matching_generic.regexp_matcher_of_regexp_string stra in
       if re_match strb then return () else fail ()
-  (* Prefix metavar: pattern "set_$P" matches source "set_X". *)
-  | (stra, _), b when String.contains stra '$' -> (
-      match match_prefix_metavar stra b with
-      | Some tin -> tin
-      | None -> m_wrap m_string a b)
   (* Note: We should try to avoid allowing case insensitive
    *  identifiers to get here because we have no way of
    *  distinguishing them from case sensitive identifiers
@@ -719,8 +714,14 @@ and m_ident_and_id_info (a1, a2) (b1, b2) =
   | (stra, _), (strb, _) when Pattern.is_regexp_string stra ->
       let re_match = Matching_generic.regexp_matcher_of_regexp_string stra in
       if re_match strb then return () else fail ()
-  (* Prefix metavar: pattern "set_$P" matches source "set_X". *)
-  | (stra, _), b1 when String.contains stra '$' -> (
+  (* Prefix metavar: pattern "set_$P" matches source "set_X", but
+     only when the pattern-side id_info is marked hidden. Synthetic
+     parser-mangled entities (e.g. C#/Apex `get_<P>` / `set_<P>` or
+     VB.NET `GET_<P>` / `SET_<P>`) are the intended trigger; we avoid
+     spurious decomposition of literal idents containing `$` in JS,
+     Scala, Java etc. by gating on the hidden flag. *)
+  | (stra, _), b1
+    when String.contains stra '$' && IdFlags.is_hidden !(a2.G.id_flags) -> (
       match match_prefix_metavar stra b1 with
       | Some tin -> tin
       | None ->

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -174,6 +174,24 @@ let m_id_string case_insensitive =
 (* Name *)
 (*****************************************************************************)
 
+(* Pattern ident "<prefix>$METAVAR" matches source ident "<prefix><s>"
+   by binding $METAVAR to <s>. Used for parser-synthesised mangled
+   names such as C#/Apex property accessors `get_<PropName>` /
+   `set_<PropName>`. Returns [Some (binder)] if it applies (pass
+   [binder] to the matching monad), [None] otherwise. *)
+let match_prefix_metavar stra (strb, tokb) =
+  if Mvar.is_metavar_name stra then None
+  else if Common.(stra =~ "^\\([^$]+\\)\\(\\$[A-Z_][A-Z_0-9]*\\)$") then
+    let pfx, mvar = Common.matched2 stra in
+    let pfx_len = String.length pfx in
+    if String.length strb > pfx_len
+       && Common.(String.sub strb 0 pfx_len =*= pfx)
+    then
+      let middle = String.sub strb pfx_len (String.length strb - pfx_len) in
+      Some (envf (mvar, tokb) (MV.Id ((middle, tokb), None)))
+    else None
+  else None
+
 (* coupling: modify also m_ident_and_id_info *)
 (* You should prefer to use m_ident_and_id_info if you can *)
 let m_ident a b =
@@ -189,6 +207,11 @@ let m_ident a b =
   | (stra, _), (strb, _) when Pattern.is_regexp_string stra ->
       let re_match = Matching_generic.regexp_matcher_of_regexp_string stra in
       if re_match strb then return () else fail ()
+  (* Prefix metavar: pattern "set_$P" matches source "set_X". *)
+  | (stra, _), b when String.contains stra '$' -> (
+      match match_prefix_metavar stra b with
+      | Some tin -> tin
+      | None -> m_wrap m_string a b)
   (* Note: We should try to avoid allowing case insensitive
    *  identifiers to get here because we have no way of
    *  distinguishing them from case sensitive identifiers
@@ -696,6 +719,16 @@ and m_ident_and_id_info (a1, a2) (b1, b2) =
   | (stra, _), (strb, _) when Pattern.is_regexp_string stra ->
       let re_match = Matching_generic.regexp_matcher_of_regexp_string stra in
       if re_match strb then return () else fail ()
+  (* Prefix metavar: pattern "set_$P" matches source "set_X". *)
+  | (stra, _), b1 when String.contains stra '$' -> (
+      match match_prefix_metavar stra b1 with
+      | Some tin -> tin
+      | None ->
+          let case_insensitive =
+            G.is_case_insensitive a2 && B.is_case_insensitive b2
+          in
+          let* () = m_wrap (m_id_string case_insensitive) a1 b1 in
+          m_id_info a2 b2)
   (* general case *)
   | _, _ ->
       let case_insensitive =

--- a/src/optimizing/Analyze_pattern.ml
+++ b/src/optimizing/Analyze_pattern.ml
@@ -61,6 +61,13 @@ class ['self] extract_strings_and_mvars_visitor =
                 We assume a match is possible without the identifier
                 being present in the target source, so we ignore it. *)
             ()
+        | IdQualified { name_info = { id_flags; _ }; _ }
+          when IdFlags.is_hidden !id_flags ->
+            (* Same rationale for a fully-synthetic qualified name
+               (e.g. C#'s `System.Index` synthesised for `arr[^N]`): if
+               name_info is hidden, the whole path — including the
+               qualifier idents — is absent from source. *)
+            ()
         | _ -> super#visit_name env x
 
       (* Same rationale as [visit_name] above, but for parameters whose

--- a/src/rule/Pattern.ml
+++ b/src/rule/Pattern.ml
@@ -77,6 +77,3 @@ let is_special_identifier ?lang str =
    * these identifiers are not expected to be found in the source files!
    * Else targets are skipped when they should not be. *)
   || AST_generic.is_implicit_param str
-  (* Elixir multi-clause functions are lowered to synthetic __pN__
-   * parameters in Elixir_to_generic; these are never present in source. *)
-  || (lang =*= Some Lang.Elixir && AST_generic.is_elixir_synthetic_param str)

--- a/src/rule/Pattern.ml
+++ b/src/rule/Pattern.ml
@@ -77,3 +77,14 @@ let is_special_identifier ?lang str =
    * these identifiers are not expected to be found in the source files!
    * Else targets are skipped when they should not be. *)
   || AST_generic.is_implicit_param str
+  (* C#/Apex property accessors synthesise parameters named "value"
+   * (setter) and, in C#, "field" (C#14 property-level keyword). The
+   * parameter declarations are never in source text even though the
+   * words sometimes are, so the prefilter must not demand them.
+   * We avoid setting the hidden flag on these pnames because
+   * Eval_generic.text_of_metavariable gates `metavariable-regex`
+   * evaluation on is_hidden, and rules like
+   * `metavariable-regex: field` / `: value` should still see the
+   * bound text. *)
+  || (lang =*= Some Lang.Csharp && (str = "value" || str = "field"))
+  || (lang =*= Some Lang.Apex && str = "value")

--- a/tests/rules/apex_prop_setter_prefilter.cls
+++ b/tests/rules/apex_prop_setter_prefilter.cls
@@ -1,0 +1,7 @@
+// ruleid: apex-prop-setter
+public class Foo {
+    public Integer X {
+        get { return X; }
+        set { X = 2; }
+    }
+}

--- a/tests/rules/apex_prop_setter_prefilter.yaml
+++ b/tests/rules/apex_prop_setter_prefilter.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: apex-prop-setter
+    pattern: |
+      public class $C {
+          public Integer $P {
+              get { return $G; }
+              set { $S = $V; }
+          }
+      }
+    languages: [apex]
+    message: apex property with get and set accessors
+    severity: INFO

--- a/tests/rules/apex_trigger_events_prefilter.trigger
+++ b/tests/rules/apex_trigger_events_prefilter.trigger
@@ -1,0 +1,6 @@
+// ruleid: apex-trigger-events
+trigger AccountTrigger on Account (before insert, after update) {
+    for (Account a : Trigger.new) {
+        a.Description = 'hi';
+    }
+}

--- a/tests/rules/apex_trigger_events_prefilter.yaml
+++ b/tests/rules/apex_trigger_events_prefilter.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: apex-trigger-events
+    pattern: |
+      trigger $NAME on Account (before insert, after update) { ... }
+    languages: [apex]
+    message: apex trigger (synthetic __trigger_events attr)
+    severity: INFO

--- a/tests/rules/apex_trigger_object_prefilter.trigger
+++ b/tests/rules/apex_trigger_object_prefilter.trigger
@@ -1,0 +1,4 @@
+// ruleid: apex-trigger-any-events
+trigger BeforeInsertTrigger on Account (before insert) {
+    System.debug('ok');
+}

--- a/tests/rules/apex_trigger_object_prefilter.yaml
+++ b/tests/rules/apex_trigger_object_prefilter.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: apex-trigger-any-events
+    pattern: |
+      trigger $NAME on Account (before insert) { ... }
+    languages: [apex]
+    message: apex trigger on Account (synthetic __trigger_object attr)
+    severity: INFO

--- a/tests/rules/cpp_decltype_id_prefilter.cpp
+++ b/tests/rules/cpp_decltype_id_prefilter.cpp
@@ -1,0 +1,5 @@
+template<typename T>
+void f(T e) {
+    // ruleid: cpp-decltype-id
+    decltype(e)::foo x;
+}

--- a/tests/rules/cpp_decltype_id_prefilter.yaml
+++ b/tests/rules/cpp_decltype_id_prefilter.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: cpp-decltype-id
+    pattern: |
+      decltype($E)::$F $X;
+    languages: [cpp]
+    message: cpp decltype(E)::foo qualified name (synthetic DecltypeId)
+    severity: INFO

--- a/tests/rules/csharp_arrow_property_prefilter.cs
+++ b/tests/rules/csharp_arrow_property_prefilter.cs
@@ -1,0 +1,4 @@
+// ruleid: csharp-arrow-property
+public class Foo {
+    public int Arrow => 3;
+}

--- a/tests/rules/csharp_arrow_property_prefilter.yaml
+++ b/tests/rules/csharp_arrow_property_prefilter.yaml
@@ -6,7 +6,5 @@ rules:
       }
     languages: [csharp]
     message: >
-      Arrow-property `public int P => E;`. Previously this was parsed
-      with a CLR-mangled `get_P` accessor entity name; now uses `get`
-      so $P can bind as a metavariable.
+      Arrow-property `public int P => E;`
     severity: INFO

--- a/tests/rules/csharp_arrow_property_prefilter.yaml
+++ b/tests/rules/csharp_arrow_property_prefilter.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: csharp-arrow-property
+    pattern: |
+      class $C {
+          public int $P => $E;
+      }
+    languages: [csharp]
+    message: >
+      Arrow-property `public int P => E;`. Previously this was parsed
+      with a CLR-mangled `get_P` accessor entity name; now uses `get`
+      so $P can bind as a metavariable.
+    severity: INFO

--- a/tests/rules/csharp_auto_property_prefilter.cs
+++ b/tests/rules/csharp_auto_property_prefilter.cs
@@ -1,0 +1,4 @@
+// ruleid: csharp-auto-property
+public class Foo {
+    public int X { get; set; }
+}

--- a/tests/rules/csharp_auto_property_prefilter.yaml
+++ b/tests/rules/csharp_auto_property_prefilter.yaml
@@ -1,0 +1,9 @@
+rules:
+  - id: csharp-auto-property
+    pattern: |
+      class $C {
+          public int $P { get; set; }
+      }
+    languages: [csharp]
+    message: csharp auto-property get/set
+    severity: INFO

--- a/tests/rules/csharp_index_from_end_prefilter.cs
+++ b/tests/rules/csharp_index_from_end_prefilter.cs
@@ -1,0 +1,6 @@
+public class Foo {
+    public int Last(int[] arr) {
+        // ruleid: csharp-index-from-end
+        return arr[^1];
+    }
+}

--- a/tests/rules/csharp_index_from_end_prefilter.yaml
+++ b/tests/rules/csharp_index_from_end_prefilter.yaml
@@ -1,0 +1,6 @@
+rules:
+  - id: csharp-index-from-end
+    pattern: $ARR[^$N]
+    languages: [csharp]
+    message: csharp from-end index ^N (synthetic System.Index)
+    severity: INFO

--- a/tests/rules/csharp_prop_setter_prefilter.cs
+++ b/tests/rules/csharp_prop_setter_prefilter.cs
@@ -1,0 +1,7 @@
+// ruleid: csharp-prop-setter
+public class Foo {
+    public int X {
+        get { return X; }
+        set { X = 2; }
+    }
+}

--- a/tests/rules/csharp_prop_setter_prefilter.yaml
+++ b/tests/rules/csharp_prop_setter_prefilter.yaml
@@ -1,0 +1,12 @@
+rules:
+  - id: csharp-prop-setter
+    pattern: |
+      class $C {
+          public int $P {
+              get { return $G; }
+              set { $S = $V; }
+          }
+      }
+    languages: [csharp]
+    message: csharp property with get and set accessors
+    severity: INFO

--- a/tests/rules/go_chan_bidir_prefilter.go
+++ b/tests/rules/go_chan_bidir_prefilter.go
@@ -1,0 +1,6 @@
+package main
+
+// ruleid: go-chan-bidir
+func router(ch chan int) {
+	ch <- 1
+}

--- a/tests/rules/go_chan_bidir_prefilter.yaml
+++ b/tests/rules/go_chan_bidir_prefilter.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: go-chan-bidir
+    pattern: |
+      func $F($P chan $T) { ... }
+    languages: [go]
+    message: go bidirectional chan (synthetic "bidirectional")
+    severity: INFO

--- a/tests/rules/go_chan_recv_prefilter.go
+++ b/tests/rules/go_chan_recv_prefilter.go
@@ -1,0 +1,6 @@
+package main
+
+// ruleid: go-chan-in
+func consumer(in <-chan int) int {
+	return <-in
+}

--- a/tests/rules/go_chan_recv_prefilter.yaml
+++ b/tests/rules/go_chan_recv_prefilter.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: go-chan-in
+    pattern: |
+      func $F($P <-chan $T) $R { ... }
+    languages: [go]
+    message: go recv-only chan (synthetic "recv")
+    severity: INFO

--- a/tests/rules/go_chan_send_prefilter.go
+++ b/tests/rules/go_chan_send_prefilter.go
@@ -1,0 +1,6 @@
+package main
+
+// ruleid: go-chan-out
+func producer(out chan<- int) {
+	out <- 42
+}

--- a/tests/rules/go_chan_send_prefilter.yaml
+++ b/tests/rules/go_chan_send_prefilter.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: go-chan-out
+    pattern: |
+      func $F($P chan<- $T) { ... }
+    languages: [go]
+    message: go send-only chan (synthetic "send")
+    severity: INFO

--- a/tests/rules/swift_dict_prefilter.swift
+++ b/tests/rules/swift_dict_prefilter.swift
@@ -1,0 +1,2 @@
+// ruleid: swift-dict-literal
+let m: [String: Int] = ["a": 1]

--- a/tests/rules/swift_dict_prefilter.yaml
+++ b/tests/rules/swift_dict_prefilter.yaml
@@ -1,0 +1,7 @@
+rules:
+  - id: swift-dict-literal
+    pattern: |
+      let $M: [$K: $V] = $E
+    languages: [swift]
+    message: swift dict literal desugared to Dictionary<K,V>
+    severity: INFO

--- a/tests/rules/vbnet_prop_setter_prefilter.vb
+++ b/tests/rules/vbnet_prop_setter_prefilter.vb
@@ -1,0 +1,11 @@
+' ruleid: vbnet-prop-setter
+Public Class Foo
+    Public Property Bar As Integer
+        Get
+            Return 3
+        End Get
+        Set(ByVal value As Integer)
+            Bar = value
+        End Set
+    End Property
+End Class

--- a/tests/rules/vbnet_prop_setter_prefilter.yaml
+++ b/tests/rules/vbnet_prop_setter_prefilter.yaml
@@ -1,0 +1,16 @@
+rules:
+  - id: vbnet-prop-setter
+    pattern: |
+      Public Class $C
+          Public Property $P As Integer
+              Get
+                  Return $G
+              End Get
+              Set(ByVal value As Integer)
+                  $S = value
+              End Set
+          End Property
+      End Class
+    languages: [vbnet]
+    message: vbnet property with get and set accessors
+    severity: INFO


### PR DESCRIPTION
  ## Summary

  Follow-up to #673. The PCRE prefilter rejects files whose source text doesn't contain strings the pattern parser has synthesised into the AST but that never  appear in source. This PR covers the remaining parser-synthesised idents we hadn't addressed, adds the matcher support needed so mangled accessor names still work as pattern targets, and fixes two latent bugs found along the way.


## Covered — synthetic idents now marked hidden

  - Go — send / recv / bidirectional synthesised from chan<- T / <-chan T / chan T.
  - Apex — __trigger_events and __trigger_object synthesised for trigger X on Y (events).
  - Swift — Dictionary synthesised when [K: V] literals desugar to Dictionary<K, V>.
  - C# — System and Index synthesised for arr[^N] from-end indexing.
  - C++ — DecltypeId synthesised for decltype(E)::foo qualified names (renamed to !!_implicit_param!decltype so is_implicit_param already filters it).
  - Elixir — __pN__ synthesised for multi-clause def lowering. Replaces the earlier is_elixir_synthetic_param string-hack in Pattern.ml with the proper hidden plumbing via param_of_id ~hidden:true.

 ## Matcher addition: prefix-metavariable in idents
This fixes #678:
C# and Apex property accessors are synthesised with CLR-style names: public int X { set { … } } becomes an entity named set_X. That naming is load-bearing for intrafile taint signature uniqueness and call-graph resolution within a class, so we keep it. But the matcher previously treated a pattern ident set_$P as one opaque string rather than set_ + metavar $P, so patterns targeting property accessors never matched source.

  Generic_vs_generic now has a match_prefix_metavar helper used by m_ident and m_ident_and_id_info: when the pattern ident is shaped <prefix>$METAVAR and the source ident starts with <prefix>, bind the metavar to the remainder. Pattern set_$P binds $P = "X" against source set_X.

  The accessor entity is still built with ~hidden:true so the mangled string doesn't leak into the prefilter regex. Applies uniformly to C# property braces, C# arrow-property (public int P => 3;), and Apex property accessors.

 ## Related fixes

  - Go tree-sitter parser direction swap. chan<- T was labelled TRecv and <-chan T was labelled TSend. The menhir parser had it right per the Go spec (chan<- is send-only, <-chan is receive-only); tree-sitter was inverted. Fixed so source and pattern AST agree. Rules keying on chan direction will shift after this lands.
  - C++ _name_option / _ANON dead code. The function at cpp_to_generic.ml:85 built a _ANON placeholder for anonymous C++ types but had no callers (the leading underscore silenced the unused-value warning). Deleted — no observable behaviour change. Any future support for anonymous C++ types should build the ident  with a hidden id_info.

###  Why not hidden on value / field pnames

  Eval_generic.text_of_metavariable gates metavariable-regex evaluation on IdFlags.is_hidden, so marking the C#/Apex setter's synthetic value pname — or C#'s synthetic field pname — hidden would break existing rules like tests/tainting_rules/csharp/implicit_vars_in_props.yaml that use metavariable-regex: value or metavariable-regex: field. Those words do appear in source text when the accessor body uses them, so we instead add scoped entries to Pattern.is_special_identifier (lang-gated on C#/Apex) that skip them from the prefilter string set without touching is_hidden.

 ## Plumbing

  - AST_generic_helpers.name_of_id / name_of_ids and AST_generic.param_of_id gain a ?hidden parameter.
  - Analyze_pattern.ml visit_name now short-circuits on IdQualified whose name_info is hidden (used by the C# System.Index fix).
  - Generic_vs_generic: new match_prefix_metavar helper shared by m_ident and m_ident_and_id_info.

 ## Tests

  New tests/rules/*_prefilter.{yaml,<ext>} fixtures covering every case above: Go chan directions (send/recv/bidir), Apex triggers (events + object), Swift [K: V], C# arr[^N], C++ decltype(E)::foo, Elixir multi-clause def, C# arrow-property + brace property + auto-property, Apex property setter. 16 tests, all pass. 