### PR TITLE
Dockerfile: Legacy `env` and `label` syntax

### DIFF
--- a/languages/dockerfile/generic/Dockerfile_to_generic.ml
+++ b/languages/dockerfile/generic/Dockerfile_to_generic.ml
@@ -269,7 +269,7 @@ let label_pair_exprs (instr_name : string wrap) (kv_pairs : label_pair list) :
                 sense since each key=value pair gets its own ENV call.
                 Such an ellipsis is ignored. *)
              None
-       | Label_pair (loc, key, _eq, value) ->
+       | Label_pair (loc, key, _sep, value) ->
            let key_expr = key_or_metavar_expr key in
            let value_expr = docker_string_expr value in
            Some (call instr_name loc [ G.Arg key_expr; G.Arg value_expr ]))

--- a/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
+++ b/languages/dockerfile/tree-sitter/Parse_dockerfile_tree_sitter.ml
@@ -793,8 +793,8 @@ let label_pair (env : env) (x : CST.label_pair) : label_pair =
         match v1 with
         | `Semg_meta tok ->
             Semgrep_metavar (str env tok (* pattern \$[A-Z_][A-Z_0-9]* *))
-        | `Pat_4128122 tok ->
-            Key (Unquoted (str env tok (* pattern [-a-zA-Z0-9\._]+ *)))
+        | `Pat_f266d6a tok ->
+            Key (Unquoted (str env tok (* pattern [-a-zA-Z0-9\._:]+ *)))
         | `Double_quoted_str x -> Key (double_quoted_string env x)
         | `Single_quoted_str x -> Key (single_quoted_string env x)
       in
@@ -802,6 +802,26 @@ let label_pair (env : env) (x : CST.label_pair) : label_pair =
       let value = string env v3 in
       let loc = key_or_metavar_loc key in
       Label_pair (loc, key, eq, value)
+
+let spaced_label_pair (env : env) ((v1, v2, v3) : CST.spaced_label_pair) :
+    label_pair =
+  let key = Key (Unquoted (str env v1 (* pattern [-a-zA-Z0-9\._:]+ *))) in
+  let blank = token env v2 (* pattern \s+ *) in
+  let value : docker_string =
+    match v3 with
+    | `Semg_meta tok ->
+        let tok = token env tok in
+        ((tok, tok), [ Frag_semgrep_metavar (Tok.content_of_tok tok, tok) ])
+    | `Double_quoted_str x ->
+        let fragment = double_quoted_string env x in
+        (docker_string_fragment_loc fragment, [ fragment ])
+    | `Single_quoted_str x ->
+        let fragment = single_quoted_string env x in
+        (docker_string_fragment_loc fragment, [ fragment ])
+    | `Unqu_str x -> unquoted_string env x
+  in
+  let loc = key_or_metavar_loc key in
+  Label_pair (loc, key, blank, value)
 
 let shell_command (env : env) (x : CST.shell_command) =
   match x with
@@ -964,10 +984,14 @@ let rec instruction (env : env) (x : CST.instruction) : env * instruction =
           (env, Cmd (loc, name, params, cmd))
       | `Label_inst (v1, v2) ->
           let name = str env v1 (* pattern [lL][aA][bB][eE][lL] *) in
-          let label_pairs = List_.map (label_pair env) v2 in
-          let loc = Tok_range.of_list label_pair_loc label_pairs in
+          let pairs =
+            match v2 with
+            | `Rep1_label_pair xs -> List_.map (label_pair env) xs
+            | `Spaced_label_pair x -> [ spaced_label_pair env x ]
+          in
+          let loc = Tok_range.of_list label_pair_loc pairs in
           let loc = Tok_range.extend loc (snd name) in
-          (env, Label (loc, name, label_pairs))
+          (env, Label (loc, name, pairs))
       | `Expose_inst (v1, v2) ->
           let name = str env v1 (* pattern [eE][xX][pP][oO][sS][eE] *) in
           let port_protos =

--- a/tests/parsing/dockerfile/legacy-label.dockerfile
+++ b/tests/parsing/dockerfile/legacy-label.dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.14
+
+# Legacy space-separated LABEL (no '=')
+LABEL maintainer "Foo Bar <foobar@example.com>"
+
+# LABEL key with colons (OCI reverse-DNS convention)
+LABEL che:server:6080:ref=VNC che:server:6080:protocol=http
+
+# Both in a realistic Dockerfile
+ENV DEBIAN_FRONTEND noninteractive
+ENV TERM xterm
+ENV LANG en_GB.UTF-8
+ENV PATH=$JAVA_HOME/bin:$M2_HOME/bin:$PATH
+ENV ANDROID_HOME=/home/user/android-sdk-linux

--- a/tests/patterns/dockerfile/label-legacy-spaced.dockerfile
+++ b/tests/patterns/dockerfile/label-legacy-spaced.dockerfile
@@ -1,0 +1,5 @@
+# MATCH:
+LABEL maintainer "Foo Bar <foobar@example.com>"
+
+# MATCH:
+LABEL maintainer="Modern Foo"

--- a/tests/patterns/dockerfile/label-legacy-spaced.sgrep
+++ b/tests/patterns/dockerfile/label-legacy-spaced.sgrep
@@ -1,0 +1,1 @@
+LABEL maintainer $VALUE


### PR DESCRIPTION
Solves issue 2 in #661