### PR TITLE
Fix directory pruning inefficiency

### DIFF
--- a/cli/src/semgrep/target_manager.py
+++ b/cli/src/semgrep/target_manager.py
@@ -839,7 +839,20 @@ class TargetManager:
 
             if target.git_tracked_only:
                 try:
-                    result |= target.files_from_git_ls()
+                    git_files = target.files_from_git_ls()
+                    # `files_from_git_ls` ignores the caller's
+                    # `--exclude`/`--semgrepignore` patterns, so when
+                    # they're present we intersect with the
+                    # dir-pruned filesystem walk. That walker never
+                    # descends into excluded directories (so a huge
+                    # `.m2` exclude costs almost nothing), and the
+                    # intersection restores the git-tracked semantics.
+                    if preprocessed or file_ignore is not None:
+                        pruned = target.files_from_filesystem_with_dir_pruning(
+                            preprocessed, file_ignore
+                        )
+                        git_files = git_files & pruned
+                    result |= git_files
                     continue
                 except (subprocess.CalledProcessError, FileNotFoundError):
                     logger.verbose(


### PR DESCRIPTION
Closes #528. Finishes the directory-pruning work started in #596.

PR #596 added `files_from_filesystem_with_dir_pruning`, but `TargetManager.get_all_files_with_dir_pruning` only uses it on the filesystem-fallback path. The git-tracked path (taken by default in any git repo) calls `files_from_git_ls` directly, which includes untracked-but-not-gitignored files via `git ls-files --others --exclude-standard` and never consults the `--exclude` patterns. So in a git repo, `--exclude ".m2"` is silently dropped and the whole subtree flows downstream; every later Python filtering pass then re-walks it.

Fix: when the git path is taken and the caller has excludes (or a `FileIgnore`), also run the dir-pruning walker and intersect. The walker never descends into `.m2`, so its set is tiny; intersecting with the git set preserves the tracked-only semantics.

Benchmark (`benchmark.sh` from #528, 1 Kotlin file next to 250 k
  `.m2` files, `scan --config=p/default --exclude ".m2" .`):
  - 1.16.3 (post-#596, pre-this): 82 s
  - this PR: 16 s
  - `--experimental`: 12 s
