### PR TITLE
chore: scaffold future Zig parser support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -153,3 +153,9 @@ url = https://github.com/opengrep/semgrep-circom.git
 [submodule "languages/apex/tree-sitter/semgrep-apex"]
 path = languages/apex/tree-sitter/semgrep-apex
 url = https://github.com/opengrep/semgrep-apex.git
+
+; TODO: create opengrep/semgrep-zig fork of tree-sitter-zig with OCaml bindings (CST.ml, Parse.ml, Boilerplate.ml)
+; then register it here:
+; [submodule "languages/zig/tree-sitter/semgrep-zig"]
+; path = languages/zig/tree-sitter/semgrep-zig
+; url = https://github.com/opengrep/semgrep-zig.git

--- a/docs/PULL_REQUEST_RULES.md
+++ b/docs/PULL_REQUEST_RULES.md
@@ -1,0 +1,79 @@
+# Pull Request Rules
+
+Use this checklist before opening a PR or marking a draft PR ready for review.
+
+## Branch And History
+
+- [ ] Rebase your branch on the target branch, usually `main`.
+- [ ] Do not merge `main` into your PR branch.
+- [ ] Keep the PR focused on one feature, bug fix, or refactor.
+- [ ] Split large work into smaller PRs when reviewers cannot validate it as one change.
+- [ ] Keep commits clean and informative before requesting review.
+- [ ] Mention issue numbers in commit messages or the PR description when the PR closes or relates to an issue.
+
+## PR Description
+
+- [ ] Explain what changed.
+- [ ] Explain why the change is needed.
+- [ ] List the main files or areas reviewers should inspect.
+- [ ] Call out behavior changes, compatibility risks, migration steps, and known limitations.
+- [ ] Include exact test commands you ran and their results.
+- [ ] If the PR intentionally leaves follow-up work, list it clearly.
+
+## Tests And Verification
+
+- [ ] Add tests for new features and bug fixes.
+- [ ] Add regression tests for every bug or review concern fixed by the PR.
+- [ ] Run the smallest relevant local test target before pushing.
+- [ ] Run broader tests when touching shared behavior, parsing, matching, targeting, tainting, output formats, CI, or release code.
+- [ ] Make sure CI is green after the latest push.
+- [ ] Re-run CI after rebasing.
+
+## Generated Code And Snapshots
+
+- [ ] Regenerate checked-in generated files when their source files change.
+- [ ] Update snapshots only when the output change is intended.
+- [ ] Review generated diffs for unrelated churn before pushing.
+- [ ] Document the command used to regenerate files or snapshots in the PR description.
+
+## Submodules And External Refs
+
+- [ ] Do not point submodules at personal or organization forks in a PR intended for `main`.
+- [ ] Land required submodule changes upstream first, or clearly mark the PR as blocked.
+- [ ] Pin submodules to commits available from the upstream submodule repository.
+- [ ] Verify `git submodule update --init --recursive` works from a clean checkout.
+- [ ] Mention related submodule PRs in the main PR description.
+
+## Language And Parser Changes
+
+- [ ] Preserve syntax that users may need to match, even when the generic AST has no perfect representation.
+- [ ] Add parser tests for representative syntax, not only minimal happy paths.
+- [ ] Add pattern tests for matching behavior users will rely on.
+- [ ] Add tests for modules/imports, qualified names, declarations, expressions, literals, comments, and error handling where relevant.
+- [ ] For tree-sitter parsers, follow the repository's domain-local safety pattern for parser state.
+- [ ] Avoid swallowing converter exceptions without diagnostics that help reviewers debug failures.
+- [ ] Mark unsupported syntax as `TODO` tests only when the limitation is explicit and acceptable for the PR.
+
+## Matching, Taint, Targeting, And Output Changes
+
+- [ ] Add tests that cover false positives and false negatives.
+- [ ] Include diff-scan tests when changing target discovery or ignore behavior.
+- [ ] Include permission, size-limit, minified-file, dirty-file, and explicit-file cases when changing targeting.
+- [ ] Include output snapshots for SARIF, JSON, or text output changes.
+- [ ] Verify changes do not silently alter unrelated languages or output formats.
+
+## Compatibility And Release Risk
+
+- [ ] Keep public interfaces backward compatible unless the breaking change is intentional and documented.
+- [ ] Update docs, help text, snapshots, and changelog entries when user-facing behavior changes.
+- [ ] Avoid unrelated formatting, version bumps, workflow changes, or dependency churn.
+- [ ] Call out performance-sensitive changes and include before/after measurements when performance is part of the claim.
+
+## Before Requesting Review
+
+- [ ] The branch is current with the target branch.
+- [ ] CI is green on the latest commit.
+- [ ] The PR is not blocked by unpublished downstream changes.
+- [ ] Reviewers can reproduce your local verification from the PR description.
+- [ ] Known limitations are documented instead of discovered by reviewers.
+- [ ] The PR is small enough to review effectively, or it has a clear staged merge plan.

