### PR TITLE
test(pyopengrep): default --test to no timeout

### DIFF
--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -749,6 +749,24 @@ def scan(
     if test:
         if len(outputs) > 0:
             abort("The --test option doesn't support additional outputs to files.")
+        # The test path defaults to no timeout (0), unlike a real scan:
+        # a slow rule under CI load must not spuriously drop findings and fail a
+        # test. We only honour --timeout / --timeout-threshold here if the user
+        # set them explicitly. coupling: scan's own --timeout default
+        # (DEFAULT_TIMEOUT) is intentionally left unchanged.
+        click_ctx = click.get_current_context()
+        test_timeout = (
+            timeout
+            if click_ctx.get_parameter_source("timeout")
+            != click.core.ParameterSource.DEFAULT
+            else 0
+        )
+        test_timeout_threshold = (
+            timeout_threshold
+            if click_ctx.get_parameter_source("timeout_threshold")
+            != click.core.ParameterSource.DEFAULT
+            else 0
+        )
         # the test code (which isn't a "test" per se but is actually
         # machinery to evaluate semgrep performance) uses
         # managed_output internally
@@ -762,6 +780,8 @@ def scan(
             engine_type=engine_type,
             jobs=jobs,
             taint_intrafile=taint_intrafile,
+            timeout=test_timeout,
+            timeout_threshold=test_timeout_threshold,
         )
 
     filtered_matches_by_rule: RuleMatchMap = {}

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -468,6 +468,8 @@ def generate_test_results(
     optimizations: str = "none",
     jobs: int,
     taint_intrafile: bool = False,
+    timeout: int = 0,
+    timeout_threshold: int = 0,
 ) -> None:
     config_filenames = get_config_filenames(config)
     config_test_filenames = get_config_test_filenames(config, config_filenames, target)
@@ -502,6 +504,8 @@ def generate_test_results(
         strict=strict,
         optimizations=optimizations,
         taint_intrafile=taint_intrafile,
+        timeout=timeout,
+        timeout_threshold=timeout_threshold,
     )
     # XXX: Maybe no need for the pool if jobs = 1.
     cpu_count = multiprocessing.cpu_count()
@@ -598,6 +602,8 @@ def generate_test_results(
         strict=strict,
         optimizations=optimizations,
         taint_intrafile=taint_intrafile,
+        timeout=timeout,
+        timeout_threshold=timeout_threshold,
         # only option that differs from the earlier call to semgrep-core:
         autofix=True,
     )
@@ -723,6 +729,8 @@ def test_main(
     engine_type: EngineType,
     jobs: int,
     taint_intrafile: bool,
+    timeout: int = 0,
+    timeout_threshold: int = 0,
 ) -> None:
     if len(target) != 1:
         raise Exception("only one target directory allowed for tests")
@@ -745,5 +753,7 @@ def test_main(
         engine_type=engine_type,
         optimizations=optimizations,
         jobs=jobs,
-        taint_intrafile=taint_intrafile
+        taint_intrafile=taint_intrafile,
+        timeout=timeout,
+        timeout_threshold=timeout_threshold,
     )


### PR DESCRIPTION
Also honour --timeout/--timeout-threshold there. Avoids a spurious
'rule id mismatch' when a slow rule hits the timeout under load and
drops all its findings on a test file.
