### PR TITLE
JS/TS: Fixes in translation to AST

### DIFF
--- a/languages/javascript/ast/ast_js.ml
+++ b/languages/javascript/ast/ast_js.ml
@@ -422,6 +422,9 @@ and definition_kind =
   | FuncDef of function_definition
   | VarDef of variable_definition
   | ClassDef of class_definition
+  (* TS 'namespace Foo { ... }' / 'module Foo { ... }'; the stmt is the body
+   * block (None for an ambient declaration without a body) *)
+  | ModuleDef of stmt option
   | DefTodo of a_todo_category * any list
 
 and variable_definition = {

--- a/languages/javascript/ast/visitor_js.ml
+++ b/languages/javascript/ast/visitor_js.ml
@@ -363,6 +363,7 @@ let (mk_visitor : visitor_in -> visitor_out) =
     | FuncDef def -> v_function_definition def
     | ClassDef def -> v_class_definition def
     | VarDef def -> v_variable_definition def
+    | ModuleDef body -> v_option v_stmt body
     | DefTodo (v1, v2) ->
         v_todo_category v1;
         v_list v_any v2

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -545,6 +545,20 @@ and definition (ent, def) =
   | ClassDef def ->
       let def, more_attrs = class_ def in
       ({ ent with G.attrs = ent.G.attrs @ more_attrs }, G.ClassDef def)
+  | ModuleDef body ->
+      (* the namespace name is carried by [ent]; leaving the ModuleStruct name
+       * as None avoids binding a metavariable name twice (which would make a
+       * pattern like 'namespace $X { ... }' fail the consistency check) *)
+      let items =
+        match body with
+        | None -> []
+        | Some st -> (
+            let s = stmt st in
+            match s.G.s with
+            | G.Block (_, xs, _) -> xs
+            | _ -> [ s ])
+      in
+      (ent, G.ModuleDef { G.mbody = G.ModuleStruct (None, items) })
   | DefTodo (v1, v2) ->
       let v2 = list any v2 in
       (ent, G.OtherDef (v1, v2))

--- a/languages/javascript/generic/js_to_generic.ml
+++ b/languages/javascript/generic/js_to_generic.ml
@@ -700,7 +700,12 @@ and field_classic
   let vt = option type_ vt in
   let ent =
     match v1 with
-    | Left n -> G.basic_entity n ~attrs:v2
+    | Left n ->
+        (* "()" / "[]" are synthetic names for the (anonymous) call/index
+         * signatures; mark them hidden so they don't pollute the prefilter
+         * (they never appear as literal text in the source). *)
+        let hidden = match fst n with "()" | "[]" -> true | _ -> false in
+        G.basic_entity n ~attrs:v2 ~hidden
     | Right e -> { G.name = G.EDynamic e; attrs = v2; tparams = None }
   in
   match v3 with

--- a/languages/javascript/menhir/parser_js.mly
+++ b/languages/javascript/menhir/parser_js.mly
@@ -950,7 +950,7 @@ annotation: ":" type_ { $2 }
 complex_annotation:
  | annotation { $1 }
  | generics? "(" optl(param_type_list) ")" ":" type_
-     { $6 (* TODO *) }
+     { TyFun ($3, Some $6) }
 
 (*----------------------------*)
 (* Types *)
@@ -964,7 +964,7 @@ type_:
  | primary_or_union_type { $1 }
  | "?" type_             { TyQuestion ($1, $2) }
  | T_LPAREN_ARROW optl(param_type_list) ")" "->" type_
-   { $5 (* TODO *) }
+   { TyFun ($2, Some $5) }
 
 primary_or_union_type:
  | primary_or_intersect_type { $1 }
@@ -1072,16 +1072,22 @@ param_type_list:
  | optional_param_type_list           { $1 }
 
 (* partial type annotations are not supported *)
-param_type: id complex_annotation { () (* TODO *) }
+param_type: id complex_annotation
+  { ParamClassic { p_name = $1; p_default = None; p_type = Some $2;
+                   p_dots = None; p_attrs = [] } }
 
-optional_param_type: id "?" complex_annotation { () }
+optional_param_type: id "?" complex_annotation
+  { ParamClassic { p_name = $1; p_default = None; p_type = Some $3;
+                   p_dots = None; p_attrs = [] } }
 
 optional_param_type_list:
  | optional_param_type "," optional_param_type_list { $1::$3 }
  | optional_param_type       { [$1] }
  | rest_param_type           { [$1] }
 
-rest_param_type: "..." id complex_annotation { () (* TODO *) }
+rest_param_type: "..." id complex_annotation
+  { ParamClassic { p_name = $2; p_default = None; p_type = Some $3;
+                   p_dots = Some $1; p_attrs = [] } }
 
 (*----------------------------*)
 (* Type parameters (type variables) *)

--- a/languages/javascript/menhir/parser_js.mly
+++ b/languages/javascript/menhir/parser_js.mly
@@ -895,10 +895,10 @@ method_get_set_star:
 
 interface_decl: T_INTERFACE binding_id generics? optl(interface_extends)
   object_type
-   { let (t1, _xsTODO, t2) = $5 in
+   { let (t1, xs, t2) = $5 in
       Some $2, ClassDef { c_kind = G.Interface, $1;
       c_extends = $4; c_implements = []; c_attrs = [];
-      c_body = (t1, [], t2) } }
+      c_body = (t1, List_.map (fun x -> Field x) xs, t2) } }
 
 interface_extends: T_EXTENDS listc(type_reference)
   { $2 |> List.map (fun t -> Right t) }
