### PR TITLE
lsp: expose taint-intrafile

### DIFF
--- a/cli/tests/default/e2e/targets/ls/rules.yaml
+++ b/cli/tests/default/e2e/targets/ls/rules.yaml
@@ -30,3 +30,12 @@ rules:
     metadata:
         interfile: true
     fix: $X == 5
+  - id: taint-cross-fn
+    mode: taint
+    languages: [python]
+    severity: ERROR
+    message: "tainted data crosses function boundary"
+    pattern-sources:
+      - pattern: ls_taint_source()
+    pattern-sinks:
+      - pattern: ls_taint_sink(...)

--- a/src/osemgrep/language_server/Test_LS_e2e.ml
+++ b/src/osemgrep/language_server/Test_LS_e2e.ml
@@ -107,6 +107,16 @@ if x == 4: # CI rule
     print("hello")
 |}
 
+let taint_content =
+  {|
+def get_data():
+    return ls_taint_source()
+
+def ls_taint_main():
+    x = get_data()
+    ls_taint_sink(x)
+|}
+
 let login_url_regex =
   Pcre2_.pcre_compile {|https://semgrep.dev/login\?cli-token=.*"|}
 
@@ -376,6 +386,15 @@ let mock_workspaces root =
   ( (Fpath.v workspace1_root, workspace1_files),
     (Fpath.v workspace2_root, workspace2_files) )
 
+let mock_taint_file root : Fpath.t =
+  let file = Fpath.(root / "taint.py") in
+  let oc =
+    open_out_gen [ Open_creat; Open_wronly ] 0o777 (Fpath.to_string file)
+  in
+  output_string oc taint_content;
+  close_out oc;
+  file
+
 let mock_search_files root : Fpath.t list =
   let path1 = root / "a" / "b" / "c.py" in
   let path2 = root / "test.py" in
@@ -398,7 +417,8 @@ let send_exit info =
   expect_empty_msg empty;
   Lwt.return info
 
-let send_initialize info ?(only_git_dirty = true) workspaceFolders =
+let send_initialize info ?(only_git_dirty = true) ?(taint_intrafile = false)
+    workspaceFolders =
   let request =
     let rootUri =
       match workspaceFolders with
@@ -427,6 +447,7 @@ let send_initialize info ?(only_git_dirty = true) workspaceFolders =
                 ("maxTargetBytes", `Int 0);
                 ("onlyGitDirty", `Bool only_git_dirty);
                 ("ci", `Bool false);
+                ("taintIntrafile", `Bool taint_intrafile);
               ] );
           ("trace", `Assoc [ ("server", `String "verbose") ]);
           ( "metrics",
@@ -1230,6 +1251,35 @@ let test_ls_delete_cache caps () =
 
       Lwt.return ())
 
+let test_ls_taint_intrafile ~taint_intrafile ~expected_ids caps () =
+  with_session caps (fun { server = info; root } ->
+      let file = mock_taint_file root in
+      let%lwt info =
+        send_initialize info ~only_git_dirty:false ~taint_intrafile [ root ]
+      in
+      let%lwt info, _ = send_did_open info file receive_notification in
+      let%lwt _info, packets = send_initialized info Fun.id in
+      let remaining =
+        map_asserts
+          (assert_progress "Refreshing Rules"
+          @ [
+              ("received rules refreshed", assert_notif "semgrep/rulesRefreshed");
+            ]
+          @ assert_progress "Scanning Open Documents")
+          packets
+      in
+      let scan_notifications = receive_and_sort_diagnostics remaining in
+      let leftover =
+        map_asserts
+          [
+            ( "taint-cross-fn diagnostic check",
+              check_diagnostics file expected_ids );
+          ]
+          scan_notifications
+      in
+      Alcotest.(check int) "no leftover packets" 0 (List.length leftover);
+      Lwt.return_unit)
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -1258,6 +1308,12 @@ let promise_tests caps =
     pair "LS with no folders" (test_ls_no_folders caps);
     pair "LS multi-workspaces" (test_ls_multi caps) ~tolerate_chdir:true;
     pair "Test LS cache deletion" (test_ls_delete_cache caps);
+    pair "LS taint-intrafile enabled"
+      (test_ls_taint_intrafile ~taint_intrafile:true
+         ~expected_ids:[ `String "taint-cross-fn" ]
+         caps);
+    pair "LS taint-intrafile disabled"
+      (test_ls_taint_intrafile ~taint_intrafile:false ~expected_ids:[] caps);
   ]
   |> List_.split
 

--- a/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
+++ b/src/osemgrep/language_server/scan_helpers/Scan_helpers.ml
@@ -85,17 +85,7 @@ let run_semgrep ?(targets : Fpath.t list option) ?rules ?git_ref
         let runner_conf = Session.runner_conf session in
         (* This is currently just ripped from Scan_subcommand. *)
         let core_run_func =
-          let pro_intrafile =
-            session.user_settings.pro_intrafile
-          in
-            if pro_intrafile then
-              Logs.warn (fun m ->
-                  m
-                    "Pro intrafile is enabled, but the pro engine is not \
-                      available, as the user is not logged in, or there is no \
-                      pro binary available. Running with the OSS engine \
-                      instead.");
-            Core_runner.mk_core_run_for_osemgrep (Core_scan.scan session.caps)
+          Core_runner.mk_core_run_for_osemgrep (Core_scan.scan session.caps)
         in
         Logs.debug (fun m ->
             m "Running Semgrep with %d rules" (List.length rules));

--- a/src/osemgrep/language_server/server/User_settings.ml
+++ b/src/osemgrep/language_server/server/User_settings.ml
@@ -49,6 +49,7 @@ type t = {
   ci : bool; [@default true]
   do_hover : bool; [@default false]
   pro_intrafile : bool; [@default false]
+  taint_intrafile : bool; [@key "taintIntrafile"] [@default false]
 }
 [@@deriving yojson]
 
@@ -92,6 +93,6 @@ let core_runner_conf_of_t settings : Core_runner.conf =
       matching_explanations = false;
       time_flag = false;
       inline_metavariables = false;
-      taint_intrafile = false;
+      taint_intrafile = settings.taint_intrafile || settings.pro_intrafile;
       engine_config = Engine_config.default;
     }

--- a/src/osemgrep/language_server/server/User_settings.mli
+++ b/src/osemgrep/language_server/server/User_settings.mli
@@ -16,6 +16,7 @@ type t = {
   ci : bool;
   do_hover : bool;
   pro_intrafile : bool;
+  taint_intrafile : bool;
 }
 
 val default : t


### PR DESCRIPTION
Adds `taintIntrafile` to LSP `initialize` scan options, threaded through `core_runner_conf`. Legacy `pro_intrafile` aliases to it; the obsolete warning is removed. Two e2e tests cover both directions.

Closes #695.