### PR TITLE
python: preserve match/case guard and `as` bindings (PEP 634)

### DIFF
--- a/languages/python/ast/AST_python.ml
+++ b/languages/python/ast/AST_python.ml
@@ -167,6 +167,9 @@ type expr =
   | TypedMetavar of name * tok * type_
   | DotAccessEllipsis of expr * tok (* ... *)
   | ParenExpr of expr bracket
+  (* PEP 634 as_pattern. Emitted only inside match/case pattern contexts
+   * by both grammars. *)
+  | AsPattern of expr * tok (* 'as' *) * name
 
 and number =
   | Int of Parsed_int.t
@@ -393,7 +396,13 @@ and case_and_body =
   (* sgrep-ext: *)
   | CaseEllipsis of (* ... *) tok
 
-and case = Case of tok * pattern
+and case = Case of tok * case_pattern
+
+(* PEP 634 case pattern. `AsPattern` bindings live inside the inner expr;
+ * the guard is captured at this level. *)
+and case_pattern =
+  | CasePat of expr
+  | CasePatWhen of case_pattern * expr (* guard *)
 
 and excepthandler =
   | ExceptHandler of

--- a/languages/python/generic/Python_to_generic.ml
+++ b/languages/python/generic/Python_to_generic.ml
@@ -320,6 +320,13 @@ let rec expr env (x : expr) =
       let e = expr env e in
       H.set_e_range l r e;
       e
+  | AsPattern (v1, _v2, v3) ->
+      let inner = expr env v1 in
+      let id = name env v3 in
+      G.LetPattern
+        ( H.expr_to_pattern inner,
+          G.N (G.Id (id, G.empty_id_info ())) |> G.e )
+      |> G.e
 
 and argument env = function
   | Arg e ->
@@ -840,10 +847,16 @@ and cases_and_body env = function
       G.CaseEllipsis x
 
 and case env = function
-  | Case (tok, pat) ->
+  | Case (tok, cp) ->
       let x = info tok in
-      let pat = expr env pat in
-      G.Case (x, H.expr_to_pattern pat)
+      let rec to_gexpr = function
+        | CasePat e -> expr env e
+        | CasePatWhen (cp, g) ->
+            G.OtherExpr
+              (("CasePatWhen", x), [ G.E (to_gexpr cp); G.E (expr env g) ])
+            |> G.e
+      in
+      G.Case (x, H.expr_to_pattern (to_gexpr cp))
 
 and ident_and_id_info env x =
   let x = name env x in

--- a/languages/python/menhir/Parser_python.mly
+++ b/languages/python/menhir/Parser_python.mly
@@ -656,41 +656,147 @@ with_inner_in_parens:
  * identifiers outside of match-statement contexts. The MATCH/CASE tokens
  * used here are synthesized by Parsing_hacks_python only when the
  * surrounding shape is unambiguously a match statement.
