### PR TITLE
Fix Pipfile package name and skip deleting the join_rule temp file on Windows

### DIFF
--- a/cli/Pipfile
+++ b/cli/Pipfile
@@ -47,4 +47,4 @@ typing_extensions = "*"
 
 [packages]
 jsonschema = "==4.6.1"
-semgrep = {editable = true, path = "."}
+opengrep = {editable = true, path = "."}

--- a/cli/Pipfile.lock
+++ b/cli/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "fda99263664d6c8f2ed80b1bb94aa2737bd7d78fd8ba73da99c754ee6674726c"
+            "sha256": "400c06d975e7ec0b68eaec0fa7dae7647d8864bc52e5eb93fdde20543353b687"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -491,7 +491,7 @@
             "markers": "python_version < '3.13' and platform_python_implementation == 'CPython'",
             "version": "==0.2.12"
         },
-        "semgrep": {
+        "opengrep": {
             "editable": true,
             "markers": "python_version >= '3.8'",
             "path": "."

--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -25,7 +25,6 @@ import semgrep.run_scan
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.config_resolver import Config
 from semgrep.config_resolver import resolve_config
-from semgrep.constants import IS_WINDOWS
 from semgrep.error import ERROR_MAP
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import SemgrepError
@@ -478,19 +477,19 @@ def run_join_rule(
         return [], [e]
 
     # Run Semgrep
-    with tempfile.NamedTemporaryFile(mode='w+', suffix=".yaml", delete=(not IS_WINDOWS)) as rule_path:
+    with tempfile.TemporaryDirectory() as rule_dir:
         # Combine inline rules and refs
         raw_rules = [rule.raw for rule in inline_rules]
         raw_rules.extend([rule.raw for rule in config_map.values()])
-        yaml.dump({"rules": raw_rules}, rule_path)
-        rule_path.flush()
-        rule_path.seek(0)
+        rule_path = Path(rule_dir) / "rules.yaml"
+        with rule_path.open("w") as rule_file:
+            yaml.dump({"rules": raw_rules}, rule_file)
 
         logger.debug(
             f"Running join mode rule {join_rule.get('id')} on {len(targets)} files."
         )
         output = semgrep.run_scan.run_scan_and_return_json(
-            config=Path(rule_path.name),
+            config=rule_path,
             targets=targets,
             no_rewrite_rule_ids=True,
             optimizations="all",

--- a/cli/src/semgrep/join_rule.py
+++ b/cli/src/semgrep/join_rule.py
@@ -25,6 +25,7 @@ import semgrep.run_scan
 import semgrep.semgrep_interfaces.semgrep_output_v1 as out
 from semgrep.config_resolver import Config
 from semgrep.config_resolver import resolve_config
+from semgrep.constants import IS_WINDOWS
 from semgrep.error import ERROR_MAP
 from semgrep.error import FATAL_EXIT_CODE
 from semgrep.error import SemgrepError
@@ -477,7 +478,7 @@ def run_join_rule(
         return [], [e]
 
     # Run Semgrep
-    with tempfile.NamedTemporaryFile() as rule_path:
+    with tempfile.NamedTemporaryFile(mode='w+', suffix=".yaml", delete=(not IS_WINDOWS)) as rule_path:
         # Combine inline rules and refs
         raw_rules = [rule.raw for rule in inline_rules]
         raw_rules.extend([rule.raw for rule in config_map.values()])


### PR DESCRIPTION
I downloaded the project on my windows 10 machine via [install.ps1](https://github.com/opengrep/opengrep/blob/d99f10bda54be12017acb83f57b0056aac297355/install.ps1) and had an issue when running a custom rule with a "join" block (from [elttam/semgrep-rules](https://github.com/elttam/semgrep-rules/blob/main/rules/generic/jsp-likely-xss.yaml)), the issue stack trace:

### Stack Trace
<details>
<summary>Click to expand stack trace</summary>

```text
[Errno 13] Permission denied: 'C:\\Users\\Mitchell\\AppData\\Local\\Temp\\tmpf5qkz1_o'
Traceback (most recent call last):
  File "C:\dev\opengrep-cli\src\semgrep\commands\wrapper.py", line 41, in wrapper
    func(*args, **kwargs)
    ~~~~^^^^^^^^^^^^^^^^^
  File "C:\dev\opengrep-cli\src\semgrep\commands\scan.py", line 855, in scan
    ) = semgrep.run_scan.run_scan(
        ~~~~~~~~~~~~~~~~~~~~~~~~~^
        diff_depth=diff_depth,
        ^^^^^^^^^^^^^^^^^^^^^^
    ...<49 lines>...
        dynamic_timeout_max_multiplier=dynamic_timeout_max_multiplier,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\dev\opengrep-cli\src\semgrep\tracing.py", line 263, in inner
    return f(*args, **kwargs)
  File "C:\dev\opengrep-cli\src\semgrep\run_scan.py", line 831, in run_scan
    ) = run_rules(
        ~~~~~~~~~^
        filtered_rules,
        ^^^^^^^^^^^^^^^
    ...<23 lines>...
        taint_intrafile=taint_intrafile,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\dev\opengrep-cli\src\semgrep\tracing.py", line 263, in inner
    return f(*args, **kwargs)
  File "C:\dev\opengrep-cli\src\semgrep\run_scan.py", line 389, in run_rules
    join_rule_matches, join_rule_errors = join_rule.run_join_rule(
                                          ~~~~~~~~~~~~~~~~~~~~~~~^
        rule.raw,
        ^^^^^^^^^
    ...<2 lines>...
        prioritize_dependency_graph_generation=prioritize_dependency_graph_generation,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\dev\opengrep-cli\src\semgrep\join_rule.py", line 492, in run_join_rule
    output = semgrep.run_scan.run_scan_and_return_json(
        config=Path(rule_path.name),
    ...<4 lines>...
        prioritize_dependency_graph_generation=prioritize_dependency_graph_generation,
    )
  File "C:\dev\opengrep-cli\src\semgrep\run_scan.py", line 1072, in run_scan_and_return_json
    ) = run_scan(
        ~~~~~~~~^
        output_handler=output_handler,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
        **kwargs,
        ^^^^^^^^^
    )
    ^
  File "C:\dev\opengrep-cli\src\semgrep\tracing.py", line 263, in inner
    return f(*args, **kwargs)
  File "C:\dev\opengrep-cli\src\semgrep\run_scan.py", line 631, in run_scan
    configs_obj, config_errors = get_config(
                                 ~~~~~~~~~~^
        pattern,
        ^^^^^^^^
    ...<4 lines>...
        no_rewrite_rule_ids=no_rewrite_rule_ids,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\dev\opengrep-cli\src\semgrep\tracing.py", line 263, in inner
    return f(*args, **kwargs)
  File "C:\dev\opengrep-cli\src\semgrep\config_resolver.py", line 1012, in get_config
    config, errors = Config.from_config_list(
                     ~~~~~~~~~~~~~~~~~~~~~~~^
        config_strs, project_url, force_jsonschema=force_jsonschema
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\dev\opengrep-cli\src\semgrep\tracing.py", line 263, in inner
    return f(*args, **kwargs)
  File "C:\dev\opengrep-cli\src\semgrep\config_resolver.py", line 603, in from_config_list
    resolved_config, config_errors = resolve_config(
                                     ~~~~~~~~~~~~~~^
        config, project_url, force_jsonschema=force_jsonschema
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "C:\dev\opengrep-cli\src\semgrep\tracing.py", line 263, in inner
    return f(*args, **kwargs)
  File "C:\dev\opengrep-cli\src\semgrep\config_resolver.py", line 512, in resolve_config
    config_loader.load_config(), force_jsonschema=force_jsonschema
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\dev\opengrep-cli\src\semgrep\config_resolver.py", line 164, in load_config
    return self._load_config_from_local_path()
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "C:\dev\opengrep-cli\src\semgrep\config_resolver.py", line 241, in _load_config_from_local_path
    config = [read_config_at_path(loc)]
              ~~~~~~~~~~~~~~~~~~~^^^^^
  File "C:\dev\opengrep-cli\src\semgrep\config_resolver.py", line 412, in read_config_at_path
    return ConfigFile(config_id, loc.read_text(), str(loc))
                                 ~~~~~~~~~~~~~^^
  File "C:\Python314\Lib\pathlib\__init__.py", line 787, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors, newline=newline) as f:
         ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Python314\Lib\pathlib\__init__.py", line 771, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: 'C:\\Users\\Mitchell\\AppData\\Local\\Temp\\tmpf5qkz1_o'
```

</details>

The exception originates from [join_rule.py Line 492](https://github.com/opengrep/opengrep/blob/d99f10bda54be12017acb83f57b0056aac297355/cli/src/semgrep/join_rule.py#L492), where semgrep sends the temporary file to `semgrep.run_scan.run_scan_and_return_json()` which tries to read the file via read_config_at_path, but because of the default locks on Windows, read_config_at_path can't access the file and crashes with Errno 13.

To resolve this, I've added a no-delete flag to the NamedTemporaryFile call, and followed the `delete=(not IS_WINDOWS)` pattern used elsewhere in semgrep [core_runner.py Line 836](https://github.com/opengrep/opengrep/blob/d99f10bda54be12017acb83f57b0056aac297355/cli/src/semgrep/core_runner.py#L836), As a future enhancement (perhaps when my temp directory fills up) I'll do a more sophisticated commit where we correctly handle the lifecycle of these temporary files on windows.

Furthermore we've renamed from semgrep to opengrep, and the cli/Pipfile wasn't reflecting that, causing these errors when trying to run `pipenv install --dev` via `make all` on the base directory.

### pipenv install errors
<details>
<summary>Click to expand stack trace</summary>

```text
ERROR: Could not find a version that satisfies the requirement opengrep==1.23.0 (from versions: none)
ERROR: No matching distribution found for opengrep==1.23.0
```

</details>

I've ran the updated code both on my WSL (Ubuntu 18.0.4) and on the windows host, both working fine now.

If you need any further detail or have requests / insist I fixup the temp directory laziness please let me know 👍