### PR TITLE
Fix taint not flowing through return value of `returns_this` methods

### DIFF
--- a/src/tainting/Builtin_models.ml
+++ b/src/tainting/Builtin_models.ml
@@ -271,7 +271,14 @@ let add_arg_taints_this_signatures db method_names arity ~taint_arg_index
   let to_lval = to_lval_this (arg_taint_set taint_arg_index) in
   let effects =
     if returns_this then
-      Effects.of_list [ to_lval; return_effect (this_taint_set ()) ]
+      (* The return value is 'this' after being tainted by the arg. We include
+       * both 'this' (for any pre-existing taint) and the arg (for the new taint)
+       * because both effects are instantiated from the pre-call env, before
+       * ToLval has a chance to update 'this'. *)
+      let ret_taints =
+        Taint.Taint_set.union (this_taint_set ()) (arg_taint_set taint_arg_index)
+      in
+      Effects.of_list [ to_lval; return_effect ret_taints ]
     else Effects.singleton to_lval
   in
   add_method_signatures db method_names arity effects

--- a/tests/rules/cross_function_tainting/test_returns_this_java.java
+++ b/tests/rules/cross_function_tainting/test_returns_this_java.java
@@ -1,0 +1,51 @@
+// Test: taint flows through the return value of methods modelled with returns_this=true.
+
+public class TestReturnsThisJava {
+
+    // Case 1: return value of append assigned to a variable then passed to sink.
+    // This is the primary regression case.
+    static void test_append_return_value_tainted() {
+        String s = source();
+        StringBuilder b = new StringBuilder();
+        String v = b.append(s);
+        // ruleid: test-returns-this-java
+        sink(v);
+    }
+
+    // Case 2: return value of append passed directly to sink.
+    static void test_append_return_direct() {
+        String s = source();
+        StringBuilder b = new StringBuilder();
+        // ruleid: test-returns-this-java
+        sink(b.append(s));
+    }
+
+    // Case 3: return value of insert (also returns_this=true) assigned and passed to sink.
+    static void test_insert_return_value_tainted() {
+        String s = source();
+        StringBuilder b = new StringBuilder();
+        String v = b.insert(0, s);
+        // ruleid: test-returns-this-java
+        sink(v);
+    }
+
+    // Case 4: pre-existing taint on 'b' should also flow through the return value.
+    static void test_append_return_carries_prior_taint() {
+        StringBuilder b = new StringBuilder(source());
+        String v = b.append("extra");
+        // ruleid: test-returns-this-java
+        sink(v);
+    }
+
+    // Case 5: no taint source - clean data should not reach sink.
+    static void test_append_no_taint() {
+        StringBuilder b = new StringBuilder();
+        String v = b.append("clean");
+        // ok: test-returns-this-java
+        sink(v);
+    }
+
+    static String source() { return "tainted"; }
+    static void sink(String x) {}
+    static void sink(StringBuilder x) {}
+}

--- a/tests/rules/cross_function_tainting/test_returns_this_java.yaml
+++ b/tests/rules/cross_function_tainting/test_returns_this_java.yaml
@@ -1,0 +1,13 @@
+rules:
+  - id: test-returns-this-java
+    message: Taint flows through the return value of a method with returns_this=true
+    languages:
+      - java
+    severity: WARNING
+    mode: taint
+    options:
+      taint_intrafile: true
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
When a method is modelled with `returns_this = true` (e.g. `StringBuilder.append` in Java), the taint analysis was failing to propagate taint to the return value in patterns like:

```java
String s = source();
StringBuilder b = new StringBuilder();
String v = b.append(s).toString();  // v should be tainted, but wasn't
sink(v);
```
**Root cause:** The signature for such a method contains two effects: a `ToLval` that taints this with the argument, and a `ToReturn(BThis)` that returns this's taint. Both effects are instantiated simultaneously from the pre-call environment, before `ToLval` has updated this. So when `ToReturn(BThis)` is instantiated, b is still untainted, the resolved taint set is empty, and the effect is dropped.

**Fix:** Instead of modelling the return value purely as `BThis` (resolved at instantiation time), the `ToReturn` effect now includes both `BThis` (for any pre-existing taint on the receiver) and the argument's taint directly. Since both are resolved from the pre-call environment, the argument taint is correctly captured without depending on the ordering of effect application.