@@ -1041,13 +1041,21 @@ type_member:
  | property_name_typescript "?" complex_annotation sc_or_comma
     { { fld_name = $1; fld_attrs = [attr (Optional, $2)]; fld_type = Some $3;
         fld_body = None } }
+ (* index signature; mirror the tree-sitter shape so patterns match targets:
+  * an "[]" field whose type is TypeTodo("Indexsig", [key; value]) *)
  | "[" T_ID ":" T_STRING_TYPE "]" complex_annotation sc_or_comma
-    { let fld_name = PN ("IndexMethod??TODO?", $1) in
-      { fld_name; fld_attrs = []; fld_type = Some $6; fld_body = None}
+    { let key = TypeTodo (("IndexKey", $3),
+                  [Type (TyName [$2]); Type (TyName [("string", $4)])]) in
+      let ty = TypeTodo (("Indexsig", $1), [Type key; Type $6]) in
+      { fld_name = PN ("[]", $1); fld_attrs = []; fld_type = Some ty;
+        fld_body = None }
     }
  | "[" T_ID ":" T_NUMBER_TYPE "]" complex_annotation sc_or_comma
-    { let fld_name = PN ("IndexMethod??TODO?", $1) in
-      { fld_name; fld_attrs = []; fld_type = Some $6; fld_body = None}
+    { let key = TypeTodo (("IndexKey", $3),
+                  [Type (TyName [$2]); Type (TyName [("number", $4)])]) in
+      let ty = TypeTodo (("Indexsig", $1), [Type key; Type $6]) in
+      { fld_name = PN ("[]", $1); fld_attrs = []; fld_type = Some ty;
+        fld_body = None }
     }
 
 (* no [xxx] here *)

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -2550,7 +2550,10 @@ and anon_choice_export_stmt_f90d83f (env : env)
   | `Call_sign_ x ->
       let _tparams, x = call_signature env x in
       let ty = mk_functype x in
-      let name = PN ("CTOR??TODO", fake) in
+      (* an (anonymous) call signature '(args): T'; name it after the call
+       * operator, like C++ names 'operator()' *)
+      let lp, _, _ = fst x in
+      let name = PN ("()", lp) in
       let fld =
         { fld_name = name; fld_attrs = []; fld_type = Some ty; fld_body = None }
       in
@@ -2576,7 +2579,10 @@ and anon_choice_export_stmt_f90d83f (env : env)
       Left (Field fld)
   | `Index_sign x ->
       let ty = index_signature env x in
-      let name = PN ("IndexMethod??TODO?", fake) in
+      (* an (anonymous) index signature '[k: K]: V'; name it after the index
+       * operator *)
+      let _, lb, _, _, _ = x in
+      let name = PN ("[]", token env lb) in
       let fld =
         { fld_name = name; fld_attrs = []; fld_type = Some ty; fld_body = None }
       in

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -2331,6 +2331,32 @@ and array_ (env : env) ((v1, v2, v3) : CST.array_) =
   let v3 = token env v3 (* "]" *) in
   Arr (v1, v2, v3)
 
+(* 'export { a, b as c } from "mod"': desugar each specifier into an import of
+ * the name from 'mod', a local const, and an export of it. *)
+and reexport_specifiers export_tok (tok2, path) names =
+  names
+  |> List.concat_map (fun (n1, n2opt) ->
+         let tmpname = ("!tmp_" ^ fst n1, snd n1) in
+         let import = Import (tok2, [ (n1, Some tmpname) ], path) in
+         let e = idexp tmpname in
+         match n2opt with
+         | None ->
+             let v = Ast_js.mk_const_var n1 e in
+             [ M import; DefStmt v; M (Export (export_tok, n1)) ]
+         | Some n2 ->
+             let v = Ast_js.mk_const_var n2 e in
+             [ M import; DefStmt v; M (Export (export_tok, n2)) ])
+
+(* 'export { a, b as c }': export the local names (aliasing via a const). *)
+and export_specifiers_local export_tok names =
+  names
+  |> List.concat_map (fun (n1, n2opt) ->
+         match n2opt with
+         | None -> [ M (Export (export_tok, n1)) ]
+         | Some n2 ->
+             let v = Ast_js.mk_const_var n2 (idexp n1) in
+             [ DefStmt v; M (Export (export_tok, n2)) ])
+
 and export_statement (env : env) (x : CST.export_statement) : stmt list =
   match x with
   | `Choice_export_choice_STAR_from_clause_choice_auto_semi x -> (
@@ -2357,33 +2383,14 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
             | `Export_clause_from_clause_choice_auto_semi (v1, v2, v3) ->
                 (* export { name1, name2, nameN } from 'foo'; *)
                 let v1 = export_clause env v1 in
-                let tok2, path = from_clause env v2 in
+                let from = from_clause env v2 in
                 let _v3 = semicolon env v3 in
-                v1
-                |> List.concat_map (fun (n1, n2opt) ->
-                       let tmpname = ("!tmp_" ^ fst n1, snd n1) in
-                       let import =
-                         Import (tok2, [ (n1, Some tmpname) ], path)
-                       in
-                       let e = idexp tmpname in
-                       match n2opt with
-                       | None ->
-                           let v = Ast_js.mk_const_var n1 e in
-                           [ M import; DefStmt v; M (Export (export_tok, n1)) ]
-                       | Some n2 ->
-                           let v = Ast_js.mk_const_var n2 e in
-                           [ M import; DefStmt v; M (Export (export_tok, n2)) ])
+                reexport_specifiers export_tok from v1
             | `Export_clause_choice_auto_semi (v1, v2) ->
                 (* export { import1 as name1, import2 as name2, nameN } from 'foo'; *)
                 let v1 = export_clause env v1 in
                 let _v2 = semicolon env v2 in
-                v1
-                |> List.concat_map (fun (n1, n2opt) ->
-                       match n2opt with
-                       | None -> [ M (Export (export_tok, n1)) ]
-                       | Some n2 ->
-                           let v = Ast_js.mk_const_var n2 (idexp n1) in
-                           [ DefStmt v; M (Export (export_tok, n2)) ])
+                export_specifiers_local export_tok v1
           in
           v2
       | `Rep_deco_export_choice_decl (v1, v2, v3) ->
@@ -2441,29 +2448,34 @@ and export_statement (env : env) (x : CST.export_statement) : stmt list =
           in
           v3)
   | `Export_type_export_clause_opt_from_clause_choice_auto_semi
-      (v1, v2, v3, _v4, v5) ->
-      let _export = token env v1 (* "export" *) in
+      (v1, v2, v3, v4, v5) ->
+      (* export type { foo, type bar } [from 'mod']; we model type re-exports
+       * like value re-exports (the type-only distinction is dropped). *)
+      let export_tok = token env v1 (* "export" *) in
       let _type = token env v2 (* "type" *) in
-      let _exported_types = export_clause env v3 in
-      (* TODO v4 from_clause *)
+      let names = export_clause env v3 in
       let _sc = semicolon env v5 in
-      (* TODO: 'export type { foo, type bar, typeof thing };' *)
-      []
+      (match v4 with
+      | Some from_cl -> reexport_specifiers export_tok (from_clause env from_cl) names
+      | None -> export_specifiers_local export_tok names)
   | `Export_EQ_exp_choice_auto_semi (v1, v2, v3, v4) ->
-      let _v1 = token env v1 (* "export" *) in
-      let _v2 = token env v2 (* "=" *) in
-      let _v3 = expression env v3 in
+      (* export = ZipCodeValidator; (TS/CommonJS export assignment), modeled
+       * like a default export of the expression. *)
+      let export_tok = token env v1 (* "export" *) in
+      let teq = token env v2 (* "=" *) in
+      let e = expression env v3 in
       let _v4 = semicolon env v4 in
-      (* TODO 'export = ZipCodeValidator;' *)
-      []
+      let def, n = Ast_js.mk_default_entity_def teq e in
+      [ DefStmt def; M (Export (export_tok, n)) ]
   | `Export_as_name_id_choice_auto_semi (v1, v2, v3, v4, v5) ->
-      let _v1 = token env v1 (* "export" *) in
+      (* export as namespace mathLib; (UMD global). We record the exported
+       * global name. *)
+      let export_tok = token env v1 (* "export" *) in
       let _v2 = token env v2 (* "as" *) in
       let _v3 = token env v3 (* "namespace" *) in
-      let _v4 = token env v4 (* identifier *) in
+      let id = identifier env v4 (* identifier *) in
       let _v5 = semicolon env v5 in
-      (* TODO 'export as namespace mathLib;' *)
-      []
+      [ M (Export (export_tok, id)) ]
 
 and type_annotation (env : env) ((v1, v2) : CST.type_annotation) =
   let v1 = token env v1 (* ":" *) in

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -1046,29 +1046,32 @@ and class_body (env : env) ((v1, v2, v3) : CST.class_body) :
             in
             add_decorators (List.rev acc_decorators) v1 :: aux [] xs
         | `Meth_sign_choice_func_sign_auto_semi (v1, v2) ->
-            let _v1 = method_signature env v1 in
+            let v1 = method_signature env v1 in
             let _v2 =
               match v2 with
               | `Func_sign_auto_semi tok ->
                   (* function_signature_automatic_semicolon *) token env tok
               | `COMMA tok -> (* "," *) token env tok
             in
-            (* TODO: types *)
-            aux [] xs
+            add_decorators (List.rev acc_decorators) (Field v1) :: aux [] xs
         | `Choice_abst_meth_sign_choice_choice_auto_semi (v1, v2) -> (
             let v1 =
               match v1 with
               | `Abst_meth_sign x ->
-                  (* TODO: types *)
                   let v = abstract_method_signature env x in
                   Some (Field v)
               | `Index_sign x ->
-                  let _t = index_signature env x in
-                  None
-              | `Meth_sign x ->
-                  (* TODO: types *)
-                  let _v = method_signature env x in
-                  None
+                  let ty = index_signature env x in
+                  let _, lb, _, _, _ = x in
+                  Some
+                    (Field
+                       {
+                         fld_name = PN ("[]", token env lb);
+                         fld_attrs = [];
+                         fld_type = Some ty;
+                         fld_body = None;
+                       })
+              | `Meth_sign x -> Some (Field (method_signature env x))
               | `Public_field_defi x -> Some (public_field_definition env x)
             in
             let _v2 =
@@ -3142,8 +3145,7 @@ and declaration (env : env) (x : CST.declaration) : definition list =
       let xs =
         xs
         |> List_.filter_map (function
-             (* TODO *)
-             | Left _fld -> None
+             | Left fld -> Some fld
              | Right _sts -> None)
       in
       let c =

--- a/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
+++ b/languages/typescript/tree-sitter/Parse_typescript_tree_sitter.ml
@@ -2125,9 +2125,17 @@ and statement (env : env) (x : CST.statement) : stmt list =
       let v1 = identifier env v1 (* "debugger" *) in
       let v2 = semicolon env v2 in
       [ ExprStmt (idexp v1, v2) ]
-  | `Exp_stmt x ->
-      let e, t = expression_statement env x in
-      [ ExprStmt (e, t) ]
+  | `Exp_stmt x -> (
+      (* tree-sitter parses a top-level 'namespace Foo { ... }' as an
+       * expression-statement; intercept it so it becomes a proper module
+       * definition instead of an IIFE. *)
+      match x with
+      | `Exp (`Inte_module im), _semi ->
+          let id, opt_body = internal_module env im in
+          [ DefStmt (basic_entity id, ModuleDef opt_body) ]
+      | _ ->
+          let e, t = expression_statement env x in
+          [ ExprStmt (e, t) ])
   | `Decl x ->
       let vars = declaration env x in
       vars |> List_.map (fun x -> DefStmt x)
@@ -3079,16 +3087,14 @@ and declaration (env : env) (x : CST.declaration) : definition list =
       in
       [ (basic_entity v4, ClassDef c) ]
   | `Module (v1, v2) ->
