### PR TITLE
Allow "opengrep-" prefix in lang submodules

### DIFF
--- a/src/main/list-tree-sitter-langs.sh
+++ b/src/main/list-tree-sitter-langs.sh
@@ -9,10 +9,15 @@ set -eu
 # Paths are relative to the project root which can be
 # semgrep, semgrep-proprietary, or semgrep-proprietary/OSS depending
 # on context.
-paths=$(echo languages/*/tree-sitter/semgrep-*)
+semgrep_paths=$(echo languages/*/tree-sitter/semgrep-*)
+opengrep_paths=$(echo languages/*/tree-sitter/opengrep-*)
 
-# Extract 'some_lang' from folders named 'semgrep-some-lang'
-for path in $paths; do
-  semgrep_lang=$(basename "$path")
-  echo "${semgrep_lang#semgrep-}" | tr '-' '_' | sort
+# Extract 'some_lang' from folders named 'semgrep-some-lang' or 'opengrep-some-lang'
+for path in $semgrep_paths; do
+  dir=$(basename "$path")
+  echo "${dir#semgrep-}" | tr '-' '_'
+done
+for path in $opengrep_paths; do
+  dir=$(basename "$path")
+  echo "${dir#opengrep-}" | tr '-' '_'
 done


### PR DESCRIPTION
The Crystal tree-sitter parser lives in `languages/crystal/tree-sitter/opengrep-crystal` (using the `opengrep-` prefix rather than `semgrep-`), but `list-tree-sitter-langs.sh` only scanned `semgrep-*` directories. As a
  result, Crystal was never included in the language list fed to `flags.sh`, so `-ltree_sitter_crystal_stubs` was never added to the macOS linker flags, causing a build error. This PR fixes this by scanning `opengrep-` dirs as well.