### PR TITLE
perf scripts: fix non-taint rule categorisation

### DIFF
--- a/perf/opengrep-scripts/copy-non-taint-rules.sh
+++ b/perf/opengrep-scripts/copy-non-taint-rules.sh
@@ -2,6 +2,6 @@
 
 set -eu
 
-rg -lv 'mode: taint' opengrep-rules -g '**/*.yaml' \
+rg --files-without-match 'mode: taint' opengrep-rules -g '**/*.yaml' \
   | sed 's|^opengrep-rules/||' \
   | rsync -av --files-from=- opengrep-rules/ opengrep-rules-non-taint/


### PR DESCRIPTION
\`rg -lv 'mode: taint'\` inverts the match line-by-line, so it lists every file with any non-matching line — i.e. every rule. Replace with \`rg --files-without-match\` for the intended file-level semantic. Without this fix, all 242 taint rules were also being copied into \`opengrep-rules-non-taint/\`.