### PR TITLE
PHP shorthand for array_push does not propagate taint

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -398,6 +398,14 @@ let rec lval env eorig : stmts * lval =
       let ss_e2, e2 = expr env e2orig in
       let offset' = { o = Index e2; oorig = SameAs eorig } in
       (ss_lv @ ss_e2, { lv1 with rev_offset = offset' :: lv1.rev_offset })
+  (* PHP's array-append shorthand '$x[] = e', treated as an assignment to an
+   * unknown index of $x so that dataflow reaches $x itself. *)
+  | G.OtherExpr (("ArrayAppend", tok), [ G.E e1orig ])
+    when env.lang =*= Lang.Php ->
+      let ss_lv, lv1 = nested_lval env tok e1orig in
+      let idx = mk_e (Fetch (fresh_lval tok)) NoOrig in
+      let offset' = { o = Index idx; oorig = SameAs eorig } in
+      (ss_lv, { lv1 with rev_offset = offset' :: lv1.rev_offset })
   | G.DeRef (_, e1orig) ->
       let ss, e1 = expr env e1orig in
       (ss, lval_of_base (Mem e1))
@@ -872,6 +880,7 @@ and assign env ~g_expr lhs tok rhs_exp : stmts * exp =
   | G.N _
   | G.DotAccess _
   | G.ArrayAccess _
+  | G.OtherExpr (("ArrayAppend", _), [ G.E _ ])
   | G.DeRef _ -> (
       try
         let ss_lv, lval = lval env lhs in

--- a/tests/tainting_rules/php/array_append.php
+++ b/tests/tainting_rules/php/array_append.php
@@ -1,0 +1,19 @@
+<?php
+
+function test() {
+    $a = source();
+    //ruleid: test-array-append
+    sink($a);
+
+    $b[] = source();
+    //ruleid: test-array-append
+    sink($b);
+
+    $c[0] = source();
+    //ruleid: test-array-append
+    sink($c);
+
+    $d[] = safe();
+    //OK:
+    sink($d);
+}

--- a/tests/tainting_rules/php/array_append.yaml
+++ b/tests/tainting_rules/php/array_append.yaml
@@ -1,0 +1,11 @@
+rules:
+  - id: test-array-append
+    languages:
+      - php
+    message: Match Found!
+    mode: taint
+    pattern-sinks:
+      - pattern: sink(...)
+    pattern-sources:
+      - pattern: source(...)
+    severity: WARNING


### PR DESCRIPTION
This fixes #95 (comming from https://github.com/semgrep/semgrep/issues/8154)

The issue is that `$b[]` to `OtherExpr("ArrayAppend", [E $b])` which is not considered in AST_to_IL (it is a FIXME).
 This fixes the issue and adds a test as suggested in the issue