### PR TITLE
Dart: Add support for `taint-intrafile`

### DIFF
--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -824,6 +824,7 @@ let check_rules ~match_hook
          | Lang.Cpp
          | Lang.Crystal
          | Lang.Csharp
+         | Lang.Dart
          | Lang.Elixir
          | Lang.Go
          | Lang.Java

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -769,7 +769,7 @@ let o_taint_intrafile : bool Term.t =
     Arg.info [ "taint-intrafile" ]
       ~doc:
         ("Enable intra-file inter-procedural taint analysis. \
-          Supported languages: Apex, C, Clojure, C#, C++, Elixir, Go, Java, JavaScript, Julia, Kotlin, Lua, Python, Ruby, Rust, Scala, Swift, TypeScript, Visual Basic. \
+          Supported languages: Apex, C, Clojure, C#, C++, Dart, Elixir, Go, Java, JavaScript, Julia, Kotlin, Lua, Python, Ruby, Rust, Scala, Swift, TypeScript, Visual Basic. \
           Other languages will fall back to intraprocedural analysis only.")
   in
   Arg.value (Arg.flag info)

--- a/src/osemgrep/cli_test/Test_CLI.ml
+++ b/src/osemgrep/cli_test/Test_CLI.ml
@@ -129,7 +129,7 @@ let o_taint_intrafile : bool Term.t =
     Arg.info [ "taint-intrafile" ]
       ~doc:
         ("Enable intra-file inter-procedural taint analysis. \
-          Supported languages: Apex, C, C#, C++, Elixir, Go, Java, JavaScript, Julia, Kotlin, Lua, Python, Ruby, Rust, Scala, Swift, TypeScript. \
+          Supported languages: Apex, C, Clojure, C#, C++, Dart, Elixir, Go, Java, JavaScript, Julia, Kotlin, Lua, Python, Ruby, Rust, Scala, Swift, TypeScript, Visual Basic. \
           Other languages will fall back to intraprocedural analysis only.")
   in
   Arg.value (Arg.flag info)

--- a/src/tainting/Graph_from_AST.ml
+++ b/src/tainting/Graph_from_AST.ml
@@ -391,9 +391,12 @@ let identify_callee ~(lang : Lang.t) ?(object_mappings = []) ?(all_funcs = [])
               (* Python/Kotlin/Scala: ClassName(args) *)
               | G.Call ({ e = G.N (G.Id ((cn, _), _)); _ }, _)
                 when Lang.(lang =*= Python || lang =*= Kotlin || lang =*= Scala) -> Some cn
