### PR TITLE
ci: match cygwin OSTYPE in build-wheels windows branch

### DIFF
--- a/scripts/build-wheels.sh
+++ b/scripts/build-wheels.sh
@@ -24,9 +24,12 @@ cd cli && python3 setup.py sdist bdist_wheel "$@"
 twine check dist/*.whl
 
 # Zipping for a stable name to upload as an artifact
-if [[ "$OSTYPE" == "msys" ]]; then
-	# zip not available on windows CI runners
-	tar czvf dist.tgz dist
-else
-	zip -r dist.zip dist
-fi
+case "$OSTYPE" in
+	msys*|cygwin*)
+		# zip not available on windows CI runners
+		tar czvf dist.tgz dist
+		;;
+	*)
+		zip -r dist.zip dist
+		;;
+esac


### PR DESCRIPTION
The `windows-2022` runner's bash now reports `OSTYPE=cygwin`, so `scripts/build-wheels.sh` falls through to the `zip` branch and fails with `zip: command not found` (run [25442523010](https://github.com/opengrep/opengrep/actions/runs/25442523010)). Match both `msys*` and `cygwin*` via `case`.