--- a/languages/zig/generic/Parse_zig_tree_sitter.ml
+++ b/languages/zig/generic/Parse_zig_tree_sitter.ml
@@ -1,0 +1,79 @@
+(*
+ * Copyright (C) 2024 Opengrep contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License
+ * version 2.1 as published by the Free Software Foundation, with the
+ * special exception on linking described in file LICENSE.
+ *
+ * This library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the file
+ * LICENSE for more details.
+ *)
+open Fpath_.Operators
+module CST = Tree_sitter_zig.CST
+module H = Parse_tree_sitter_helpers
+module H2 = AST_generic_helpers
+module G = AST_generic
+module R = Raw_tree
+open AST_generic
+
+(*****************************************************************************)
+(* Prelude *)
+(*****************************************************************************)
+(* Zig parser using tree-sitter-lang/semgrep-zig and converting
+ * directly to AST_generic.ml
+ *)
+
+(*****************************************************************************)
+(* Helpers *)
+(*****************************************************************************)
+
+type context = Program | Pattern
+type env = context H.env
+
+let todo (_env : env) _ = failwith "not implemented"
+let str = H.str
+let token = H.token
+let fb = Tok.unsafe_fake_bracket
+
+(*****************************************************************************)
+(* Boilerplate converter *)
+(*****************************************************************************)
+
+(* Generated from tree-sitter-zig/Boilerplate.ml — fill in incrementally. *)
+
+let map_identifier (env : env) (tok : CST.identifier) : ident =
+  str env tok
+
+(*****************************************************************************)
+(* Entry points *)
+(*****************************************************************************)
+
+let map_source_file (env : env) (x : CST.source_file) : G.stmt list =
+  ignore (env, x);
+  todo env x
+
+let parse file =
+  H.wrap_parser
+    (fun () -> Tree_sitter_zig.Parse.file !!file)
+    (fun cst _extras ->
+      let env = { H.file; conv = H.line_col_to_pos file; extra = Program } in
+      let stmts = map_source_file env cst in
+      G.stmt_list_to_program stmts)
+
+let parse_pattern str =
+  H.wrap_parser
+    (fun () -> Tree_sitter_zig.Parse.string str)
+    (fun cst _extras ->
+      let file = Fpath.v "<pattern>" in
+      let env =
+        { H.file; conv = H.line_col_to_pos_pattern str; extra = Pattern }
+      in
+      match map_source_file env cst with
+      | [ s ] -> (
+          match s.G.s with
+          | ExprStmt (e, _) -> G.E e
+          | _ -> G.S s)
+      | stmts -> G.Ss stmts)

--- a/languages/zig/generic/Parse_zig_tree_sitter.mli
+++ b/languages/zig/generic/Parse_zig_tree_sitter.mli
@@ -1,0 +1,5 @@
+val parse :
+  Fpath.t -> (AST_generic.program, unit) Tree_sitter_run.Parsing_result.t
+
+val parse_pattern :
+  string -> (AST_generic.any, unit) Tree_sitter_run.Parsing_result.t

