### PR TITLE
Upgrade ppxlib to 0.38 and cmdliner to 2.x

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -113,7 +113,7 @@ a few other projects developed at r2c.
     ; we're currently "vendoring" pcre2 in libs/pcre2
     ; so no need to get opam to install it
     ;(pcre2 (>= "7.5.3" ))
-    (ppxlib (= "0.35.0"))
+    (ppxlib (= "0.38.0"))
     (ppx_deriving (>= "5.2.1"))
     (ppx_hash (>= "v0.14.0" ))
     (digestif (>= "1.0.0"))
@@ -487,14 +487,14 @@ For more information see https://opengrep.dev.
     ; CLI
     cmdliner
     ; PPX
-    (ppxlib (= 0.35.0)) ; because 0.36.0 moved to AST 5.2, breaking ppx_profiling.
+    (ppxlib (= 0.38.0))
     (ppx_deriving (>= 6.0.3))
     ppx_deriving_yojson
     ppx_hash
     ppx_inline_test
     (ppx_sexp_conv (>= v0.16.0))
     ppx_expect
-    (visitors (= 20250212))
+    (visitors (= 20260520))
     ; regexps
     re
     pcre

--- a/libs/commons/Cmdliner_.ml
+++ b/libs/commons/Cmdliner_.ml
@@ -104,7 +104,7 @@ let units_conversion =
 let number_of_bytes_converter : int Cmdliner.Arg.conv =
   let parser s =
     let fail =
-      `Error (spf "Invalid representation for a number of bytes: %s" s)
+      Error (`Msg (spf "Invalid representation for a number of bytes: %s" s))
     in
     let s = String.uppercase_ascii s in
     if s =~ "^\\([^ BKMGT]*\\)[ ]*\\([BKMGT][A-Z]*\\)$" then
@@ -112,12 +112,12 @@ let number_of_bytes_converter : int Cmdliner.Arg.conv =
       match
         (float_of_string_opt number, List.assoc_opt unit units_conversion)
       with
-      | Some n, Some unit -> `Ok (int_of_float (n *. unit))
+      | Some n, Some unit -> Ok (int_of_float (n *. unit))
       | _else_ -> fail
     else
       match int_of_string_opt s with
-      | Some i -> `Ok i
+      | Some i -> Ok i
       | None -> fail
   in
   let printer ppf x = Format.pp_print_int ppf x in
-  (parser, printer)
+  Arg.conv (parser, printer)

--- a/libs/commons/Testutil_files.ml
+++ b/libs/commons/Testutil_files.ml
@@ -117,8 +117,13 @@ let get_dir_entries path =
 
 let remove path =
   let rec remove path =
-    match (UUnix.lstat !!path).st_kind with
-    | S_DIR ->
+    match UUnix.lstat !!path with
+    (* The entry can vanish between reading its parent directory and this
+       lstat when another process mutates the tree concurrently — e.g. git's
+       background maintenance removing a lock file under .git. An
+       already-absent entry is nothing to remove. *)
+    | exception UUnix.Unix_error (Unix.ENOENT, _, _) -> ()
+    | { st_kind = S_DIR; _ } ->
         let names = get_dir_entries path in
         List.iter (fun name -> remove (path / name)) names;
         UUnix.rmdir !!path

--- a/libs/profiling/ppx/ppx_profiling.ml
+++ b/libs/profiling/ppx/ppx_profiling.ml
@@ -87,12 +87,21 @@ open Ast_helper
 (*****************************************************************************)
 let rec parameters body =
   match body with
-  | { pexp_desc = Pexp_fun (Nolabel, _, _, body); _ } ->
-      Nolabel :: parameters body
-  | { pexp_desc = Pexp_fun (Labelled name, _, _, body); _ } ->
-      Labelled name :: parameters body
-  | { pexp_desc = Pexp_fun (Optional name, _, _, body); _ } ->
-      Optional name :: parameters body
+  | { pexp_desc = Pexp_function (params, _, fbody); _ } ->
+      let labels =
+        List_.filter_map
+          (fun (p : function_param) ->
+            match p.pparam_desc with
+            | Pparam_val (label, _, _) -> Some label
+            | Pparam_newtype _ -> None)
+          params
+      in
+      let rest =
+        match fbody with
+        | Pfunction_body e -> parameters e
+        | Pfunction_cases _ -> []
+      in
+      labels @ rest
   | _else_ -> []
 
 let name_of_lbl_opt n lbl_opt =
@@ -105,12 +114,18 @@ let name_of_lbl_opt n lbl_opt =
 let mk_params loc params e =
   let rec aux xs n =
     match xs with
-    | [] -> e
+    | [] -> []
     | x :: xs ->
         let param = name_of_lbl_opt n x in