-      (* does this exist only in .d.ts files? *)
+      (* 'module Foo { ... }' (ambient module, often in .d.ts) *)
       let _v1 = token env v1 (* "module" *) in
-      let _id, _opt_body = module__ env v2 in
-      []
-      (* TODO *)
+      let id, opt_body = module__ env v2 in
+      [ (basic_entity id, ModuleDef opt_body) ]
   | `Inte_module x ->
-      (* namespace *)
-      let _x = internal_module env x in
-      []
-      (* TODO *)
+      (* 'namespace Foo { ... }' *)
+      let id, opt_body = internal_module env x in
+      [ (basic_entity id, ModuleDef opt_body) ]
   | `Type_alias_decl (v1, v2, v3, v4, v5, v6) ->
       let typekwd = token env v1 (* "type" *) in
       let id = str env v2 (* identifier *) in

--- a/tests/patterns/ts/class_method_sig.sgrep
+++ b/tests/patterns/ts/class_method_sig.sgrep
@@ -1,0 +1,1 @@
+declare class $C { danger(): void; }

--- a/tests/patterns/ts/class_method_sig.ts
+++ b/tests/patterns/ts/class_method_sig.ts
@@ -1,0 +1,7 @@
+// MATCH:
+declare class HasSig {
+  danger(): void;
+}
+declare class Safe {
+  ok(): void;
+}