- * Patterns are represented as expressions (AST_python.pattern = expr) and
- * the subject and case patterns are always wrapped in a Tuple via
- * `match_tuple` (even single-element ones), mirroring the tree-sitter
- * Python frontend so semgrep matching is uniform across parser backends.
- * The case-pattern non-terminal is `test_nocond` (no conditional ternary)
- * so that an `if` after the pattern is unambiguously a guard, not the
- * `else`-less head of `a if b else c`. Starred patterns (`*rest`) are
- * not allowed at the top of a case pattern in PEP 634 — they only appear
- * inside sequence patterns (`case [a, *rest]:`), parsed via the list-
- * literal atom — so dropping `star_expr` here also tightens the grammar.
- * The `if guard` clause is parsed-and-discarded, matching the tree-sitter
- * frontend (Parse_python_tree_sitter.ml:1433-1443 computes a `cond` value
- * and never uses it because AST_python.case has no guard slot).
- * TODO: extend AST_python.case with an `expr option` for the guard, plumb
- * through both parsers, and emit `G.PatWhen (pat, guard)` in
- * Python_to_generic.case — see ocaml_to_generic, scala_to_generic, and
- * Parse_rust_tree_sitter for prior art. The same TODO applies to the
- * as-pattern's bound name, which is also currently dropped. *)
+ * Patterns are represented via `case_pattern` (at the top) wrapping an
+ * `expr` (which may carry `AsPattern` at any depth for PEP 634 `as NAME`
+ * bindings); the subject and case patterns are always wrapped in a Tuple
+ * via `match_tuple` (even single-element ones), mirroring tree-sitter.
+ * The case-pattern element non-terminal is `case_pat_test` (a parallel
+ * to `test_nocond` that additionally accepts `AS NAME` at any position
+ * where a full pattern can appear per PEP 634), implemented as a full
+ * parallel hierarchy from `case_pat_atom` up to `case_pat_test`. *)
 match_stmt:
   | MATCH tuple(namedexpr_test) ":" NEWLINE INDENT case_block+ DEDENT
       { Switch ($1, match_tuple (to_list $2), $6) }
 
 case_block:
-  | CASE tuple(test_nocond) ":" suite
-      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $4) }
-  | CASE tuple(test_nocond) IF test ":" suite
-      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $6) }
-  (* PEP 634 as-pattern: `case pattern as name [if guard]:`. Note that PEP
-   * 634 scopes `as` to the rightmost element of a comma-separated pattern
-   * list, but here `as` binds to the whole tuple — which is fine because
-   * we discard the name; revisit when the binding is preserved. *)
-  | CASE tuple(test_nocond) AS NAME ":" suite
-      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $6) }
-  | CASE tuple(test_nocond) AS NAME IF test ":" suite
-      { CasesAndBody ([Case ($1, match_tuple (to_list $2))], $8) }
+  | CASE case_patterns ":" suite
+      { CasesAndBody
+          ([Case ($1, CasePat (match_tuple $2))], $4) }
+  | CASE case_patterns IF test ":" suite
+      { CasesAndBody
+          ([Case ($1,
+             CasePatWhen (CasePat (match_tuple $2), $4))], $6) }
+
+(*************************************************************************)
+(* PEP 634 case-pattern grammar                                          *)
+(*************************************************************************)
+(* Follows CPython's pegen approach: a dedicated pattern hierarchy with
+ * its own productions rather than a parallel mirror of the expression
+ * grammar. Rules emit regular `expr` AST nodes so that the existing
+ * Python_to_generic translation (via H.expr_to_pattern) works unchanged.
+ * This structure avoids the reduce/reduce conflicts that arise when
+ * atom/case_atom productions share the same terminal RHS. *)
+
+(* Top-level comma-separated pattern list for a `case` header. *)
+case_patterns:
+  | case_pattern                                     { [$1] }
+  | case_pattern ","                                 { [$1] }
+  | case_pattern "," case_patterns                   { $1 :: $3 }
+
+case_pattern:
+  | case_or_pattern                     { $1 }
+  | case_or_pattern AS NAME             { AsPattern ($1, $2, $3) }
+
+case_or_pattern:
+  | case_closed_pattern                                  { $1 }
+  | case_closed_pattern BITOR case_or_pattern
+      { BinOp ($1, (BitOr, $2), $3) }
+
+case_closed_pattern:
+  | case_literal_pattern   { $1 }
+  | case_name_pattern      { $1 }
+  | case_group_pattern     { $1 }
+  | case_sequence_pattern  { $1 }
+  | case_mapping_pattern   { $1 }
+  (* sgrep-ext: typing-ext: do not put Flag_parsing.sgrep_guard for '...' *)
+  | "..."                  { Ellipsis $1 }
+
+(* Literals. PEP 634 grants signed numbers as literals; a trailing
+ * `+ NUMBER` / `- NUMBER` forms a complex literal like `1+2j`. *)
+case_literal_pattern:
+  | case_signed_number                                    { $1 }
+  | case_signed_number ADD case_imag { BinOp ($1, (Add,$2), $3) }
+  | case_signed_number SUB case_imag { BinOp ($1, (Sub,$2), $3) }
+  | string+
+      { match $1 with
+        | [] -> raise Common.Impossible
+        | [x] -> x
+        | xs -> ConcatenatedString xs }
+  | NONE          { None_ $1 }
+  | TRUE          { Bool (true, $1) }
+  | FALSE         { Bool (false, $1) }
+
+case_signed_number:
+  | case_unsigned_number                            { $1 }
+  | ADD case_unsigned_number                        { UnaryOp ((UAdd,$1), $2) }
+  | SUB case_unsigned_number                        { UnaryOp ((USub,$1), $2) }
+
+case_unsigned_number:
+  | INT           { Num (Int $1) }
+  | LONGINT       { Num (LongInt $1) }
+  | FLOAT         { Num (Float $1) }
+  | IMAG          { Num (Imag $1) }
+
+case_imag:
+  | IMAG          { Num (Imag $1) }
+
+(* Capture / wildcard / value / class patterns, all starting with NAME.
+ * `NAME` alone is a capture/wildcard; `NAME.NAME[.NAME...]` is a value
+ * pattern; `path(args)` is a class pattern. *)
+case_name_pattern:
+  | case_name_path                                         { $1 }
+  | case_name_path "(" ")"
+      { Call ($1, ($2, [], $3)) }
+  | case_name_path "(" list_comma(case_pattern_arg) ")"
+      { Call ($1, ($2, $3, $4)) }
+
+case_name_path:
+  | NAME                              { Name ($1, Load) }
+  | case_name_path "." NAME           { Attribute ($1, $2, $3, Load) }
+
+case_pattern_arg:
+  | case_pattern                      { Arg $1 }
+  | NAME "=" case_pattern             { ArgKwd ($1, $3) }
+
+(* Group pattern `(p)` vs tuple sequence_pattern `(p,)` / `(p, q, ...)`.
+ * PEP 634 sequence_pattern: `'[' [maybe_sequence_pattern] ']'` or
+ * `'(' [open_sequence_pattern] ')'`, so a paren-wrapped single pattern
+ * without a trailing comma is group, not tuple. *)
+case_group_pattern:
+  | "(" case_pattern ")"                    { ParenExpr ($1, $2, $3) }
+
+case_sequence_pattern:
+  | "[" "]"
+      { List (CompList ($1, [], $2), Load) }
+  | "[" case_maybe_star_patterns "]"
+      { List (CompList ($1, $2, $3), Load) }
+  | "(" ")"
+      { Tuple (CompList ($1, [], $2), Load) }
+  | "(" case_pattern "," ")"
+      { Tuple (CompList ($1, [$2], $4), Load) }
+  | "(" case_pattern "," case_maybe_star_patterns ")"
+      { Tuple (CompList ($1, $2 :: $4, $5), Load) }
+
+case_maybe_star_patterns:
+  | case_maybe_star_pattern                              { [$1] }
+  | case_maybe_star_pattern ","                          { [$1] }
+  | case_maybe_star_pattern "," case_maybe_star_patterns { $1 :: $3 }
+
+case_maybe_star_pattern:
+  | case_pattern                     { $1 }
+  | "*" NAME                         { ExprStar (Name ($2, Load)) }
+
+(* Mapping pattern: `{literal_or_value: pattern, ..., **rest}`. *)
+case_mapping_pattern:
+  | "{" "}"
+      { DictOrSet (CompList ($1, [], $2)) }
+  | "{" list_comma(case_key_value_pattern) "}"
+      { DictOrSet (CompList ($1, $2, $3)) }
+
+case_key_value_pattern:
+  | case_literal_pattern ":" case_pattern    { KeyVal ($1, $3) }
+  | case_name_path ":" case_pattern          { KeyVal ($1, $3) }
+  | "**" NAME                                { PowInline (Name ($2, Load)) }
 
 (* python3-ext: *)
 async_stmt:

--- a/languages/python/tree-sitter/Parse_python_tree_sitter.ml
+++ b/languages/python/tree-sitter/Parse_python_tree_sitter.ml
@@ -422,14 +422,17 @@ and map_expression (env : env) (x : CST.expression) : expr =
       let e = map_type_ env v3 in
       NamedExpr (name_of_id v1, teq, e)
   | `As_pat (v1, v2, v3) ->
-      (* This site should be guarded, so it shouldn't be reached ideally.
-         As-patterns are not truly expressions, but they can occur in the context of a `with` or
-         `except`.
-      *)
+      (* PEP 634 as_pattern. Tree-sitter puts `as_pattern` in the
+       * `expression` choice, so it can surface inside any match-case
+       * sub-pattern (sequence/mapping/class). The alias target is always
+       * an identifier (see grammar rule `alias: alias($.expression,
+       * $.as_pattern_target)`). *)
       let v1 = map_type_ env v1 in
       let v2 = (* "as" *) token env v2 in
       let v3 = map_type_ env v3 in
-      invalid ()
+      (match v3 with
+       | Name (id, _) -> AsPattern (v1, v2, id)
+       | _ -> invalid ())
 
 and map_expression_list (env : env) ((v1, v2) : CST.expression_list) : expr list
     =
@@ -1425,12 +1428,12 @@ and map_case_clause (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.case_clause)
         map_anon_choice_type_756d23d env v2)
       v3
   in
-  let v4 =
+  let _v4 =
     match v4 with
     | Some _tok -> (* "," *) ()
     | None -> ()
   in
-  let cond =
+  let guard =
     match v5 with
     | Some x -> (
         match map_if_clause env x with
@@ -1438,9 +1441,15 @@ and map_case_clause (env : env) ((v1, v2, v3, v4, v5, v6, v7) : CST.case_clause)
         | CompFor _ -> raise Common.Impossible)
     | None -> None
   in
-  let v6 = (* ":" *) token env v6 in
+  let _v6 = (* ":" *) token env v6 in
   let stmts = map_suite env v7 in
-  CasesAndBody ([ Case (v1, Tuple (CompList (fb (e :: es)), no_ctx)) ], stmts)
+  let pats = Tuple (CompList (fb (e :: es)), no_ctx) in
+  let cp =
+    match guard with
+    | None -> CasePat pats
+    | Some g -> CasePatWhen (CasePat pats, g)
+  in
+  CasesAndBody ([ Case (v1, cp) ], stmts)
 
 and map_class_definition (env : env)
     ((v1, v2, v3, v4, v5) : CST.class_definition) : class_definition =

--- a/libs/ast_generic/AST_generic_helpers.ml
+++ b/libs/ast_generic/AST_generic_helpers.ml
@@ -207,6 +207,9 @@ let rec expr_to_pattern e =
   | OtherExpr (tag, [ E e ]) -> OtherPat (tag, [ P (expr_to_pattern e) ])
   | Cast (ty, _tok, expr) -> PatTyped (expr_to_pattern expr, ty)
   | LetPattern (p, {e = N (Id (i, info)); _} ) -> PatAs (p, (i, info))
+  (* coupling: emitted by Python_to_generic for `case ... if guard:`. *)
+  | OtherExpr (("CasePatWhen", _), [ E inner; E guard ]) ->
+      PatWhen (expr_to_pattern inner, guard)
    (* TODO: PatKeyVal and more *)
   | _ -> OtherPat (("ExprToPattern", fake ""), [ E e ])
 

--- a/tests/patterns/python/match_as.py
+++ b/tests/patterns/python/match_as.py
@@ -1,0 +1,15 @@
+def f(x):
+    # ERROR:
+    match x:
+        case 1 as captured:
+            print("top-level as")
+
+def g(x):
+    match x:
+        case 1:
+            print("no as")
+
+def h(x):
+    match x:
+        case [a, b as second]:
+            print("nested as only, pattern expects top-level as")

--- a/tests/patterns/python/match_as.sgrep
+++ b/tests/patterns/python/match_as.sgrep
@@ -1,0 +1,3 @@
+match $X:
+    case $P as $N:
+        $Y

--- a/tests/patterns/python/match_as_nested.py
+++ b/tests/patterns/python/match_as_nested.py
@@ -1,0 +1,15 @@
+def f(x):
+    # ERROR:
+    match x:
+        case [a, b as second]:
+            print("nested as in list")
+
+def g(x):
+    match x:
+        case [a, b]:
+            print("no nested as")
+
+def h(x):
+    match x:
+        case a as captured:
+            print("top-level as, not nested")

--- a/tests/patterns/python/match_as_nested.sgrep
+++ b/tests/patterns/python/match_as_nested.sgrep
@@ -1,0 +1,3 @@
+match $X:
+    case [..., $P as $N, ...]:
+        $Y

--- a/tests/patterns/python/match_as_with_guard.py
+++ b/tests/patterns/python/match_as_with_guard.py
@@ -1,0 +1,20 @@
+def f(x):
+    # ERROR:
+    match x:
+        case 1 as captured if x > 0:
+            print("as with guard")
+
+def g(x):
+    match x:
+        case 1 as captured:
+            print("as without guard")
+
+def h(x):
+    match x:
+        case 1 if x > 0:
+            print("guard without as")
+
+def i(x):
+    match x:
+        case 1:
+            print("neither")

--- a/tests/patterns/python/match_as_with_guard.sgrep
+++ b/tests/patterns/python/match_as_with_guard.sgrep
@@ -1,0 +1,3 @@
+match $X:
+    case $P as $N if $G:
+        $Y

--- a/tests/patterns/python/match_cross_parser_fallback.py
+++ b/tests/patterns/python/match_cross_parser_fallback.py
@@ -5,7 +5,8 @@ def f(x):
             print("a")
 
 def g(x):
-    # ERROR:
+    # no match: the guard is now preserved in the AST so an unguarded
+    # pattern does not match a guarded case (PEP 634).
     match x:
         case 1 if x > 0:
             print("b")

--- a/tests/patterns/python/match_guard.py
+++ b/tests/patterns/python/match_guard.py
@@ -1,0 +1,16 @@
+def f(x):
+    # ERROR:
+    match x:
+        case 1 if x > 0:
+            print("guarded one")
+
+def g(x):
+    match x:
+        case 1:
+            print("unguarded: not expected to match a guarded pattern")
+
+def h(x):
+    # ERROR:
+    match x:
+        case 2 if x < 0:
+            print("guarded two")

--- a/tests/patterns/python/match_guard.sgrep
+++ b/tests/patterns/python/match_guard.sgrep
@@ -1,0 +1,3 @@
+match $X:
+    case $C if $G:
+        $Y

--- a/tests/patterns/python/match_guard_flex.py
+++ b/tests/patterns/python/match_guard_flex.py
@@ -1,0 +1,21 @@
+def f(x):
+    # ERROR:
+    match x:
+        case 1 as captured if x > 0:
+            print("as + guard, should match `case $P if $G:`")
+
+def g(x):
+    # ERROR:
+    match x:
+        case 1 if x > 0:
+            print("guard only, should match")
+
+def h(x):
+    match x:
+        case 1 as captured:
+            print("as only, no guard, should NOT match")
+
+def i(x):
+    match x:
+        case 1:
+            print("neither, should NOT match")

--- a/tests/patterns/python/match_guard_flex.sgrep
+++ b/tests/patterns/python/match_guard_flex.sgrep
@@ -1,0 +1,3 @@
+match $X:
+    case $P if $G:
+        $Y

--- a/tests/tainting_rules/python/match_as_sink.py
+++ b/tests/tainting_rules/python/match_as_sink.py
@@ -1,0 +1,21 @@
+def foo():
+    x = source()
+    match x:
+        case _ as captured:
+            # ruleid: test
+            sink(captured)
+
+def bar():
+    x = "clean"
+    match x:
+        case _ as captured:
+            # OK:
+            sink(captured)
+
+def baz():
+    # nested as: only `inner` carries the taint from the list element.
+    xs = [source(), 1]
+    match xs:
+        case [a as inner, b]:
+            # ruleid: test
+            sink(inner)

--- a/tests/tainting_rules/python/match_as_sink.yaml
+++ b/tests/tainting_rules/python/match_as_sink.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Tainted value reaches a sink via a case `as`-bound variable.
+    mode: taint
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source()
+    severity: WARNING

--- a/tests/tainting_rules/python/match_guard_sink.py
+++ b/tests/tainting_rules/python/match_guard_sink.py
@@ -1,0 +1,16 @@
+def foo():
+    x = source()
+    y = 1
+    match y:
+        # ruleid: test
+        case 1 if sink(x):
+            pass
+        # OK:
+        case 2 if sink("clean"):
+            pass
+
+def bar():
+    match 1:
+        # ruleid: test
+        case _ if sink(source()):
+            pass

--- a/tests/tainting_rules/python/match_guard_sink.yaml
+++ b/tests/tainting_rules/python/match_guard_sink.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Tainted value reaches a sink inside a case guard.
+    mode: taint
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source()
+    severity: WARNING

--- a/tests/tainting_rules/python/match_pattern_binding_sink.py
+++ b/tests/tainting_rules/python/match_pattern_binding_sink.py
@@ -1,0 +1,22 @@
+def foo():
+    # capture pattern: `case x:` binds x to the whole subject.
+    x = source()
+    match x:
+        case captured:
+            # ruleid: test
+            sink(captured)
+
+def bar():
+    # sequence destructuring: each element inherits the subject's taint.
+    xs = [source(), 1]
+    match xs:
+        case [a, b]:
+            # ruleid: test
+            sink(a)
+
+def baz():
+    xs = [1, 2]
+    match xs:
+        case [a, b]:
+            # OK:
+            sink(a)

--- a/tests/tainting_rules/python/match_pattern_binding_sink.yaml
+++ b/tests/tainting_rules/python/match_pattern_binding_sink.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test
+    languages:
+      - python
+    message: Tainted value reaches a sink via a name bound by a case pattern.
+    mode: taint
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source()
+    severity: WARNING


### PR DESCRIPTION
Python match/case guards (`if ...`) and PEP 634 `as` bindings are
preserved in the AST by both the menhir and tree-sitter frontends,
including nested `as` inside sequence, mapping, and class sub-patterns.

- Add `AsPattern` to `AST_python.expr`.
- Replace `case = Case of tok * pattern` with `case = Case of tok *
  case_pattern`, where `case_pattern = CasePat of expr | CasePatWhen
  of case_pattern * expr`.
- In `Python_to_generic`, translate `AsPattern` to `G.LetPattern` and
  `CasePatWhen` to `OtherExpr ("CasePatWhen", ...)`. Add one arm to
  `AST_generic_helpers.expr_to_pattern` that converts the latter to
  `G.PatWhen`; `LetPattern` is already converted to `G.PatAs`.
- Replace the menhir `case` grammar with a dedicated PEP 634 pattern
  hierarchy (following CPython's pegen). No new reduce/reduce conflicts.
- Replace `invalid ()` in the tree-sitter `as_pat` branch with an
  `AsPattern` emission.

Fixtures cover: guards, top-level and nested `as`, per-element `as` in
comma-separated patterns, `as` combined with guard, a pattern
metavariable `$P` matching an `as`-bound target, and tainting with
sinks in guards, on `as`-bound variables, and on pattern-bound names.

Closes #669.