-        Exp.fun_ x None (Pat.var { txt = param; loc }) (aux xs (n + 1))
+        {
+          pparam_loc = loc;
+          pparam_desc = Pparam_val (x, None, Pat.var { txt = param; loc });
+        }
+        :: aux xs (n + 1)
   in
-  aux params 0
+  match aux params 0 with
+  | [] -> e
+  | fparams -> Ast_builder.Default.pexp_function ~loc fparams None (Pfunction_body e)
 
 let mk_args loc params =
   let rec aux xs n =
@@ -214,10 +229,19 @@ let impl xs =
                                Exp.constant
                                  (Pconst_string (action_name, loc, None)) );
                              ( Nolabel,
-                               Exp.fun_ Nolabel None (Pat.any ())
-                                 (Exp.apply
-                                    (Exp.ident { txt = Lident fname; loc })
-                                    (mk_args loc params)) );
+                               Ast_builder.Default.pexp_function ~loc
+                                 [
+                                   {
+                                     pparam_loc = loc;
+                                     pparam_desc =
+                                       Pparam_val (Nolabel, None, Pat.any ());
+                                   };
+                                 ]
+                                 None
+                                 (Pfunction_body
+                                    (Exp.apply
+                                       (Exp.ident { txt = Lident fname; loc })
+                                       (mk_args loc params))) );
                            ]));
                  ]
              in

--- a/libs/spacegrep/src/bin/Spacecat_main.ml
+++ b/libs/spacegrep/src/bin/Spacecat_main.ml
@@ -71,15 +71,13 @@ let man =
     `P "spacegrep(1)";
   ]
 
-let info name = Term.info ~doc ~man name
+let info name = Cmd.info ~doc ~man name
 
 let parse_command_line name =
-  match Term.eval (cmdline_term, info name) with
-  | `Error _ -> exit 1
-  | `Version
-  | `Help ->
-      exit 0
-  | `Ok config -> config
+  match Cmd.eval_value (Cmd.v (info name) cmdline_term) with
+  | Ok (`Ok config) -> config
+  | Ok (`Version | `Help) -> exit 0
+  | Error _ -> exit 1
 
 let run_one config input =
   let src =

--- a/libs/spacegrep/src/bin/Spacegrep_main.ml
+++ b/libs/spacegrep/src/bin/Spacegrep_main.ml
@@ -494,15 +494,13 @@ let man =
     `P "semgrep, spacecat";
   ]
 
-let info name = Term.info ~doc ~man name
+let info name = Cmd.info ~doc ~man name
 
 let parse_command_line name =
-  match Term.eval (cmdline_term, info name) with
-  | `Error _ -> exit 1
-  | `Version
-  | `Help ->
-      exit 0
-  | `Ok config -> config
+  match Cmd.eval_value (Cmd.v (info name) cmdline_term) with
+  | Ok (`Ok config) -> config
+  | Ok (`Version | `Help) -> exit 0
+  | Error _ -> exit 1
 
 (*
    Entry point for calling the command 'spacegrep' directly.

--- a/opam/commons.opam
+++ b/opam/commons.opam
@@ -21,7 +21,7 @@ depends: [
   "yojson" {>= "1.7.0"}
   "re" {>= "1.10.4"}
   "pcre" {>= "7.5.0"}
-  "ppxlib" {= "0.35.0"}
+  "ppxlib" {= "0.38.0"}
   "ppx_deriving" {>= "5.2.1"}
   "ppx_hash" {>= "v0.14.0"}
   "digestif" {>= "1.0.0"}

--- a/opam/semgrep.opam
+++ b/opam/semgrep.opam
@@ -45,14 +45,14 @@ depends: [
   "xmlm"
   "sarif" {>= "0.3.0"}
   "cmdliner"
-  "ppxlib" {= "0.35.0"}
+  "ppxlib" {= "0.38.0"}
   "ppx_deriving" {>= "6.0.3"}
   "ppx_deriving_yojson"
   "ppx_hash"
   "ppx_inline_test"
   "ppx_sexp_conv" {>= "v0.16.0"}
   "ppx_expect"
-  "visitors" {= "20250212"}
+  "visitors" {= "20260520"}
   "re"
   "pcre"
   "ocamlgraph"


### PR DESCRIPTION
Moves core ppx/CLI dependencies forward, toward OCaml 5.5:

- ppxlib 0.35 -> 0.38, visitors -> 20260520; `ppx_profiling` ported to the 0.36+ function AST.
- cmdliner -> 2.x `Cmd` API (`Cmdliner_.ml` + spacegrep; the `ocaml-tree-sitter-core` submodule migrated in its own merged PR).
- Fix a flaky test-cleanup race with git background maintenance.