--- a/tests/patterns/ts/export_assignment.sgrep
+++ b/tests/patterns/ts/export_assignment.sgrep
@@ -1,0 +1,1 @@
+export = $X

--- a/tests/patterns/ts/export_assignment.ts
+++ b/tests/patterns/ts/export_assignment.ts
@@ -1,0 +1,3 @@
+// 'export = X' (TS/CommonJS export assignment) is now represented
+// MATCH:
+export = ZipCodeValidator;

--- a/tests/patterns/ts/export_type_reexport.sgrep
+++ b/tests/patterns/ts/export_type_reexport.sgrep
@@ -1,0 +1,1 @@
+import { Foo } from "./types"

--- a/tests/patterns/ts/export_type_reexport.ts
+++ b/tests/patterns/ts/export_type_reexport.ts
@@ -1,0 +1,4 @@
+// 'export type { X } from "mod"' desugars to imports, so the re-exported
+// name is visible to import rules
+// MATCH:
+export type { Foo } from './types';

--- a/tests/patterns/ts/function_type.sgrep
+++ b/tests/patterns/ts/function_type.sgrep
@@ -1,0 +1,1 @@
+type $T = () => string;

--- a/tests/patterns/ts/function_type.ts
+++ b/tests/patterns/ts/function_type.ts
@@ -1,0 +1,3 @@
+// MATCH:
+type StringFactory = () => string;
+type NumberFactory = () => number;