--- a/languages/zig/generic/dune
+++ b/languages/zig/generic/dune
@@ -1,0 +1,13 @@
+; TODO: uncomment once languages/zig/tree-sitter/semgrep-zig submodule exists
+; (library
+;  (public_name parser_zig.ast_generic)
+;  (name parser_zig_ast_generic)
+;  (wrapped false)
+;  (libraries
+;    commons
+;    lib_parsing lib_parsing_tree_sitter
+;    tree-sitter-lang.zig
+;    ast_generic
+;  )
+;  (preprocess (pps ppx_deriving.show))
+; )

--- a/src/parsing_languages/dune
+++ b/src/parsing_languages/dune
@@ -56,5 +56,7 @@
    parser_circom.ast_generic
    parser_apex.ast_generic
    parser_vbnet
+   ; TODO: uncomment once languages/zig/tree-sitter/semgrep-zig submodule exists
+   ; parser_zig.ast_generic
  )
 )

--- a/tests/parsing_todo/zig/allocator.zig
+++ b/tests/parsing_todo/zig/allocator.zig
@@ -1,0 +1,13 @@
+const std = @import("std");
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    const buf = try allocator.alloc(u8, 64);
+    defer allocator.free(buf);
+
+    @memset(buf, 0);
+    std.debug.print("buf len: {d}\n", .{buf.len});
+}

--- a/tests/parsing_todo/zig/errors.zig
+++ b/tests/parsing_todo/zig/errors.zig
@@ -1,0 +1,11 @@
+const std = @import("std");
+
+fn mayFail(x: i32) !i32 {
+    if (x < 0) return error.Negative;
+    return x * 2;
+}
+
+pub fn main() void {
+    const result = mayFail(5) catch unreachable;
+    std.debug.print("result: {d}\n", .{result});
+}

--- a/tests/parsing_todo/zig/hello.zig
+++ b/tests/parsing_todo/zig/hello.zig
@@ -1,0 +1,5 @@
+const std = @import("std");
+
+pub fn main() void {
+    std.debug.print("Hello, World!\n", .{});
+}


### PR DESCRIPTION
## Summary

Scaffold future Zig parser support without enabling Zig parsing yet.

This adds:
- a commented `parser_zig.ast_generic` placeholder in `src/parsing_languages/dune`
- a commented future `semgrep-zig` submodule stub in `.gitmodules`
- initial `languages/zig/generic/` parser scaffold files with the dune stanza fully commented out
- TODO parser fixtures under `tests/parsing_todo/zig/`
- `docs/PULL_REQUEST_RULES.md` — a PR readiness checklist (file was empty, added content)

Closes #705

## Known Limitations

This PR does not enable Zig language discovery, parsing, pattern matching, or matching. No existing language or output behavior is changed. The `languages/zig/generic/dune` stanza is fully commented out so the scaffold does not participate in any build.

Zig support is blocked on two upstream steps:
1. A `opengrep/semgrep-interfaces` PR adding `Zig` to `Language.ml`, `Language.mli`, and `lang.json`
2. An `opengrep/semgrep-zig` repo with OCaml tree-sitter bindings (fork of `tree-sitter-zig`)

## Follow-Up Work

- Create `opengrep/semgrep-zig` with OCaml tree-sitter bindings
- Register the submodule in `.gitmodules` (stub already commented in)
- Update the `semgrep-interfaces` submodule pointer after Zig lands there
- Uncomment the Zig dune stanzas
- Wire `.zig` discovery through `File_type` / `Lang.langs_of_filename`
- Add `Lang.Zig` dispatch in `Parse_target2` / `Parse_pattern2`
- Implement `Parse_zig_tree_sitter.ml` AST conversion
- Add real parser and pattern tests

## Verification

- Confirmed `git diff --stat HEAD` contains only the intended files
- Confirmed submodule `cli/src/semgrep/semgrep_interfaces` is clean
- Confirmed no `Lang.Zig` or `FT.Zig` references in tracked OCaml source
- Did not run `dune build`; `dune` is not available in this environment — CI is the verification gate