### PR TITLE
ci: set CLCACHE_DIR for nuitka clcache on windows

### DIFF
--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -8,6 +8,10 @@ env:
   CYGWIN: winsymlinks:native
   PYTHONUTF8: "1"
   NUITKA_CACHE_DIR: D:/_nuitka
+  # Nuitka's inline clcache reads CLCACHE_DIR from os.environ directly, not
+  # from the Scons env it builds; without this it falls back to ~/clcache
+  # and the GHA cache of NUITKA_CACHE_DIR never contains the object store.
+  CLCACHE_DIR: D:/_nuitka/clcache
 
 jobs:
 


### PR DESCRIPTION
## TL;DR : 10m less time in building the nuitka self-contained windows binary

This drops the time it takes to create the Windows self-contained executable from appox. 21m to 10m 30s.
In the logs: `Nuitka-Scons: Compiled 400 C files using clcache with 400 cache hits and 0 cache misses`.

## Details 
Nuitka's inline clcache reads `CLCACHE_DIR` directly from `os.environ` when its `Cache()` singleton is constructed — Nuitka's `setEnvironmentVariable` only updates the Scons `env.ENV`, so the Python process env stays empty and clcache silently falls back to `~/clcache`. That directory is outside `NUITKA_CACHE_DIR` and therefore outside the GHA cache, so every Windows binary build re-compiles all 395 C files from scratch despite a primary
cache-key hit.

Setting `CLCACHE_DIR` in the workflow env places it in `os.environ` before Nuitka runs, which both lets `setEnvironmentVariable` propagate the value and points clcache at `D:/_nuitka/clcache` (already inside the cached path).

Fixes #454.