### PR TITLE
Go: Nontrivial types in interfaces

### DIFF
--- a/languages/go/generic/go_to_generic.ml
+++ b/languages/go/generic/go_to_generic.ml
@@ -233,9 +233,22 @@ let top_func () =
     | Constraints xs -> (
         match xs with
         | [] -> raise Impossible
-        | (_tilde_optTODO, ty) :: _xsTODO ->
-            let ty = type_ ty in
-            let st = G.OtherStmt (G.OS_Todo, [ G.T ty ]) |> G.s in
+        | first :: rest ->
+            let constraint_to_type (tilde_opt, ty) =
+              let inner_ty = type_ ty in
+              match tilde_opt with
+              | None -> inner_ty
+              | Some tok ->
+                  G.OtherType (("GoTilde", tok), [ G.T inner_ty ]) |> G.t
+            in
+            let union_ty =
+              List.fold_left
+                (fun acc c ->
+                  G.TyOr (acc, unsafe_fake "|", constraint_to_type c) |> G.t)
+                (constraint_to_type first)
+                rest
+            in
+            let st = G.OtherStmt (G.OS_Todo, [ G.T union_ty ]) |> G.s in
             G.F st)
   and expr_or_type v = either expr type_ v
   (* used for translating call make/call new *)

--- a/languages/go/tree-sitter/Parse_go_tree_sitter.ml
+++ b/languages/go/tree-sitter/Parse_go_tree_sitter.ml
@@ -374,8 +374,7 @@ and constraint_term (env : env) ((v1, v2) : CST.constraint_term) : constraint_ =
     | Some tok -> Some ((* "~" *) token env tok)
     | None -> None
   in
-  let id = (* identifier *) identifier env v2 in
-  let ty = TName [ id ] in
+  let ty = simple_type env v2 in
   (tilde_opt, ty)
 
 and interface_type_name (env : env) (x : CST.interface_type_name) :

--- a/tests/parsing/go/interface_type_constraints.go
+++ b/tests/parsing/go/interface_type_constraints.go
@@ -1,0 +1,39 @@
+package main
+
+import "io"
+
+// pointer type in a type set
+type PtrConstraint interface {
+	*int
+}
+
+// qualified type in a type set
+type QualConstraint interface {
+	io.Reader
+}
+
+// union of qualified types
+type UnionQual interface {
+	io.Reader | io.Writer
+}
+
+// union mixing pointer and qualified
+type UnionPtrQual interface {
+	*int | io.Reader
+}
+
+// tilde with qualified type
+type TildeQual interface {
+	~io.Reader
+}
+
+// multi-term union with pointer, qualified, and underlying
+type Mixed interface {
+	*int | io.Reader | ~string
+}
+
+// embedded alongside a method
+type WithMethod interface {
+	Method() error
+	*int | io.Reader
+}


### PR DESCRIPTION
Fix for #709

Before merging, update the submodule: https://github.com/opengrep/semgrep-go/pull/1