### PR TITLE
signatures fixed point for mutually recursive functions

### DIFF
--- a/src/call_graph/Graph_fixpoint.ml
+++ b/src/call_graph/Graph_fixpoint.ml
@@ -1,0 +1,82 @@
+module type LATTICE = sig
+  type t
+
+  val equal : t -> t -> bool
+end
+
+module type GRAPH = sig
+  type t
+
+  module V : sig
+    type t
+
+    val compare : t -> t -> int
+    val equal : t -> t -> bool
+    val hash : t -> int
+  end
+
+  val mem_edge : t -> V.t -> V.t -> bool
+end
+
+module type STORE = sig
+  type t
+  type node
+  type lattice
+
+  val get : node -> t -> lattice
+  val set : node -> lattice -> t -> t
+end
+
+module Make
+    (G : GRAPH)
+    (L : LATTICE)
+    (S : STORE with type node = G.V.t and type lattice = L.t) =
+struct
+  type analyze = G.V.t -> S.t -> S.t
+
+  let run_singleton ~graph ~(analyze : analyze) ~max_iter
+      ~(on_max_iter : G.V.t list -> unit) (v : G.V.t) (store : S.t) : S.t =
+    if not (G.mem_edge graph v v) then analyze v store
+    else
+      let rec loop store iter =
+        if iter >= max_iter then (
+          on_max_iter [ v ];
+          store)
+        else
+          let before = S.get v store in
+          let store' = analyze v store in
+          let after = S.get v store' in
+          if L.equal before after then store' else loop store' (iter + 1)
+      in
+      loop store 0
+
+  let run_scc ~max_iter ~(on_max_iter : G.V.t list -> unit)
+      ~(analyze : analyze) (members : G.V.t list) (store : S.t) : S.t =
+    let rec loop store iter =
+      if iter >= max_iter then (
+        on_max_iter members;
+        store)
+      else
+        let snapshot = List.map (fun v -> (v, S.get v store)) members in
+        let store' =
+          List.fold_left (fun s v -> analyze v s) store members
+        in
+        let stable =
+          List.for_all
+            (fun (v, prev) -> L.equal prev (S.get v store'))
+            snapshot
+        in
+        if stable then store' else loop store' (iter + 1)
+    in
+    loop store 0
+
+  let run ?(max_iter = 20) ?(on_max_iter = fun _ -> ()) ~sccs ~graph ~analyze
+      (store : S.t) : S.t =
+    List.fold_left
+      (fun store scc ->
+        match scc with
+        | [] -> store
+        | [ v ] -> run_singleton ~graph ~analyze ~max_iter ~on_max_iter v store
+        | members -> run_scc ~max_iter ~on_max_iter ~analyze members store)
+      store sccs
+end

--- a/src/call_graph/Graph_fixpoint.mli
+++ b/src/call_graph/Graph_fixpoint.mli
@@ -1,0 +1,78 @@
+(** Generic SCC-aware fixed-point engine over a directed graph.
+
+    Iterates a per-node analysis to a fixed point on a user-supplied
+    lattice, one SCC at a time. Singleton SCCs without a self-loop run the
+    analysis exactly once -- preserving the behaviour of a plain
+    topological fold. SCCs with cycles iterate until a snapshot of every
+    member's lattice element compares equal across two consecutive rounds.
+
+    The engine is graph- and domain-agnostic: it knows nothing about
+    function signatures, taint, or files, and it does not interpret edge
+    direction. The caller passes the SCCs in the desired processing order
+    -- typically arranged so that nodes whose summaries are consumed by
+    other nodes are processed first. *)
+
+module type LATTICE = sig
+  type t
+
+  val equal : t -> t -> bool
+  (** Equality on the lattice. Used as the fixed-point termination test. *)
+end
+
+module type GRAPH = sig
+  type t
+
+  module V : sig
+    type t
+
+    val compare : t -> t -> int
+    val equal : t -> t -> bool
+    val hash : t -> int
+  end
+
+  val mem_edge : t -> V.t -> V.t -> bool
+end
+
+module type STORE = sig
+  type t
+  type node
+  type lattice
+
+  val get : node -> t -> lattice
+  val set : node -> lattice -> t -> t
+end
+
+module Make
+    (G : GRAPH)
+    (L : LATTICE)
+    (S : STORE with type node = G.V.t and type lattice = L.t) : sig
+  type analyze = G.V.t -> S.t -> S.t
+  (** Per-node analysis. Reads the current store, returns an updated store.
+      Must be monotone with respect to [L] for guaranteed termination. Must
+      not produce side effects observable outside the store -- in
+      particular, must not emit matches/findings during fixpoint
+      iteration. *)
+
+  val run :
+    ?max_iter:int ->
+    ?on_max_iter:(G.V.t list -> unit) ->
+    sccs:G.V.t list list ->
+    graph:G.t ->
+    analyze:analyze ->
+    S.t ->
+    S.t
+  (** [run ~sccs ~graph ~analyze store] processes [sccs] in the given list
+      order and returns the final store. The caller is responsible for
+      arranging [sccs] so that any SCC whose nodes are consumed by another
+      SCC's analysis appears first.
+
+      Per SCC: a singleton without a self-loop runs [analyze] once. A
+      cycle (multi-element SCC, or singleton with a self-loop) iterates
+      [analyze] over every member, comparing each member's lattice element
+      before and after via [L.equal], until no member changes -- or until
+      [max_iter] rounds elapse, in which case [on_max_iter] is invoked
+      with the SCC's members and the current store is returned for that
+      SCC.
+
+      [max_iter] defaults to 20. [on_max_iter] defaults to [ignore]. *)
+end

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -604,21 +604,6 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
           Call_graph.Dot.output_graph dot_file relevant_graph;
           close_out dot_file;
           Log.debug (fun m -> m "SUBGRAPH: Wrote call graph to call_graph.dot"); *)
-          let analysis_order =
-            Call_graph.Topo.fold
-              (fun fn acc -> fn :: acc)
-              relevant_graph []
-            |> List.rev
-          in
-          Log.debug (fun m ->
-              m "TAINT_TOPO: Analysis order has %d functions"
-                (List.length analysis_order));
-          List.iteri
-            (fun i node ->
-              Log.debug (fun m ->
-                  m "TAINT_TOPO: [%d] %s" i (Function_id.show node)))
-            analysis_order;
-
           let run_check_fundef_if_needed (info : fun_info)
               (updated_db : Shape_and_sig.signature_database) :
               Shape_and_sig.signature_database =
@@ -666,13 +651,30 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
             updated_db
           in
 
-          let process_fun_info info db =
+          (* Phase 1 body: extract a function's signature(s).
+
+             Returns the [signature_database] threaded through the
+             extraction calls (so other functions' newly-added sigs are
+             observable) AND the list of [extended_sig]s freshly produced
+             for THIS function in this call. The caller uses the latter to
+             replace the function's entry in the DB so that signatures from
+             previous fixpoint iterations don't accumulate alongside the
+             current iteration's signatures.
+
+             No match emission here -- that is phase 2. *)
+          let extract_signatures_for_fun_info info db :
+              Shape_and_sig.signature_database
+              * Shape_and_sig.extended_sig list =
+            let to_extended_sig (s, arity) : Shape_and_sig.extended_sig =
+              { sig_ = s; arity }
+            in
             match extract_multi_arity_cases info.fdef with
             | Some arity_cases ->
                 (* Multi-arity function: extract one signature per arity branch *)
-                let updated_db =
+                let db', fresh =
                   List.fold_left
-                    (fun acc_db (case_params, case_body, arity) ->
+                    (fun (acc_db, fresh)
+                         (case_params, case_body, arity) ->
                       let synthetic_fdef : G.function_definition =
                         {
                           G.fparams = Tok.unsafe_fake_bracket case_params;
@@ -685,86 +687,155 @@ let check_rule per_file_formula_cache (rule : R.taint_rule) match_hook
                         AST_to_IL.function_definition lang synthetic_fdef
                       in
                       let cfg = CFG_build.cfg_of_fdef fdef_il in
-                      let db', _sig =
+                      let db', sig_ =
                         Taint_signature_extractor
                         .extract_signature_with_file_context ~arity ~db:acc_db
                           ?builtin_signature_db taint_inst ~name:info.name
                           ~method_properties:info.method_properties
                           ~call_graph:(Some relevant_graph) cfg ast
                       in
-                      db')
-                    db arity_cases
+                      (db', to_extended_sig (sig_, arity) :: fresh))
+                    (db, []) arity_cases
                 in
-                run_check_fundef_if_needed info updated_db
+                (db', List.rev fresh)
             | None ->
                 (* Single-arity path (unchanged logic) *)
                 let params = Tok.unbracket info.fdef.fparams in
                 let arity = get_arity params info lang in
-                let updated_db, _signature =
+                let arity_t = Shape_and_sig.Arity_exact arity in
+                let db', sig_ =
                   Taint_signature_extractor.extract_signature_with_file_context
-                    ~arity:(Shape_and_sig.Arity_exact arity) ~db
-                    ?builtin_signature_db taint_inst ~name:info.name
+                    ~arity:arity_t ~db ?builtin_signature_db taint_inst
+                    ~name:info.name
                     ~method_properties:info.method_properties
                     ~call_graph:(Some relevant_graph) info.cfg ast
                 in
+                let fresh = [ to_extended_sig (sig_, arity_t) ] in
                 (* For Kotlin, if the last parameter is a lambda (function type),
-                 * also extract signature with arity-1 to handle trailing lambda syntax:
-                 * f(a, b) vs f(a) { b } *)
-                let updated_db =
-                  if Lang.equal lang Lang.Kotlin && arity >= 1 then
-                    let last_param_is_lambda =
-                      match List.rev params with
-                      | G.Param { G.ptype = Some { t = G.TyFun _; _ }; _ } :: _
-                        ->
-                          true
-                      | _ -> false
+                 * also extract signature with arity-1 to handle trailing lambda
+                 * syntax: f(a, b) vs f(a) { b } *)
+                if Lang.equal lang Lang.Kotlin && arity >= 1 then
+                  let last_param_is_lambda =
+                    match List.rev params with
+                    | G.Param { G.ptype = Some { t = G.TyFun _; _ }; _ } :: _ ->
+                        true
+                    | _ -> false
+                  in
+                  if last_param_is_lambda then
+                    let arity_t' = Shape_and_sig.Arity_exact (arity - 1) in
+                    let db'', sig_' =
+                      Taint_signature_extractor
+                      .extract_signature_with_file_context ~arity:arity_t'
+                        ~db:db' ?builtin_signature_db taint_inst
+                        ~name:info.name
+                        ~method_properties:info.method_properties
+                        ~call_graph:(Some relevant_graph) info.cfg ast
                     in
-                    if last_param_is_lambda then
-                      let db', _ =
-                        Taint_signature_extractor
-                        .extract_signature_with_file_context
-                          ~arity:(Shape_and_sig.Arity_exact (arity - 1))
-                          ~db:updated_db ?builtin_signature_db taint_inst
-                          ~name:info.name
-                          ~method_properties:info.method_properties
-                          ~call_graph:(Some relevant_graph) info.cfg ast
-                      in
-                      db'
-                    else updated_db
-                  else updated_db
-                in
-                run_check_fundef_if_needed info updated_db
+                    (db'', fresh @ [ to_extended_sig (sig_', arity_t') ])
+                  else (db', fresh)
+                else (db', fresh)
           in
 
-          let signature_db_after_order =
+          (* SCC-aware signature fixpoint over the relevant call graph.
+
+             Edges go callee -> caller (Call_graph.ml). Components.scc
+             numbers components so that for any arc u -> v, f(u) >= f(v);
+             with our edges that puts the deepest callees at the highest
+             indices. scc_list returns components in array order [0..n-1],
+             so we reverse to get a callees-first traversal. *)
+          let sccs_callees_first =
+            List.rev (Call_graph.SCC.scc_list relevant_graph)
+          in
+          Log.debug (fun m ->
+              m "TAINT_SCC: %d SCC(s) in relevant graph"
+                (List.length sccs_callees_first));
+          List.iteri
+            (fun i scc ->
+              Log.debug (fun m ->
+                  m "TAINT_SCC: [%d] size=%d members: %s" i (List.length scc)
+                    (String.concat ", " (List.map Function_id.show scc))))
+            sccs_callees_first;
+
+          let module Sig_lattice = struct
+            type t = Shape_and_sig.SignatureSet.t
+
+            let equal = Shape_and_sig.SignatureSet.equal
+          end in
+          let module Sig_store = struct
+            type t = Shape_and_sig.signature_database
+            type node = Function_id.t
+            type lattice = Shape_and_sig.SignatureSet.t
+
+            let get n (db : Shape_and_sig.signature_database) =
+              match Shape_and_sig.FunctionMap.find_opt n db.signatures with
+              | Some s -> s
+              | None -> Shape_and_sig.SignatureSet.empty
+
+            let set n s (db : Shape_and_sig.signature_database) =
+              {
+                db with
+                signatures = Shape_and_sig.FunctionMap.add n s db.signatures;
+              }
+          end in
+          let module Engine =
+            Graph_fixpoint.Make (Call_graph.G) (Sig_lattice) (Sig_store)
+          in
+          let analyze (node : Function_id.t)
+              (db : Shape_and_sig.signature_database) :
+              Shape_and_sig.signature_database =
+            match Shape_and_sig.FunctionMap.find_opt node info_map with
+            | None -> db
+            | Some info ->
+                (* Run extract with the function's previous-iteration sig
+                   still in place so the body's self-references see it.
+                   Then REPLACE the function's entry with only the freshly
+                   extracted sigs. Without this replace, sigs from earlier
+                   iterations would accumulate as separate elements of the
+                   per-function SignatureSet, and find_by_arity gives up
+                   when it sees multiple sigs at the same arity (returning
+                   None) -- so callers stop seeing the function's
+                   signature entirely. *)
+                let db', fresh_sigs =
+                  extract_signatures_for_fun_info info db
+                in
+                let fresh_set =
+                  List.fold_left
+                    (fun acc s -> Shape_and_sig.SignatureSet.add s acc)
+                    Shape_and_sig.SignatureSet.empty fresh_sigs
+                in
+                {
+                  db' with
+                  signatures =
+                    Shape_and_sig.FunctionMap.add node fresh_set
+                      db'.signatures;
+                }
+          in
+          let signature_db_converged =
+            Engine.run ~max_iter:20
+              ~on_max_iter:(fun members ->
+                Log.warn (fun m ->
+                    m
+                      "TAINT_FP: SCC of size %d hit max_iter, bailing with \
+                       current DB. Members: %s"
+                      (List.length members)
+                      (String.concat ", "
+                         (List.map Function_id.show members))))
+              ~sccs:sccs_callees_first ~graph:relevant_graph ~analyze
+              initial_signature_db
+          in
+
+          (* Phase 2: single match-emission pass over the converged DB.
+             Order is irrelevant (the DB is stable); we reuse the
+             callees-first ordering for log determinism. *)
+          let final_signature_db =
             List.fold_left
               (fun db node ->
-                Log.debug (fun m ->
-                    m "TAINT_SIGBUILD: Processing %s" (Function_id.show node));
                 match Shape_and_sig.FunctionMap.find_opt node info_map with
-                | None ->
-                    Log.debug (fun m ->
-                        m "TAINT_SIGBUILD: fn_id NOT FOUND in info_map!");
-                    db
-                | Some info ->
-                    Log.debug (fun m ->
-                        m
-                          "TAINT_SIGBUILD: fn_id found in info_map, \
-                           processing...");
-                    let new_db = process_fun_info info db in
-                    Log.debug (fun m ->
-                        m
-                          "TAINT_SIGBUILD: After processing, db.signatures \
-                           size=%d"
-                          (Shape_and_sig.FunctionMap.cardinal
-                             new_db.Shape_and_sig.signatures));
-                    new_db)
-              initial_signature_db analysis_order
+                | None -> db
+                | Some info -> run_check_fundef_if_needed info db)
+              signature_db_converged
+              (List.concat sccs_callees_first)
           in
-
-          (* Skip the "remaining functions" phase entirely - if a function isn't
-             in the relevant subgraph, we don't need to analyze it *)
-          let final_signature_db = signature_db_after_order in
           (Some final_signature_db, Some relevant_graph))
         else (
           (* Cross-function taint analysis disabled: use main branch behavior *)

--- a/tests/rules/cross_function_tainting/test_recursion_go.go
+++ b/tests/rules/cross_function_tainting/test_recursion_go.go
@@ -1,0 +1,14 @@
+package main
+
+func p(x interface{}) interface{} { return q(x) }
+func q(x interface{}) interface{} { return r(source()) }
+func r(x interface{}) interface{} {
+	if cond() {
+		return p(x)
+	}
+	return x
+}
+func test_3cycle() {
+	// ruleid: test-recursion-fixpoint
+	sink(p(0))
+}

--- a/tests/rules/cross_function_tainting/test_recursion_go.yaml
+++ b/tests/rules/cross_function_tainting/test_recursion_go.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-recursion-fixpoint
+    message: Taint propagating through (mutually) recursive functions
+    languages:
+      - go
+    severity: WARNING
+    mode: taint
+    options:
+      taint_intrafile: true
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_recursion_java.java
+++ b/tests/rules/cross_function_tainting/test_recursion_java.java
@@ -1,0 +1,17 @@
+public class TestRecursion {
+    static Object p(Object x) { return q(x); }
+    static Object q(Object x) { return r(source()); }
+    static Object r(Object x) {
+        if (cond()) return p(x);
+        return x;
+    }
+
+    void test_3cycle() {
+        // ruleid: test-recursion-fixpoint
+        sink(p(0));
+    }
+
+    static Object source() { return null; }
+    static void sink(Object x) {}
+    static boolean cond() { return false; }
+}

--- a/tests/rules/cross_function_tainting/test_recursion_java.yaml
+++ b/tests/rules/cross_function_tainting/test_recursion_java.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-recursion-fixpoint
+    message: Taint propagating through (mutually) recursive functions
+    languages:
+      - java
+    severity: WARNING
+    mode: taint
+    options:
+      taint_intrafile: true
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_recursion_js.js
+++ b/tests/rules/cross_function_tainting/test_recursion_js.js
@@ -1,0 +1,38 @@
+// Three-function cycle p -> q -> r -> p. Without an SCC fixed-point pass,
+// any single visit order leaves at least one cycle member with an
+// incomplete signature, and sink(p(0)) is missed.
+function p(x) { return q(x); }
+function q(x) { return r(source()); }
+function r(x) {
+    if (cond()) return p(x);
+    return x;
+}
+function test_3cycle() {
+    // ruleid: test-recursion-fixpoint
+    sink(p(0));
+}
+
+// Self-recursion counter: source is in the BASE case (at n === 5), and
+// the recursive case does NOT carry source through its arguments. Once
+// guarded effects land in the engine, this test will require both
+// guards AND the SCC fixed-point to fire correctly:
+//   * Without guards, conservative analysis records ToReturn(source)
+//     unconditionally, so sink(counter(0)) fires by over-approximation.
+//   * With guards but a single pass, iter 0 stamps the base-case effect
+//     with [guard n === 5]; at sink(counter(0)) the guard folds to
+//     0 === 5 = false and the effect is dropped (false negative).
+//   * With guards AND fixed-point iteration, each iteration substitutes
+//     the previous iteration's sig through one more recursive frame,
+//     accumulating guard variants n === 4, n === 3, ..., n === 0.
+//     sink(counter(0)) eventually finds a guard that holds and fires.
+// Today (no guards yet), this test passes by conservative
+// over-approximation -- it serves as a regression check for the
+// fixpoint engine's self-loop handling.
+function counter(n) {
+    if (n === 5) return source();
+    return counter(n + 1);
+}
+function test_counter() {
+    // ruleid: test-recursion-fixpoint
+    sink(counter(0));
+}

--- a/tests/rules/cross_function_tainting/test_recursion_js.yaml
+++ b/tests/rules/cross_function_tainting/test_recursion_js.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-recursion-fixpoint
+    message: Taint propagating through (mutually) recursive functions
+    languages:
+      - javascript
+    severity: WARNING
+    mode: taint
+    options:
+      taint_intrafile: true
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_recursion_python.py
+++ b/tests/rules/cross_function_tainting/test_recursion_python.py
@@ -1,0 +1,10 @@
+def p(x): return q(x)
+def q(x): return r(source())
+def r(x):
+    if cond():
+        return p(x)
+    return x
+
+def test_3cycle():
+    # ruleid: test-recursion-fixpoint
+    sink(p(0))

--- a/tests/rules/cross_function_tainting/test_recursion_python.yaml
+++ b/tests/rules/cross_function_tainting/test_recursion_python.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-recursion-fixpoint
+    message: Taint propagating through (mutually) recursive functions
+    languages:
+      - python
+    severity: WARNING
+    mode: taint
+    options:
+      taint_intrafile: true
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_recursion_ts.ts
+++ b/tests/rules/cross_function_tainting/test_recursion_ts.ts
@@ -1,0 +1,10 @@
+function p(x: any): any { return q(x); }
+function q(x: any): any { return r(source()); }
+function r(x: any): any {
+    if (cond()) return p(x);
+    return x;
+}
+function test_3cycle() {
+    // ruleid: test-recursion-fixpoint
+    sink(p(0));
+}

--- a/tests/rules/cross_function_tainting/test_recursion_ts.yaml
+++ b/tests/rules/cross_function_tainting/test_recursion_ts.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-recursion-fixpoint
+    message: Taint propagating through (mutually) recursive functions
+    languages:
+      - typescript
+    severity: WARNING
+    mode: taint
+    options:
+      taint_intrafile: true
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
### Problem

  `Match_tainting_mode` walks the relevant call subgraph in a single
  topological pass. OCamlGraph's topo fold doesn't iterate cycles, so
  mutually recursive functions get analysed once in arbitrary order —
  at least one cycle member sees its mutual callee with no signature
  and produces an incomplete one. 

  ### Fix

  Two phases:
  1. **Signature fixpoint per SCC.** Decompose into SCCs (callees
     first, via `List.rev (SCC.scc_list)`), iterate signature
     extraction over each SCC until `SignatureSet.equal` stabilises.
     No match emission.
  2. **Single match-emission pass.** Walk the converged DB and run
     the existing `run_check_fundef_if_needed`.

  New `src/call_graph/Graph_fixpoint.{ml,mli}` — a generic functor
  over `GRAPH × LATTICE × STORE`, with `max_iter` and `widen` hooks.
  Singleton-no-self-loop SCCs run `analyze` once (current behaviour).


  ### Tests

  `tests/rules/cross_function_tainting/test_recursion_*.{js,ts,py,java,go}`
  — 3-cycle `p→q→r→p` (p forwards, q returns `r(source())`, r
  identity-passes). Verified to fail on baseline and pass with the
  fixpoint. JS also has a `counter` self-recursion case with a
  comment noting it'll discriminate once guarded effects land.

