### PR TITLE
Fix Windows '..' walk-up in reported file paths

### DIFF
--- a/.github/workflows/windows-path-regression.yml
+++ b/.github/workflows/windows-path-regression.yml
@@ -1,0 +1,70 @@
+# Windows-only end-to-end regression for the path '..' walk-up in osemgrep
+# target discovery (Find_targets / Git_wrapper). On case-insensitive and 8.3
+# short-name filesystems the typed scanning root and cwd can diverge from
+# git's canonical paths; we canonicalise them (Rpath.canonical_if_win) before
+# relativizing, so reported paths keep the typed prefix and have no '..'.
+#
+# The bug only reproduces on Windows, so this workflow is the regression guard
+# (there is no cheap cross-platform unit test). It runs only on demand.
+name: windows-path-regression
+
+on:
+  workflow_dispatch:
+
+jobs:
+  # Reuse the existing Windows build (it already declares workflow_call) so we
+  # don't duplicate the opam/cygwin/dune setup. It uploads
+  # 'opengrep-core-and-dependent-libs-w64-artifact' (opengrep-core.exe + DLLs).
+  build:
+    uses: ./.github/workflows/build-test-windows-x86.yml
+
+  regression:
+    needs: build
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
+        with:
+          name: opengrep-core-and-dependent-libs-w64-artifact
+      - name: unpack binary + dlls
+        run: tar xvfz artifacts.tgz
+      - name: case-insensitive path regression (native osemgrep)
+        run: |
+          set -eu
+          # 'scan' is dispatched by argv[0]: copy opengrep-core.exe to
+          # opengrep-cli.exe (same bytes, DLLs alongside) so it runs the osemgrep
+          # CLI, and pass --experimental to force native osemgrep (Find_targets)
+          # instead of delegating to pyopengrep -- otherwise the buggy discovery
+          # code never runs.
+          cp artifacts/opengrep-core.exe artifacts/opengrep-cli.exe
+          CLI="$PWD/artifacts/opengrep-cli.exe"
+          base="$(mktemp -d)"
+          mkdir -p "$base/MixedRepo/sub"
+          ( cd "$base/MixedRepo" \
+              && git init -q \
+              && git config user.email a@b.c \
+              && git config user.name ci \
+              && printf 'print("foo")\n' > sub/test.py \
+              && git add -A )
+          printf 'rules:\n  - id: t\n    pattern: print(...)\n    message: t\n    severity: ERROR\n    languages: [python]\n' > "$base/rules.yml"
+          winbase="$(cygpath -w "$base")"
+          winrules="$(cygpath -w "$base/rules.yml")"
+          # Scan via the lower-cased spelling of MixedRepo so the typed scanning
+          # root diverges from git's canonical casing -- the bug's trigger.
+          winlower="${winbase}\\mixedrepo"
+          echo "root: $winlower"
+          PYTHONIOENCODING=utf-8 "$CLI" scan --experimental --json -f "$winrules" "$winlower" > out.json 2>err.txt || true
+          echo "--- stderr (first 400 chars) ---"; head -c 400 err.txt; echo
+          echo "--- result paths ---"
+          paths="$(grep -o '"path":[[:space:]]*"[^"]*"' out.json || true)"
+          printf '%s\n' "$paths"
+          # Any '..' segment in a result path is the walk-up (the '...' ellipsis
+          # lives in the rule pattern, never in a path value).
+          if printf '%s\n' "$paths" | grep -qE '\.\.[\\/]'; then
+            echo "REGRESSION: '..' walk-up in result path:"
+            printf '%s\n' "$paths" | grep -E '\.\.[\\/]'
+            exit 1
+          fi
+          echo "OK: no walk-up"

--- a/libs/commons/Fpath_.mli
+++ b/libs/commons/Fpath_.mli
@@ -57,6 +57,7 @@ val append_no_dot : Fpath.t -> Fpath.t -> Fpath.t
 
      open File.Operators
 *)
+
 module Operators : sig
   (* Fpath.add_seg = Fpath.(/) *)
   val ( / ) : Fpath.t -> string -> Fpath.t

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -360,7 +360,12 @@ let relativize_if_possible ~abs_cwd abs_path =
          "Git_wrapper.relativize_if_possible: abs_path must be an absolute \
           path but we received %s"
          !!abs_path);
-  match Fpath.relativize ~root:(append_slash_to_dir_path abs_cwd) abs_path with
+  (* Callers pass an 'abs_cwd' that is canonicalised on Windows (see
+     ls_files_relative), so a plain relativize against it no longer emits a
+     '..' walk-up on case-insensitive filesystems. *)
+  match
+    Fpath.relativize ~root:(append_slash_to_dir_path abs_cwd) abs_path
+  with
   | Some rel_path -> rel_path
   | None -> abs_path
 