--- a/tests/patterns/ts/index_signature.sgrep
+++ b/tests/patterns/ts/index_signature.sgrep
@@ -1,0 +1,1 @@
+interface $I { [$K: string]: number; }

--- a/tests/patterns/ts/index_signature.ts
+++ b/tests/patterns/ts/index_signature.ts
@@ -1,0 +1,3 @@
+// MATCH:
+interface StrKeys { [key: string]: number; }
+interface Other { plain: boolean; }

--- a/tests/patterns/ts/interface_member.sgrep
+++ b/tests/patterns/ts/interface_member.sgrep
@@ -1,0 +1,1 @@
+interface $I { token: string; }

--- a/tests/patterns/ts/interface_member.ts
+++ b/tests/patterns/ts/interface_member.ts
@@ -1,0 +1,7 @@
+// MATCH:
+interface HasToken {
+  token: string;
+}
+interface Other {
+  count: number;
+}

--- a/tests/patterns/ts/namespace.sgrep
+++ b/tests/patterns/ts/namespace.sgrep
@@ -1,0 +1,1 @@
+namespace $X { ... }

--- a/tests/patterns/ts/namespace.ts
+++ b/tests/patterns/ts/namespace.ts
@@ -1,0 +1,5 @@
+// a TS namespace is now a real module definition (not an IIFE)
+// MATCH:
+namespace MyApp {
+  export const version = 1;
+}


### PR DESCRIPTION
Fixes several JS/TS translation gaps where TypeScript constructs were dropped, given placeholder names, or parsed inconsistently between the two parsers (tree-sitter for targets, menhir for patterns) — making them unmatchable. Where needed, fixes were applied to both parsers so patterns and targets produce the same generic AST.

**Changes**
- **Exports:** `export type { … }`, `export = X`, and `export as namespace X` now produce AST instead of being dropped.
- **Namespaces/modules:** now translate to `ModuleDef` instead of a fake IIFE; `namespace $X { … }` binds correctly.
- **Call/index signatures:** replaced placeholder names `CTOR??TODO` / `IndexMethod??TODO?` with `()` / `[]` and real tokens (similarly to other languages with `operator()`-style constructs),
- **Interface/class members:** interface bodies were emptied (matched vacuously) and class method/index signatures were dropped — both now preserved.
- **Index-signature matching** (`[k: string]: V`) now works in interfaces and classes with literal and metavariable keys/values, enforcing key and value types.
- **Function types:** the pattern parser dropped the `TyFun` wrapper for `(): T` / `() => T`, so `$F(): string` and `type $T = () => string` couldn't match — now built correctly.

