### PR TITLE
Ast-to-IL: Translate more types of function params

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -3279,28 +3279,25 @@ and cond env cond_e : stmts * exp =
       expr env e
 
 and for_var_or_expr_list env xs : stmts =
-  let list_of_lists =
-    List.map
-      (fun x ->
-        match x with
-        | G.ForInitExpr e ->
-            let ss, _eIGNORE = expr env e in
-            ss
-        | G.ForInitVar (ent, vardef) -> (
-            (* copy paste of VarDef case in stmt *)
-            match vardef with
-            | { G.vinit = Some e; vtype = opt_ty; vtok = _ } ->
-                let ss1, e' = expr env e in
-                let ss2, () = type_opt env opt_ty in
-                let ss_lv, lv = lval_of_ent env ent in
-                ss1 @ ss2 @ ss_lv
-                  @ [
-                      mk_s (Instr (mk_i (Assign (lv, e')) (Related (G.En ent))));
-                    ]
-            | _ -> []))
-      xs
-  in
-  List.concat list_of_lists (*TODO this is not tail recursive!!!!*)
+  List.concat_map
+    (fun x ->
+      match x with
+      | G.ForInitExpr e ->
+          let ss, _eIGNORE = expr env e in
+          ss
+      | G.ForInitVar (ent, vardef) -> (
+          (* copy paste of VarDef case in stmt *)
+          match vardef with
+          | { G.vinit = Some e; vtype = opt_ty; vtok = _ } ->
+              let ss1, e' = expr env e in
+              let ss2, () = type_opt env opt_ty in
+              let ss_lv, lv = lval_of_ent env ent in
+              ss1 @ ss2 @ ss_lv
+                @ [
+                    mk_s (Instr (mk_i (Assign (lv, e')) (Related (G.En ent))));
+                  ]
+          | _ -> []))
+    xs
 
 (*****************************************************************************)
 (* Parameters *)
@@ -3332,13 +3329,19 @@ and parameters params : param list =
            let i = G.implicit_param_id_indexed idx tk in
            let pname = var_of_id_info i pinfo in
            ParamPattern ({ pname; pdefault }, pat)
-       | G.ParamReceiver _param ->
-           (* TODO: Treat receiver as this parameter *)
-           ParamFixme (* TODO *)
+       | G.ParamReceiver { pname = Some i; pinfo; pdefault; _ } ->
+           (* Go receiver: treat as a regular named parameter for now.
+            * TODO: Ideally it would map to VarSpecial(This), but that requires
+            * rewriting all uses of the receiver variable in the body. *)
+           Param { pname = var_of_id_info i pinfo; pdefault }
+       | G.ParamReceiver { pname = None; _ } -> ParamFixme
        (* Ruby/PHP block parameter: &callback -> OtherParam("Ref", [Pa(Param(...))]) *)
        | G.OtherParam (("Ref", _), [ G.Pa (G.Param { pname = Some i; pinfo; pdefault; _ }) ])
          ->
            Param { pname = var_of_id_info i pinfo; pdefault }
+       | G.ParamHashSplat (_, { pname = Some i; pinfo; pdefault; _ }) ->
+           (* **kwargs in Python / **opts in Ruby: treat as rest param *)
+           ParamRest { pname = var_of_id_info i pinfo; pdefault }
        | G.Param { pname = None; _ }
        | G.ParamRest (_, _)
        | G.ParamHashSplat (_, _)

--- a/tests/tainting_rules/go/param_receiver.go
+++ b/tests/tainting_rules/go/param_receiver.go
@@ -1,0 +1,16 @@
+// ParamReceiver was previously translated to ParamFixme, so the receiver
+// variable was invisible to the taint engine (Fold_IL_params.fold skipped it).
+// It is now translated to Param so focus-metavariable picks it up.
+
+func (r *SomeType) Dangerous() {
+	x := r.Field
+	// ruleid: taint
+	sink(x)
+}
+
+// Regular function — not a receiver method, so $RECV never binds here.
+func NotAMethod(r *SomeType) {
+	x := r.Field
+	// ok: taint
+	sink(x)
+}

--- a/tests/tainting_rules/go/param_receiver.yaml
+++ b/tests/tainting_rules/go/param_receiver.yaml
@@ -1,0 +1,13 @@
+rules:
+- id: taint
+  languages: [go]
+  message: "tainted receiver reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - patterns:
+      - pattern: |
+          func ($RECV *SomeType) $METHOD(...) { ... }
+      - focus-metavariable: $RECV
+  pattern-sinks:
+    - pattern: sink(...)

--- a/tests/tainting_rules/python/kwargs_param.py
+++ b/tests/tainting_rules/python/kwargs_param.py
@@ -1,0 +1,8 @@
+def foo(**kwargs):
+    # ruleid: taint
+    sink(kwargs)
+
+# Regular positional param — not matched by the **$PARAM source pattern.
+def bar(x):
+    # ok: taint
+    sink(x)

--- a/tests/tainting_rules/python/kwargs_param.yaml
+++ b/tests/tainting_rules/python/kwargs_param.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: taint
+  languages: [python]
+  message: "tainted kwargs reached sink"
+  severity: ERROR
+  mode: taint
+  pattern-sources:
+    - patterns:
+      - pattern: |
+          def $FUNC(**$PARAM):
+            ...
+      - focus-metavariable: $PARAM
+  pattern-sinks:
+    - pattern: sink(...)


### PR DESCRIPTION
Used for kwargs in Python and receiver params in Go (see tests).

Notes (to be translated to issues unless decided otherwise during review)
- Kwargs don't have field sensitivity:

```python
def my_function(**kwargs):
  # ruleid: safe
  sink(kwargs["safe"])
  # ruleid: taint
  sink(kwargs["src"])

my_function(safe = 123, src = source())
```

- General args in patterns don't capture kwargs, e.g. the pattern

```python
def $FUNC($PARAM):
   ...
```

will not capture the program

```python
def foo(**param):
  ...
```

So if someone just wants a rule like "taint comes from a function param (whatever form)", we need to duplicate patterns