### PR TITLE
install.sh: add OPENGREP_SKIP_BINARY_TEST env var to bypass smoke test

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -221,21 +221,27 @@ main() {
         fi
 
         echo "Testing binary..."
-        # Test by calling --version on the downloaded binary
-        STDERR_LOG=$(mktemp)
-        TEST=$("${INST}/opengrep" --version 2>"$STDERR_LOG" || true)
-        if [ -z "$TEST" ]; then
-            echo "Failed to execute installed binary: ${INST}/opengrep." 1>&2
-            if [ -s "$STDERR_LOG" ]; then
-                echo "Error output:" 1>&2
-                cat "$STDERR_LOG" 1>&2
-                echo 1>&2
-                echo "Full error log saved to: $STDERR_LOG" 1>&2
+        # Test by calling --version on the downloaded binary.
+        # Set OPENGREP_SKIP_BINARY_TEST=1 to bypass this check in environments where
+        # binary execution is unreliable (e.g. docker buildx multi-platform builds).
+        if [[ "${OPENGREP_SKIP_BINARY_TEST:-}" == "1" ]]; then
+            echo "Skipping binary test (OPENGREP_SKIP_BINARY_TEST=1)."
+        else
+            STDERR_LOG=$(mktemp)
+            TEST=$("${INST}/opengrep" --version 2>"$STDERR_LOG" || true)
+            if [ -z "$TEST" ]; then
+                echo "Failed to execute installed binary: ${INST}/opengrep." 1>&2
+                if [ -s "$STDERR_LOG" ]; then
+                    echo "Error output:" 1>&2
+                    cat "$STDERR_LOG" 1>&2
+                    echo 1>&2
+                    echo "Full error log saved to: $STDERR_LOG" 1>&2
+                fi
+                echo "If reporting this issue, please include the above output." 1>&2
+                exit 1
             fi
-            echo "If reporting this issue, please include the above output." 1>&2
-            exit 1
+            rm -f "$STDERR_LOG"
         fi
-        rm -f "$STDERR_LOG"
 
         echo
         echo "Successfully installed Opengrep binary at ${INST}/opengrep"


### PR DESCRIPTION
**Fixes:** #727

**What Changed:**
- Added `OPENGREP_SKIP_BINARY_TEST=1` environment variable to `install.sh` that bypasses the binary smoke test.

**Why:**
`docker buildx build --platform linux/amd64,linux/arm64` fails at the smoke test (`Testing binary...`) on the `linux/amd64` build when QEMU is registered for the concurrent `arm64` build. The error is `cannot execute: required file not found` — consistent with the kernel routing binary execution through a `binfmt_misc` handler whose interpreter path doesn't exist inside the container. The binary itself downloads correctly; only the smoke test fails.

Setting `OPENGREP_SKIP_BINARY_TEST=1` bypasses the test and allows multi-platform builds to proceed. Verified on an Amazon Linux EC2 instance with `docker buildx build --platform linux/amd64,linux/arm64`.

**Usage:**
```dockerfile
RUN OPENGREP_SKIP_BINARY_TEST=1 /tmp/install.sh
```