### PR TITLE
Go: Allow tilde and union in function args

### DIFF
--- a/languages/go/tree-sitter/Parse_go_tree_sitter.ml
+++ b/languages/go/tree-sitter/Parse_go_tree_sitter.ml
@@ -1076,16 +1076,44 @@ and type_spec (env : env) ((v1, v2, v3) : CST.type_spec) =
   let v3 = type_ env v3 in
   DTypeDef (v1, tparams_opt, v3)
 
+and type_parameter_declaration (env : env)
+    ((v1, v2, v3) : CST.type_parameter_declaration) : parameter_binding list =
+  let id1 = identifier env v1 in
+  let ids =
+    id1
+    :: List_.map
+         (fun (v1, v2) ->
+           let _v1 = (* "," *) token env v1 in
+           identifier env v2)
+         v2
+  in
+  let ty =
+    match v3 with
+    | `Choice_simple_type x -> type_ env x
+    | `Cons_elem (v1, v2) ->
+        let v1 = constraint_term env v1 in
+        let v2 =
+          List_.map
+            (fun (v1, v2) ->
+              let _v1 = (* "|" *) token env v1 in
+              constraint_term env v2)
+            v2
+        in
+        let xs = v1 :: v2 in
+        let ftok = Tok.unsafe_fake_tok "interface" in
+        TInterface (ftok, (ftok, [ Constraints xs ], ftok))
+  in
+  List_.map (fun id -> ParamClassic { pname = Some id; ptype = ty; pdots = None }) ids
+
 and type_parameter_list (env : env)
     ((v1, v2, v3, v4, v5) : CST.type_parameter_list) =
   let lbra = (* "[" *) token env v1 in
-  let params = parameter_declaration env v2 in
+  let params = type_parameter_declaration env v2 in
   let paramss =
     List.concat_map
       (fun (v1, v2) ->
         let _v1 = (* "," *) token env v1 in
-        let v2 = parameter_declaration env v2 in
-        v2)
+        type_parameter_declaration env v2)
       v3
   in
   let _v4 = trailing_comma env v4 in

--- a/tests/parsing/go/tilde_type_constraints.go
+++ b/tests/parsing/go/tilde_type_constraints.go
@@ -1,0 +1,19 @@
+package main
+
+// tilde in a single type parameter
+func SingleTilde[S ~uint8]() {}
+
+// tilde union in a type parameter
+func TildeUnion[S ~uint8 | ~string]() {}
+
+// multiple type parameters, one with tilde
+func MultiParam[S ~uint8, P interface{ Foo() }]() {}
+
+// tilde with qualified type
+func QualifiedTilde[S ~io.Reader]() {}
+
+// tilde with multiple names sharing a constraint
+func SharedConstraint[S, T ~int]() {}
+
+// type definition with tilde constraint
+type Stack[T ~[]E, E any] struct{}


### PR DESCRIPTION
The fix adds a new `type_parameter_declaration` grammar rule (separate from `parameter_declaration`) that allows type parameter constraints to be either a regular type or a `constraint_elem` (tilde/union forms like `~uint8 or ~int | ~string`). Examples:

```go
func Foo[S ~uint8]() {}                        // single tilde
func Foo[S ~uint8 | ~string]() {}              // tilde union
func Foo[S, T ~int]() {}                       // shared tilde constraint
type Stack[T ~[]E, E any] struct{}             // tilde in type def**
```

In the OCaml parser, constraint elements are converted to a `TInterface` wrapping `Constraints`, matching the representation already used for interface body type constraints. Note that the tilde syntax `~uint8` in `[S ~uint8]` is a type constraint, not a type — and in Go's type system, inline constraints like ~uint8 are semantically equivalent to interface{~uint8}. Wrapping in `TInterface` with `Constraints` reuses the existing Go AST representation for "a set of type constraints", which is exactly what `~uint8` means regardless of whether it appears in an interface body or a function's type parameter list.

**TODO:**

- [x] Merge the Go PR https://github.com/opengrep/semgrep-go/pull/2 and update the submodule