### PR TITLE
Clamp out-of-range line reads so a truncated file can't abort the scan

### DIFF
--- a/libs/commons/UFile.ml
+++ b/libs/commons/UFile.ml
@@ -294,6 +294,11 @@ let find_first_match_with_whole_line path ?split term =
  *)
 let lines_of_file_exn (start_line, end_line) file : string list =
   let arr = cat_array file in
+  (* Clamp the end line to the last index: a match's end position can point
+     past the file's last line when the parser inserts a synthetic token at
+     EOF (e.g. a '}' closing a truncated block), and we must not read past
+     the array. The [try/with] below still guards any other bad index. *)
+  let end_line = min end_line (Array.length arr - 1) in
   let lines = List_.enum start_line end_line in
   match arr with
   (* This is the case of the empty file. *)

--- a/src/osemgrep/cli_scan/Test_scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Test_scan_subcommand.ml
@@ -119,6 +119,25 @@ def foo(a, b):
     return a + b == a + b
 |}
 
+let terraform_aws_lb_yaml_content =
+  {|
+rules:
+  - id: aws-lb-block
+    pattern: |
+      resource "aws_lb" $NAME {
+        ...
+      }
+    message: "aws_lb block"
+    languages: [terraform]
+    severity: WARNING
+|}
+
+(* A 'resource' block that is never closed: the file ends mid-block. *)
+let truncated_terraform_content =
+  {|resource "aws_lb" "x" {
+  internal = false
+|}
+
 let dummy_app_token = "FAKETESTINGAUTHTOKEN"
 
 (* coupling: subset of cli/tests/conftest.py ALWAYS_MASK *)
@@ -318,6 +337,29 @@ let test_basic_verbose_output (caps : Scan_subcommand.caps) () =
           in
           Exit_code.Check.ok exit_code))
 
+(* A truncated Terraform file whose 'resource' block is never closed. The
+   parser's error recovery inserts a synthetic '}' at EOF, so a rule matching
+   the block gets an end position one line past the file's content. Reading the
+   lines around the match (for nosemgrep suppression and for the output) must
+   not raise and abort the whole scan. *)
+let test_truncated_terraform_block (caps : Scan_subcommand.caps) () =
+  with_env_app_token (fun () ->
+      let repo_files =
+        [
+          F.File ("rules.yml", terraform_aws_lb_yaml_content);
+          F.File ("main.tf", truncated_terraform_content);
+        ]
+      in
+      Testutil_git.with_git_repo ~verbose:true repo_files (fun _cwd ->
+          let exit_code =
+            without_settings (fun () ->
+                Scan_subcommand.main caps
+                  [|
+                    "opengrep-scan"; "--experimental"; "--config"; "rules.yml";
+                  |])
+          in
+          Exit_code.Check.ok exit_code))
+
 (*****************************************************************************)
 (* Entry point *)
 (*****************************************************************************)
@@ -351,4 +393,6 @@ let tests (caps : < Scan_subcommand.caps >) =
         (test_basic_output_max_match caps);
       t "basic output with max-match-per-file rule option" ~checked_output:(Testo.stdxxx ()) ~normalize
         (test_basic_output_max_match_in_rule caps);
+      t "truncated terraform block does not abort scan"
+        (test_truncated_terraform_block caps);
     ]


### PR DESCRIPTION
Fixes #723.

A rule matching a truncated file (e.g. an unclosed Terraform `resource` block) produces a match whose end line is past the file's last line, because tree-sitter error recovery inserts a synthetic closing token at EOF. `UFile.lines_of_file_exn` then read past the file and raised `ErrorOnFile`, aborting the entire scan (exit 2, all results discarded).

Clamp the requested end line to the file's last line. Adds an e2e regression test.