-              (* Java/JS/TS/C#: new ClassName(args) *)
+              (* Java/JS/TS/C#: new ClassName(args)
+                 Dart: ClassName(args) — the parser produces G.New even
+                 without the (optional) `new` keyword *)
               | G.New (_, ty, _, _)
-                when Lang.(lang =*= Java || lang =*= Js || lang =*= Ts || lang =*= Csharp) ->
+                when Lang.(lang =*= Java || lang =*= Js || lang =*= Ts || lang =*= Csharp
+                           || lang =*= Dart) ->
                   (match ty.G.t with
                   | G.TyN (G.Id ((cn, _), _)) -> Some cn
                   | G.TyExpr { G.e = G.N (G.Id ((cn, _), _)); _ } -> Some cn

--- a/src/tainting/Lang_config.ml
+++ b/src/tainting/Lang_config.ml
@@ -366,11 +366,34 @@ let lua = {
 }
 
 let dart = {
-  hof_configs = [];
-  collection_configs = [];
-  constructor_names = ["constructor"];
+  hof_configs = [
+    MethodHOF {
+      methods = ["map"; "where"; "forEach"; "expand"; "firstWhere";
+                 "lastWhere"; "any"; "every"; "removeWhere"; "retainWhere"];
+      arity = 1;
+      taint_arg_index = 0;
+    };
+    (* reduce(combine) - combine(value, element), the element (arg 1) comes
+       from the collection *)
+    MethodHOF { methods = ["reduce"]; arity = 1; taint_arg_index = 1 };
+  ];
+  collection_configs = [
+    (* List.add, Set.add, List.addAll, Map.addEntries - item taints this *)
+    ArgTaintsThis { methods = ["add"; "addAll"; "addEntries"]; arity = 1; taint_arg_index = 0; returns_this = false };
+    (* List.insert(index, item) - item taints this *)
+    ArgTaintsThis { methods = ["insert"; "insertAll"]; arity = 2; taint_arg_index = 1; returns_this = false };
+    (* StringBuffer.write/writeln/writeAll - str taints this *)
+    ArgTaintsThis { methods = ["write"; "writeln"; "writeAll"]; arity = 1; taint_arg_index = 0; returns_this = false };
+    (* accessors - this taints return *)
+    ThisTaintsReturn { methods = ["removeLast"; "toString"; "join"; "toList"; "toSet"]; arity = 0 };
+    ThisTaintsReturn { methods = ["removeAt"; "elementAt"; "remove"; "join"]; arity = 1 };
+  ];
+  (* Dart constructors are class-named (User.User), which is_constructor
+     covers via the class-name equality check *)
+  constructor_names = [];
   uses_new_keyword = false;
-  invoke_methods = [];
+  (* Function objects: f.call(args) invokes the closure f *)
+  invoke_methods = ["call"];
 }
 
 let elixir = {

--- a/tests/rules/cross_function_tainting/test_collection_models_dart.dart
+++ b/tests/rules/cross_function_tainting/test_collection_models_dart.dart
@@ -1,0 +1,43 @@
+// Built-in collection and StringBuffer models: mutators taint the receiver,
+// accessors propagate the receiver's taint to their return value.
+
+void testListAdd() {
+  var list = <String>[];
+  list.add(source());
+  // ruleid: test-collection-models-dart
+  sink(list.join(","));
+}
+
+void testListInsert() {
+  var list = <String>[];
+  list.insert(0, source());
+  // ruleid: test-collection-models-dart
+  sink(list.removeAt(0));
+}
+
+void testListAddAll() {
+  var list = <String>[];
+  list.addAll([source()]);
+  // ruleid: test-collection-models-dart
+  sink(list.elementAt(0));
+}
+
+void testListFirst() {
+  var list = <String>[];
+  list.add(source());
+  // ruleid: test-collection-models-dart
+  sink(list.first);
+}
+
+void testStringBuffer() {
+  var buf = StringBuffer();
+  buf.writeln(source());
+  // ruleid: test-collection-models-dart
+  sink(buf.toString());
+}
+
+void testCleanCollection() {
+  var list = <String>[];
+  list.add("clean");
+  sink(list.join(","));
+}

--- a/tests/rules/cross_function_tainting/test_collection_models_dart.yaml
+++ b/tests/rules/cross_function_tainting/test_collection_models_dart.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-collection-models-dart
+    message: Taint flows through built-in collection methods
+    languages:
+      - dart
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_dart_constructor.dart
+++ b/tests/rules/cross_function_tainting/test_dart_constructor.dart
@@ -1,0 +1,49 @@
+class TaintedUser {
+  String key;
+
+  TaintedUser(String seller) {
+    this.key = source();
+  }
+
+  void props() {
+    // ruleid: dart_constructor_taint
+    sink(this.key);
+  }
+}
+
+class User {
+  String name;
+
+  User(String userName) {
+    this.name = userName;
+  }
+
+  String getProfile() {
+    return this.name;
+  }
+}
+
+void testImplicitNew() {
+  var taintedInput = source();
+  var user = User(taintedInput);
+  // ruleid: dart_constructor_taint
+  sink(user.getProfile());
+}
+
+void testExplicitNew() {
+  var taintedInput = source();
+  var user = new User(taintedInput);
+  // ruleid: dart_constructor_taint
+  sink(user.getProfile());
+}
+
+void testChainedConstructorCall() {
+  var profile = User(source()).getProfile();
+  // ruleid: dart_constructor_taint
+  sink(profile);
+}
+
+void testCleanConstructor() {
+  var user = User("clean");
+  sink(user.getProfile());
+}

--- a/tests/rules/cross_function_tainting/test_dart_constructor.yaml
+++ b/tests/rules/cross_function_tainting/test_dart_constructor.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: dart_constructor_taint
+    message: Tainted data flows through a constructor to a sink
+    languages:
+      - dart
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_hof_comprehensive_dart.dart
+++ b/tests/rules/cross_function_tainting/test_hof_comprehensive_dart.dart
@@ -1,0 +1,110 @@
+// Comprehensive HOF test for Dart: custom and built-in higher-order functions
+// All annotated sinks should detect taint flow from source() to sink()
+
+// ===== Custom HOF functions =====
+
+List customMap(List arr, Function callback) {
+  var result = [];
+  for (var item in arr) {
+    result.add(callback(item));
+  }
+  return result;
+}
+
+void customForEach(List arr, Function callback) {
+  for (var item in arr) {
+    callback(item);
+  }
+}
+
+void directCall(Function callback, value) {
+  callback(value);
+}
+
+// ===== Custom HOF test cases =====
+
+void testCustomMap() {
+  var arr = [source()];
+  customMap(arr, (x) {
+    // ruleid: test-hof-taint
+    sink(x);
+    return x;
+  });
+}
+
+void testCustomForEach() {
+  var arr = [source()];
+  customForEach(arr, (x) {
+    // ruleid: test-hof-taint
+    sink(x);
+  });
+}
+
+void testDirectCall() {
+  directCall((x) {
+    // ruleid: test-hof-taint
+    sink(x);
+  }, source());
+}
+
+// ===== Built-in iterable methods =====
+
+void testBuiltinMap() {
+  var arr = [source()];
+  arr.map((x) {
+    // ruleid: test-hof-taint
+    sink(x);
+    return x;
+  });
+}
+
+void testBuiltinForEach() {
+  var arr = [source()];
+  arr.forEach((x) {
+    // ruleid: test-hof-taint
+    sink(x);
+  });
+}
+
+void testBuiltinWhere() {
+  var arr = [source()];
+  arr.where((x) {
+    // ruleid: test-hof-taint
+    sink(x);
+    return true;
+  });
+}
+
+void testBuiltinReduce() {
+  var arr = [source()];
+  arr.reduce((acc, element) {
+    // ruleid: test-hof-taint
+    sink(element);
+    return acc;
+  });
+}
+
+// ===== Tear-offs (function references as callbacks) =====
+
+void handler(x) {
+  // ruleid: test-hof-taint
+  sink(x);
+}
+
+void testBuiltinTearoff() {
+  var arr = [source()];
+  arr.forEach(handler);
+}
+
+void testCustomTearoff() {
+  customForEach([source()], handler);
+}
+
+// ===== Chained HOF result =====
+
+void testMapChainResult() {
+  var input = source();
+  var mapped = [input].map((e) => e).toList();
+  // ruleid: test-hof-taint
+  sink(mapped);
+}

--- a/tests/rules/cross_function_tainting/test_hof_comprehensive_dart.yaml
+++ b/tests/rules/cross_function_tainting/test_hof_comprehensive_dart.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-hof-taint
+    message: Taint should flow through higher-order functions (custom and built-in)
+    languages:
+      - dart
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_interprocedural_dart.dart
+++ b/tests/rules/cross_function_tainting/test_interprocedural_dart.dart
@@ -1,0 +1,35 @@
+String helperSource() {
+  return source();
+}
+
+void helperToSink(String x) {
+  // ruleid: test-interprocedural-dart
+  sink(x);
+}
+
+String helperFlow(String x) {
+  var y = x;
+  return y;
+}
+
+String nestedFlow(String input) {
+  String inner(String v) {
+    return v;
+  }
+
+  return inner(input);
+}
+
+void main() {
+  var input = helperSource();
+  var x = helperFlow(input);
+  helperToSink(x);
+  // ruleid: test-interprocedural-dart
+  sink(nestedFlow(input));
+}
+
+void mainClean() {
+  var x = helperFlow("clean");
+  sink(x);
+  sink(nestedFlow("clean"));
+}

--- a/tests/rules/cross_function_tainting/test_interprocedural_dart.yaml
+++ b/tests/rules/cross_function_tainting/test_interprocedural_dart.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-interprocedural-dart
+    message: Interprocedural taint flow detected from source to sink
+    languages:
+      - dart
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - pattern: source(...)
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/rules/cross_function_tainting/test_invoke_methods_dart.dart
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_dart.dart
@@ -1,0 +1,25 @@
+// Dart function objects can be invoked explicitly through .call()
+
+void testClosureCall() {
+  var f = (String s) {
+    // ruleid: test-invoke-methods-dart
+    sink(s);
+  };
+  f.call(source());
+}
+
+void testClosureCallFlow() {
+  var pass = (String s) {
+    return s;
+  };
+  var out = pass.call(source());
+  // ruleid: test-invoke-methods-dart
+  sink(out);
+}
+
+void testCleanClosureCall() {
+  var f = (String s) {
+    return s;
+  };
+  sink(f.call("clean"));
+}

--- a/tests/rules/cross_function_tainting/test_invoke_methods_dart.yaml
+++ b/tests/rules/cross_function_tainting/test_invoke_methods_dart.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-invoke-methods-dart
+    message: Taint flows through a closure invoked via .call()
+    languages:
+      - dart
+    severity: WARNING
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
Adds Dart to the languages supported by `--taint-intrafile`.