@@ -376,7 +381,10 @@ let ls_files_relative ?exclude_standard ?kinds ~(project_root : Rpath.t)
     root_paths =
   (* Both project_root and sys_cwd are absolute, physical paths *)
   let project_root = Rpath.to_fpath project_root in
-  let sys_cwd = Sys.getcwd () |> Fpath.v in
+  (* Canonicalise cwd on Windows so it agrees with git's canonical paths;
+     otherwise relativizing git's output against it can emit a '..' walk-up.
+     No-op on case-sensitive filesystems. *)
+  let sys_cwd = Rpath.canonical_if_win (Sys.getcwd () |> Fpath.v) in
   let abs_root_paths =
     root_paths
     |> List_.map (fun path ->
@@ -484,7 +492,10 @@ let merge_base (commit : string) : string =
   | _ -> raise (Error "Could not get merge base from git merge-base")
 
 let run_with_worktree (caps : < Cap.chdir ; Cap.tmp >) ~commit ?branch f =
-  let cwd = getcwd () |> Fpath.to_dir_path in
+  (* Canonicalise cwd on Windows so it agrees with git's canonical project
+     root; otherwise relativizing against it can emit a '..' walk-up. No-op on
+     case-sensitive filesystems. *)
+  let cwd = Rpath.canonical_if_win (getcwd ()) |> Fpath.to_dir_path in
   let git_root =
     match project_root_for_files_in_dir cwd with
     | None ->

--- a/libs/paths/Rpath.ml
+++ b/libs/paths/Rpath.ml
@@ -85,6 +85,20 @@ let of_fpath_exn fpath = of_string_exn (Fpath.to_string fpath)
 let to_fpath (Rpath x) = x
 let canonical_exn s = to_fpath (of_fpath_exn s)
 
+(* On case-insensitive filesystems (Windows), resolve [p] to its physical real
+   path so its spelling (case and 8.3 short names) agrees with the canonical
+   paths the OS and git report. On case-sensitive filesystems the command-line
+   path is already canonical, so [p] is returned unchanged. If [p] can't be
+   resolved (e.g. removed since it was last checked, or a parent directory is
+   not traversable), it is returned unchanged too, matching the behaviour
+   before canonicalisation. *)
+let canonical_if_win p =
+  if Sys.win32 then
+    match of_fpath p with
+    | Ok rp -> to_fpath rp
+    | Error _ -> p
+  else p
+
 (* deprecated *)
 let to_string (Rpath x) = Fpath.to_string x
 

--- a/libs/paths/Rpath.mli
+++ b/libs/paths/Rpath.mli
@@ -68,6 +68,14 @@ val to_string : t -> string
 (* <=> to_fpath (of_fpath s) *)
 val canonical_exn : Fpath.t -> Fpath.t
 
+(* On case-insensitive filesystems (Windows), resolve [p] to its physical real
+   path so its spelling (case and 8.3 short names) agrees with the canonical
+   paths the OS and git report. On case-sensitive filesystems the command-line
+   path is already canonical and is returned unchanged. If [p] can't be
+   resolved, it is returned unchanged, matching the behaviour before
+   canonicalisation. *)
+val canonical_if_win : Fpath.t -> Fpath.t
+
 (*
    Get the current working directory from the system.
    It raises an exception with a slightly better error message than

--- a/src/targeting/Find_targets.ml
+++ b/src/targeting/Find_targets.ml
@@ -493,33 +493,50 @@ let git_list_files ~exclude_standard
    *)
   match project.kind with
   | Git_project ->
-      let cwd = Fpath.v (Sys.getcwd ()) in
+      (* Canonicalise cwd on Windows so its spelling (case, 8.3 short names)
+         agrees with git's canonical paths; otherwise relativizing against it
+         can emit a '..' walk-up. No-op on case-sensitive filesystems. *)
+      let cwd = Rpath.canonical_if_win (Fpath.v (Sys.getcwd ())) in
       Some
         (project_roots.scanning_roots
         |> List.concat_map (fun (sc_root : Fppath.t) ->
                if UFile.is_reg ~follow_symlinks:true sc_root.fpath then
+                 (* A single-file scanning root is returned as-is: it has no
+                    descendants to relativize, so it never produced the '..'
+                    walk-up. Canonicalising it here would only desync its fpath
+                    from its ppath and double-report the file. *)
                  [ sc_root ]
                else if UFile.is_dir ~follow_symlinks:true sc_root.fpath then (
                  Log.info (fun m ->
                      m "List git files for scanning root %s"
                        (Fppath.show sc_root));
                  let project_root = Rfpath.to_rpath project.root in
-                 (* The path prefix we want for all the target file paths
-                    that we return *)
+                 (* The path prefix we want for all the target file paths that
+                    we return: the scanning root exactly as the user typed it,
+                    like pyopengrep. *)
                  let orig_scanning_root_path = sc_root.fpath in
+                 (* On Windows the typed root can differ from git's canonical
+                    paths in case or via 8.3 short names; relativizing it
+                    against git's canonical targets would emit a '..' walk-up.
+                    Canonicalise a copy for the relativize and the git lookup
+                    below so they stay clean, while still prefixing the typed
+                    root onto the result. No-op on case-sensitive filesystems. *)
+                 let canon_scanning_root_path =
+                   Rpath.canonical_if_win sc_root.fpath
+                 in
                  (* Best effort to get a relative scanning root path
                     (will fail in file systems with multiple roots) *)
                  let rel_scanning_root_path_or_absolute =
-                   if Fpath.is_rel orig_scanning_root_path then
-                     orig_scanning_root_path
+                   if Fpath.is_rel canon_scanning_root_path then
+                     canon_scanning_root_path
                    else
                      match
-                       Fpath.relativize ~root:cwd orig_scanning_root_path
+                       Fpath.relativize ~root:cwd canon_scanning_root_path
                      with
                      | Some rel_scanning_root -> rel_scanning_root
                      | None ->
                          (* absolute, on another volume than cwd *)
-                         orig_scanning_root_path
+                         canon_scanning_root_path
                  in
                  (* We can't just cd into the scanning root to obtain paths
                     relative to it because the scanning root may be a regular
@@ -529,7 +546,7 @@ let git_list_files ~exclude_standard
                     the resulting paths to be relative to the scanning root. *)
                  Git_wrapper.ls_files_relative ~exclude_standard
                    ~kinds:file_kinds ~project_root
-                   [ orig_scanning_root_path ]
+                   [ canon_scanning_root_path ]
                  |> List_.map (fun target_relative_to_cwd_or_absolute ->
                         (* Invariant: the target path is a descendant of the
                            scanning root path *)
@@ -544,7 +561,11 @@ let git_list_files ~exclude_standard
                         *)
                         let target_fpath =
                           match
-                            (* 'root' must be a folder *)
+                            (* 'root' must be a folder. We relativize against
+                               the canonicalised root and cwd, so on Windows
+                               this no longer emits a '..' walk-up; the clean
+                               remainder is then prefixed with the typed root
+                               below. *)
                             Fpath.relativize
                               ~root:rel_scanning_root_path_or_absolute
                               target_relative_to_cwd_or_absolute


### PR DESCRIPTION
> So we're scanning with arguments:
> opengrep-cli.exe scan --sarif --experimental C:\Users\e\Source\Repos\A --config path-to-rules
>
> And in the results, the path for each file seems to change from C:\Users\e\Source\Repos\A to
> C:\Users\e\Source\Repos\A\..\..\source\repos\A.

On case-insensitive filesystems (Windows), when the scanning root the user typed differs from git's canonical path — in **case** (`Source\Repos` vs `source\repos`) or as an **8.3 short name** (`RUNNER~1` vs `runneradmin`) — native osemgrep reported file paths with a `..` walk-up (e.g. `..\..\source\repos\A\file.cs` instead of `A\file.cs`). The path still resolves on disk, but it breaks any SARIF/JSON consumer that string-compares or de-duplicates locations.

Native target discovery relativizes the typed scanning root against git's canonical paths with the purely syntactic `Fpath.relativize`; when the two spell a shared directory differently it can't see the target as a descendant and emits a "walk up, then re-descend" path full of `..`. (The Python CLI is unaffected — it runs `git ls-files` from the resolved root and prefixes the typed path, so it never relativizes divergent spellings.)

### Fix
- Add `Rpath.canonical_if_win`: on Windows, resolve a path to its physical real path (normalises case **and** 8.3 short names); a no-op on case-sensitive filesystems.
- In `Find_targets` and `Git_wrapper`, canonicalise `cwd` and the scanning root for the relativize comparison only, and keep the user's typed root as the output prefix — so reported paths stay exactly as typed (matching the Python CLI) and contain no `..`.

### Tests
- `.github/workflows/windows-path-regression.yml` (manual, `workflow_dispatch`): builds on a Windows runner, then scans a `MixedRepo` via its lower-cased root with `opengrep-cli scan --experimental --json` and asserts the result paths have no `..`. The bug only reproduces on Windows, so there's no cross-platform unit test.
