### PR TITLE
Matching: Match statement-sequence patterns against every class member

### DIFF
--- a/libs/commons/List_.ml
+++ b/libs/commons/List_.ml
@@ -312,6 +312,10 @@ let span (p : 'a -> bool) xs =
   let acc_left, right = span [] xs in
   (List.rev acc_left, right)
 
+let rec suffixes = function
+  | [] -> [ [] ]
+  | _ :: tl as xs -> xs :: suffixes tl
+
 let rec take_safe n xs =
   match (n, xs) with
   | 0, _ -> []

--- a/libs/commons/List_.mli
+++ b/libs/commons/List_.mli
@@ -147,6 +147,10 @@ val drop : int -> 'a list -> 'a list
    predicate. *)
 val span : ('a -> bool) -> 'a list -> 'a list * 'a list
 
+(* All suffixes of a list, longest first, including the empty list:
+   suffixes [1;2;3] = [[1;2;3]; [2;3]; [3]; []]. *)
+val suffixes : 'a list -> 'a list list
+
 (* zip a list with an increasing list of numbers.
  * e.g., index_list ["a"; "b"] -> ["a", 0; "b", 1].
  * An alternative is to use functions like List.iteri.

--- a/src/engine/tests/Unit_engine.ml
+++ b/src/engine/tests/Unit_engine.ml
@@ -627,6 +627,7 @@ let lang_tainting_tests () =
       (Lang.Go, "go", ".go");
       (Lang.Java, "java", ".java");
       (Lang.Js, "js", ".js");
+      (Lang.Kotlin, "kotlin", ".kt");
       (Lang.Php, "php", ".php");
       (Lang.Python, "python", ".py");
       (Lang.Ruby, "ruby", ".rb");

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -472,6 +472,42 @@ class ['self] check_visitor range_filter m_env has_as_metavariable
           | _ -> super#visit_stmt env x)
       | _ -> super#visit_stmt env x
           
+    (* Report the matches found by a statement-sequence rule (shared by
+       [v_stmts] and [v_fields]). *)
+    method private report_stmts_matches rule matches_with_env =
+      matches_with_env
+      |> List.iter (fun (env : MG.tin) ->
+             let matched = env.stmts_matched in
+             match location_stmts matched with
+             | None -> () (* empty sequence or bug *)
+             | Some range_loc ->
+                 let mv = env.mv in
+                 let tokens = lazy (list_original_tokens_stmts matched) in
+                 let rule_id = rule_id_of_mini_rule rule in
+                 let pm =
+                   {
+                     PM.rule_id;
+                     path;
+                     env = mv;
+                     range_loc;
+                     (* as-metavariable: *)
+                     ast_node =
+                       (if has_as_metavariable then Some (Ss matched) else None);
+                     enclosure = Option.map (!) enclosure;
+                     tokens;
+                     taint_trace = None;
+                     engine_of_match = `OSS;
+                     validation_state = `No_validator;
+                     severity_override = None;
+                     metadata_override = None;
+                     sca_match = None;
+                     fix_text = None;
+                     facts = [];
+                   }
+                 in
+                 Stack_.push pm mp_env.matches;
+                 hook pm)
+
     method! v_stmts env x =
       (* this is potentially slower than what we did in Coccinelle with
        * CTL. We try every sequences. Hopefully the first statement in
@@ -485,45 +521,8 @@ class ['self] check_visitor range_filter m_env has_as_metavariable
       stmts_rules
       |> List.iter (fun (pattern, rule) ->
              Profiling.profile_code "Semgrep_generic.kstmts" (fun () ->
-                 let matches_with_env =
-                   match_sts_sts rule pattern x m_env
-                 in
-                 matches_with_env
-                 |> List.iter (fun (env : MG.tin) ->
-                        let matched = env.stmts_matched in
-                        match location_stmts matched with
-                        | None -> () (* empty sequence or bug *)
-                        | Some range_loc ->
-                            let mv = env.mv in
-                            let tokens =
-                              lazy (list_original_tokens_stmts matched)
-                            in
-                            let rule_id = rule_id_of_mini_rule rule in
-                            let pm =
-                              {
-                                PM.rule_id;
-                                path;
-                                env = mv;
-                                range_loc;
-                                (* as-metavariable: *)
-                                ast_node =
-                                  (if has_as_metavariable then
-                                     Some (Ss matched)
-                                   else None);
-                                enclosure = Option.map (!) enclosure;
-                                tokens;
-                                taint_trace = None;
-                                engine_of_match = `OSS;
-                                validation_state = `No_validator;
-                                severity_override = None;
-                                metadata_override = None;
-                                sca_match = None;
-                                fix_text = None;
-                                facts = [];
-                              }
-                            in
-                            Stack_.push pm mp_env.matches;
-                            hook pm)));
+                 self#report_stmts_matches rule
+                   (match_sts_sts rule pattern x m_env)));
       super#v_stmts env x
 
     method! visit_type_ env x =
@@ -609,51 +608,21 @@ class ['self] check_visitor range_filter m_env has_as_metavariable
          Since [m_stmts_deep] anchors the pattern at the head of the list, we
          run it on every suffix so the pattern can start at any field.
       *)
-      let stmts = List_.map (fun (F x) -> x) x in
+      (* This runs on every class body / record / object literal, so only pay
+         for unwrapping the fields when there is a sequence pattern to match.
+         The suffixes don't depend on the rule, so compute them once. *)
+      let stmts_suffixes =
+        match stmts_rules with
+        | [] -> []
+        | _ :: _ -> List_.suffixes (List_.map (fun (F x) -> x) x)
+      in
       stmts_rules
       |> List.iter (fun (pattern, rule) ->
              Profiling.profile_code "Semgrep_generic.kfields" (fun () ->
-                 List_.suffixes stmts
+                 stmts_suffixes
                  |> List.iter (fun stmts ->
-                        let matches_with_env =
-                          match_sts_sts rule pattern stmts m_env
-                        in
-                        matches_with_env
-                        |> List.iter (fun (env : MG.tin) ->
-                               let matched = env.stmts_matched in
-                               match location_stmts matched with
-                               | None -> () (* empty sequence or bug *)
-                               | Some range_loc ->
-                                   let mv = env.mv in
-                                   let tokens =
-                                     lazy (list_original_tokens_stmts matched)
-                                   in
-                                   let rule_id = rule_id_of_mini_rule rule in
-                                   let pm =
-                                     {
-                                       PM.rule_id;
-                                       path;
-                                       env = mv;
-                                       range_loc;
-                                       (* as-metavariable: *)
-                                       ast_node =
-                                         (if has_as_metavariable then
-                                            Some (Ss matched)
-                                          else None);
-                                       enclosure = Option.map (!) enclosure;
-                                       tokens;
-                                       taint_trace = None;
-                                       engine_of_match = `OSS;
-                                       validation_state = `No_validator;
-                                       severity_override = None;
-                                       metadata_override = None;
-                                       sca_match = None;
-                                       fix_text = None;
-                                       facts = [];
-                                     }
-                                   in
-                                   Stack_.push pm mp_env.matches;
-                                   hook pm))));
+                        self#report_stmts_matches rule
+                          (match_sts_sts rule pattern stmts m_env))));
       match_rules_and_recurse mp_env flds_rules match_flds_flds
         (super#v_fields env)
         (fun x -> Flds x)

--- a/src/matching/Match_patterns.ml
+++ b/src/matching/Match_patterns.ml
@@ -605,50 +605,55 @@ class ['self] check_visitor range_filter m_env has_as_metavariable
 
          So if someone writes a pattern which could be interpreted as a sequence of
          fields, we allow it to match to fields.
+
+         Since [m_stmts_deep] anchors the pattern at the head of the list, we
+         run it on every suffix so the pattern can start at any field.
       *)
+      let stmts = List_.map (fun (F x) -> x) x in
       stmts_rules
       |> List.iter (fun (pattern, rule) ->
              Profiling.profile_code "Semgrep_generic.kfields" (fun () ->
-                 let x = List_.map (fun (F x) -> x) x in
-                 let matches_with_env =
-                   match_sts_sts rule pattern x m_env
-                 in
-                 matches_with_env
-                 |> List.iter (fun (env : MG.tin) ->
-                        let matched = env.stmts_matched in
-                        match location_stmts matched with
-                        | None -> () (* empty sequence or bug *)
-                        | Some range_loc ->
-                            let mv = env.mv in
-                            let tokens =
-                              lazy (list_original_tokens_stmts matched)
-                            in
-                            let rule_id = rule_id_of_mini_rule rule in
-                            let pm =
-                              {
-                                PM.rule_id;
-                                path;
-                                env = mv;
-                                range_loc;
-                                (* as-metavariable: *)
-                                ast_node =
-                                  (if has_as_metavariable then
-                                     Some (Ss matched)
-                                   else None);
-                                enclosure = Option.map (!) enclosure;
-                                tokens;
-                                taint_trace = None;
-                                engine_of_match = `OSS;
-                                validation_state = `No_validator;
-                                severity_override = None;
-                                metadata_override = None;
-                                sca_match = None;
-                                fix_text = None;
-                                facts = [];
-                              }
-                            in
-                            Stack_.push pm mp_env.matches;
-                            hook pm)));
+                 List_.suffixes stmts
+                 |> List.iter (fun stmts ->
+                        let matches_with_env =
+                          match_sts_sts rule pattern stmts m_env
+                        in
+                        matches_with_env
+                        |> List.iter (fun (env : MG.tin) ->
+                               let matched = env.stmts_matched in
+                               match location_stmts matched with
+                               | None -> () (* empty sequence or bug *)
+                               | Some range_loc ->
+                                   let mv = env.mv in
+                                   let tokens =
+                                     lazy (list_original_tokens_stmts matched)
+                                   in
+                                   let rule_id = rule_id_of_mini_rule rule in
+                                   let pm =
+                                     {
+                                       PM.rule_id;
+                                       path;
+                                       env = mv;
+                                       range_loc;
+                                       (* as-metavariable: *)
+                                       ast_node =
+                                         (if has_as_metavariable then
+                                            Some (Ss matched)
+                                          else None);
+                                       enclosure = Option.map (!) enclosure;
+                                       tokens;
+                                       taint_trace = None;
+                                       engine_of_match = `OSS;
+                                       validation_state = `No_validator;
+                                       severity_override = None;
+                                       metadata_override = None;
+                                       sca_match = None;
+                                       fix_text = None;
+                                       facts = [];
+                                     }
+                                   in
+                                   Stack_.push pm mp_env.matches;
+                                   hook pm))));
       match_rules_and_recurse mp_env flds_rules match_flds_flds
         (super#v_fields env)
         (fun x -> Flds x)

--- a/tests/rules/class_field_multi_match.py
+++ b/tests/rules/class_field_multi_match.py
@@ -1,0 +1,20 @@
+# Every class attribute initialized to [] and later appended to should be
+# matched, not just the first one.
+class C:
+    # ruleid: class_field_multi_match
+    a = []
+
+    def use_a(self, p):
+        a.append(p)
+
+    # ruleid: class_field_multi_match
+    b = []
+
+    def use_b(self, p):
+        b.append(p)
+
+    # ruleid: class_field_multi_match
+    c = []
+
+    def use_c(self, p):
+        c.append(p)

--- a/tests/rules/class_field_multi_match.yaml
+++ b/tests/rules/class_field_multi_match.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: class_field_multi_match
+    message: "class member $VAL is initialized to [] and appended to"
+    languages: [python]
+    severity: WARNING
+    patterns:
+      - focus-metavariable: $VAL
+      - pattern-inside: |
+          $VAL = []
+          ...
+          $VAL.append($P)

--- a/tests/tainting_rules/kotlin/class_var_taint.kt
+++ b/tests/tainting_rules/kotlin/class_var_taint.kt
@@ -1,0 +1,37 @@
+// The source pattern matches a `private val` populated from a method
+// parameter; every such class member should become a taint source.
+class Controller {
+
+    private val a = mutableListOf<String>()
+    private val b = mutableListOf<String>()
+    private val c = mutableListOf<String>()
+
+    fun addA(p: String): Boolean {
+        a.add(p)
+        return true
+    }
+
+    fun addB(p: String): Boolean {
+        b.add(p)
+        return true
+    }
+
+    fun useA(): String {
+        // ruleid: taint
+        sink(a)
+        return ""
+    }
+
+    fun useB(): String {
+        // ruleid: taint
+        sink(b)
+        return ""
+    }
+
+    fun useC(): String {
+        // c is never populated from a parameter, so it is not a source
+        // ok: taint
+        sink(c)
+        return ""
+    }
+}

--- a/tests/tainting_rules/kotlin/class_var_taint.yaml
+++ b/tests/tainting_rules/kotlin/class_var_taint.yaml
@@ -1,0 +1,19 @@
+rules:
+  - id: taint
+    languages: [kotlin]
+    message: "tainted data reached sink"
+    severity: ERROR
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - focus-metavariable: $VAL
+          - pattern-inside: |
+              private val $VAL = $ANY
+              ...
+              fun $M(..., $P: $T, ...) {
+                  ...
+                  $VAL.add($P)
+                  ...
+              }
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
# Match statement-sequence patterns against every class member

## Problem

A multi-statement pattern (one that uses `...` between statements) matched against a **class body** only ever matched the *first* member that fit the pattern's leading statement. Later members were silently skipped, even when they matched just as well.

## Example

Rule pattern:

```
$VAL = []
...
$VAL.append($P)
```

Target:

```python
class C:
    a = []
    def use_a(self, p):
        a.append(p)

    b = []
    def use_b(self, p):
        b.append(p)

    c = []
    def use_c(self, p):
        c.append(p)
```

Expected: three matches (`$VAL = a`, `b`, `c`).
Actual: **one** match (`$VAL = a`); `b` and `c` were never reported.

## Why

Statement lists and class bodies are matched by two different visitor methods:

- `v_stmts` (for statement blocks, e.g. a function body) recurses on the tail of the list, so the pattern is re-tried anchored at *every* position in the block.
- `v_fields` (for class bodies, whose members are stored as fields) does **not** recurse on sublists — it runs the matcher once on the whole field list.

The underlying sequence matcher (`m_stmts_deep`) is *head-anchored*: it only matches the pattern's first statement against the head of the list it is given, and fails otherwise. So when the pattern was run once on the full field list, only the first field could serve as the anchor — the match for `a` was found, but `b` and `c`, which would need to be the anchor themselves, never were.

The same pattern works correctly inside a function body, because there `v_stmts` re-anchors at each statement.

## Solution

In `v_fields`, run the matcher on **every suffix** of the field list rather than just the whole list, mirroring what `v_stmts`' tail recursion already does for statement blocks. This lets the pattern be anchored at any class member. Overlapping matches from different anchors are deduplicated downstream, exactly as they already are for statement blocks.

A small `List_.suffixes` helper is added for this (`suffixes [1;2;3] = [[1;2;3]; [2;3]; [3]; []]`).

This PR fixes #472 

## Testing

- `tests/rules/class_field_multi_match.{py,yaml}` — the example above; asserts all three members are matched.
- `tests/tainting_rules/kotlin/class_var_taint.{kt,yaml}` — the taint version of the same scenario, with several tainted class members.
- Wires Kotlin into the taint test suite (`lang_tainting_tests`), which was missing, so the existing Kotlin taint tests now run too.

`make core` builds; all fixtures verified against the built binary.

