### PR TITLE
Fix Aikido security findings: bump setuptools/urllib3, pin cosign, bump semgrep-interfaces

### DIFF
--- a/.github/workflows/build-test-manylinux.yml
+++ b/.github/workflows/build-test-manylinux.yml
@@ -37,9 +37,7 @@ jobs:
       - run: |
           yum update -y
           yum install -y zip
-          alternatives --remove-all python3 || true
-          alternatives --install /usr/bin/python3 python3 /opt/python/cp310-cp310/bin/python3 1
-          alternatives --auto python3
+          echo /opt/python/cp310-cp310/bin >> "$GITHUB_PATH"
       - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
           name: opengrep-core-${{ inputs.arch == 'x86_64' && 'x86' || 'aarch64' }}

--- a/.github/workflows/build-test-manylinux.yml
+++ b/.github/workflows/build-test-manylinux.yml
@@ -36,9 +36,9 @@ jobs:
           submodules: true
       - run: |
           yum update -y
-          yum install -y zip python3-pip python3.9
-          alternatives --remove-all python3
-          alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 1
+          yum install -y zip
+          alternatives --remove-all python3 || true
+          alternatives --install /usr/bin/python3 python3 /opt/python/cp310-cp310/bin/python3 1
           alternatives --auto python3
       - uses: actions/download-artifact@b14cf4c92620c250e1c074ab0a5800e37df86765 # ratchet:actions/download-artifact@v4
         with:
@@ -63,14 +63,14 @@ jobs:
           name: manylinux-${{ inputs.arch == 'x86_64' && 'x86' || 'aarch64' }}-wheel
       - run: unzip dist.zip
       - name: install package
-        run: /opt/python/cp39-cp39/bin/pip install dist/*.whl
+        run: /opt/python/cp310-cp310/bin/pip install dist/*.whl
       - name: test package
         run: |
-          export PATH=/opt/python/cp39-cp39/bin:$PATH
+          export PATH=/opt/python/cp310-cp310/bin:$PATH
           opengrep --version
       - name: e2e opengrep-core test
         run: |
-          export PATH=/opt/python/cp39-cp39/bin:$PATH
+          export PATH=/opt/python/cp310-cp310/bin:$PATH
           echo '1 == 1' | opengrep -l python -e '$X == $X' -
 
   test-wheels-venv:
@@ -85,7 +85,7 @@ jobs:
           name: manylinux-x86-wheel
       - run: unzip dist.zip
       - name: create venv
-        run: /opt/python/cp39-cp39/bin/python3 -m venv env
+        run: /opt/python/cp310-cp310/bin/python3 -m venv env
       - name: install package
         run: env/bin/pip install dist/*.whl
       - name: test package
@@ -106,6 +106,8 @@ jobs:
           name: manylinux-x86-wheel
       - run: unzip dist.zip
       - uses: Vampire/setup-wsl@3b46b44374d5d0ae94654c45d114a3ed7a0e07a8 # ratchet:Vampire/setup-wsl@v5.0.1
+        with:
+          distribution: Ubuntu-22.04
       - name: Install Python
         run: |
           sudo sed -i '/bullseye-backports/d' /etc/apt/sources.list

--- a/.github/workflows/test-install-ps1.yml
+++ b/.github/workflows/test-install-ps1.yml
@@ -68,7 +68,7 @@ jobs:
           submodules: false
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v3
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
 
       - name: Verify cosign installed
         shell: pwsh

--- a/cli/Pipfile.lock
+++ b/cli/Pipfile.lock
@@ -498,11 +498,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:8199222558df7c86216af4f84c30e9b34a61d8ba19366cc914424cdbd28252f6",
-                "sha256:ce74b49e8f7110f9bf04883b730f4765b774ef3ef28f722cce7c273d253aaf7d"
+                "sha256:c3a9c4211ff4c309edb8b8c4f1cbfa7ae324c4ba9f91ff254e3d305b9fd54561",
+                "sha256:fcc17fd9cd898242f6b4adfaca46137a9edef687f43e6f78469692a5e70d851d"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==75.6.0"
+            "version": "==78.1.1"
         },
         "tomli": {
             "hashes": [
@@ -522,11 +522,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
-                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897",
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.2.3"
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "wcmatch": {
             "hashes": [
@@ -1141,11 +1141,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:ca899ca043dcb1bafa3e262d73aa25c465bfb49e0bd9dd5d59f1d0acba2f8fac",
-                "sha256:e7d814a81dad81e6caf2ec9fdedb284ecc9c73076b62654547cc64ccdcae26e9"
+                "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897",
+                "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.2.3"
+            "markers": "python_version >= '3.10'",
+            "version": "==2.7.0"
         },
         "virtualenv": {
             "hashes": [

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -33,13 +33,13 @@ if WHEEL_CMD in sys.argv:
             # For more information about python compatibility tags, check out:
             # https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/
 
-            # We support Python 3.9+
+            # We support Python 3.10+
             # coupling: if you drop support for some python, you'll probably
             # have to update 'python_requires' at the end of this file
             # and a few workflows as show for example in this PR:
             # https://github.com/semgrep/semgrep-proprietary/pull/2606/files
             # coupling: semgrep.libsonnet default_python_version
-            python = "cp39.cp310.cp311.cp312.cp313.py39.py310.py311.py312.py313"
+            python = "cp310.cp311.cp312.cp313.py310.py311.py312.py313"
 
             # We don't require a specific Python ABI
             abi = "none"
@@ -149,7 +149,6 @@ setuptools.setup(
         "License :: OSI Approved :: GNU Lesser General Public License v2 (LGPLv2)",
         "Operating System :: MacOS",
         "Operating System :: POSIX :: Linux",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Topic :: Security",

--- a/cli/setup.py
+++ b/cli/setup.py
@@ -155,6 +155,6 @@ setuptools.setup(
         "Topic :: Security",
         "Topic :: Software Development :: Quality Assurance",
     ],
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     zip_safe=False,
 )


### PR DESCRIPTION
Addresses the security findings flagged by Aikido.

- setuptools 75.6.0 → 78.1.1 (CVE-2025-47273, PackageIndex path traversal).
- urllib3 2.2.3 → 2.7.0 (CVE-2025-50181/50182, CVE-2025-66418/66471, CVE-2026-21441/44431). setup.py `python_requires` and the lock marker bumped to >=3.10 to match urllib3's requires_python.
- Pin sigstore/cosign-installer to 398d4b0 (v3.9.1) instead of the floating @v3 tag.
- Bump semgrep-interfaces submodule (opengrep/semgrep-interfaces#10): removes the Semgrep-coupled compatibility CI job and with it the unpinned marocchino/sticky-pull-request-comment action.
