### PR TITLE
Dune: Add rresult as direct dependency

### DIFF
--- a/libs/commons/dune
+++ b/libs/commons/dune
@@ -20,6 +20,7 @@
    timedesc
    cmdliner
    bos
+   rresult
    re
    pcre
    pcre2


### PR DESCRIPTION
Otherwise, macos won't build in CI