### PR TITLE
Include sha and tag in perf scripts report

### DIFF
--- a/perf/opengrep-scripts/README.md
+++ b/perf/opengrep-scripts/README.md
@@ -45,6 +45,14 @@ Binaries are cached in `binaries/<label>/venv/bin/opengrep`.
 
 Unstaged changes are allowed when the reference is cached (no checkout required).
 
+Both sides usually report the same opengrep version during development (main is
+typically still at the last release), so each side is identified by its commit as
+well: `<tag>-<short-sha>` when the commit is tagged, otherwise the short SHA
+(plus `-dirty` for a HEAD with uncommitted changes). These identifiers are passed
+to `bench.sh` as `--reference-label`/`--binary-label` and show up in the hyperfine
+result tables, `metadata.json`, and the report header, e.g.
+`opengrep-1.15.0@v1.15.0-a1b2c3d` vs `opengrep-1.15.0@d77978d-dirty`.
+
 ### `bench.sh`
 
 Core benchmarking script using [hyperfine](https://github.com/sharkdp/hyperfine). Compares two binaries (reference vs comparison).
@@ -57,6 +65,8 @@ Options:
 - `--reference-binary PATH` - Reference opengrep binary (required; `~/.local/bin/opengrep` is a common location)
 - `--binary PATH` - Binary to compare (required)
 - `--binary-variant TYPE` - Type of binary: `opengrep` or `semgrep` (auto-detected if binary is `semgrep` or ends with `/semgrep`)
+- `--reference-label LABEL` - Extra identifier (tag/sha) for the reference binary, shown as `opengrep-<version>@<label>` in results and metadata
+- `--binary-label LABEL` - Extra identifier (tag/sha) for the comparison binary
 - `--repo NAME[:RUNS]` - Benchmark specific repo (can be repeated)
 - `--taint-rules-only` - Use only taint rules
 - `--no-taint-rules` - Use only non-taint (search) rules

--- a/perf/opengrep-scripts/bench-against-sha.sh
+++ b/perf/opengrep-scripts/bench-against-sha.sh
@@ -28,9 +28,11 @@ GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 NC='\033[0m' # No Color
 
-log_info() { echo -e "${GREEN}==>${NC} $1"; }
-log_warn() { echo -e "${YELLOW}Warning:${NC} $1"; }
-log_error() { echo -e "${RED}Error:${NC} $1" >&2; }
+# printf, not `echo -e`: when the script is run as `sh bench-against-sha.sh`,
+# echo is POSIX and prints the -e literally.
+log_info() { printf '%b==>%b %s\n' "$GREEN" "$NC" "$1"; }
+log_warn() { printf '%bWarning:%b %s\n' "$YELLOW" "$NC" "$1"; }
+log_error() { printf '%bError:%b %s\n' "$RED" "$NC" "$1" >&2; }
 
 usage() {
   echo "Usage: $0 <reference-sha> [bench.sh options]"
@@ -73,6 +75,21 @@ get_commit_label() {
   fi
 }
 
+# Get an unambiguous identifier for a commit: "<tag>-<short-sha>" when the
+# commit is tagged, otherwise just the short SHA. Versions on main are usually
+# identical to the last release, so this is what distinguishes the results.
+get_commit_id() {
+  local sha_full="$1"
+  local tag short_sha
+  tag=$(git tag --points-at "$sha_full" 2>/dev/null | head -n1)
+  short_sha=$(git rev-parse --short "$sha_full")
+  if [[ -n "$tag" ]]; then
+    echo "$tag-$short_sha"
+  else
+    echo "$short_sha"
+  fi
+}
+
 # Parse arguments
 if [[ $# -lt 1 ]]; then
   usage
@@ -99,9 +116,14 @@ REF_SHA_FULL=$(git rev-parse "$REF_SHA")
 REF_LABEL=$(get_commit_label "$REF_SHA_FULL")
 HEAD_SHA_FULL=$(git rev-parse HEAD)
 HEAD_LABEL=$(get_commit_label "$HEAD_SHA_FULL")
+REF_ID=$(get_commit_id "$REF_SHA_FULL")
+HEAD_ID=$(get_commit_id "$HEAD_SHA_FULL")
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  HEAD_ID="$HEAD_ID-dirty"
+fi
 
-echo "  Reference: $REF_SHA -> $REF_LABEL ($REF_SHA_FULL)"
-echo "  HEAD:      $HEAD_LABEL ($HEAD_SHA_FULL)"
+echo "  Reference: $REF_SHA -> $REF_ID ($REF_SHA_FULL)"
+echo "  HEAD:      $HEAD_ID ($HEAD_SHA_FULL)"
 
 if [[ "$REF_SHA_FULL" == "$HEAD_SHA_FULL" ]]; then
   log_error "HEAD is the same as reference: $REF_SHA_FULL"
@@ -130,14 +152,16 @@ if [[ -n "$dry_run" ]]; then
   echo "  $HEAD_LABEL: build in place (always rebuilt)"
   echo ""
   echo "Would run:"
-  echo "  ./bench.sh --reference-binary $REF_BINARY --binary $HEAD_BINARY ${BENCH_ARGS[*]}"
+  echo "  ./bench.sh --reference-binary $REF_BINARY --reference-label $REF_ID --binary $HEAD_BINARY --binary-label $HEAD_ID ${BENCH_ARGS[*]-}"
   echo ""
 
   cd "$SCRIPT_DIR"
   exec ./bench.sh \
     --reference-binary "$REF_BINARY" \
+    --reference-label "$REF_ID" \
     --binary "$HEAD_BINARY" \
-    "${BENCH_ARGS[@]}"
+    --binary-label "$HEAD_ID" \
+    ${BENCH_ARGS[@]+"${BENCH_ARGS[@]}"}
 fi
 
 # Function to build at current HEAD
@@ -217,12 +241,14 @@ echo ""
 
 # Run benchmarks
 log_info "Running benchmarks..."
-echo "  Reference: $REF_BINARY"
-echo "  HEAD:      $HEAD_BINARY"
+echo "  Reference: $REF_BINARY ($REF_ID)"
+echo "  HEAD:      $HEAD_BINARY ($HEAD_ID)"
 echo ""
 
 cd "$SCRIPT_DIR"
 exec ./bench.sh \
   --reference-binary "$REF_BINARY" \
+  --reference-label "$REF_ID" \
   --binary "$HEAD_BINARY" \
-  "${BENCH_ARGS[@]}"
+  --binary-label "$HEAD_ID" \
+  ${BENCH_ARGS[@]+"${BENCH_ARGS[@]}"}

--- a/perf/opengrep-scripts/bench.sh
+++ b/perf/opengrep-scripts/bench.sh
@@ -8,6 +8,8 @@ set -eu
 # Default configuration
 reference_binary=""
 binary=""
+reference_label=""
+binary_label=""
 binary_variant="opengrep"
 explicit_binary_variant=""
 output_base="bench_results"
@@ -43,6 +45,14 @@ while [ $# -gt 0 ]; do
       ;;
     --binary)
       binary="$2"
+      shift 2
+      ;;
+    --reference-label)
+      reference_label="$2"
+      shift 2
+      ;;
+    --binary-label)
+      binary_label="$2"
       shift 2
       ;;
     --binary-variant)
@@ -97,6 +107,9 @@ while [ $# -gt 0 ]; do
       echo "Options:"
       echo "  --reference-binary PATH  Path to reference opengrep binary (required)"
       echo "  --binary PATH            Path to binary to compare (required)"
+      echo "  --reference-label LABEL  Extra identifier for the reference binary (e.g. tag/sha),"
+      echo "                           appended to its version in reports"
+      echo "  --binary-label LABEL     Extra identifier for --binary (e.g. tag/sha)"
       echo "  --binary-variant TYPE    Type of --binary: opengrep or semgrep (auto-detected from path)"
       echo "  --output-base DIR        Base directory for results (default: bench_results)"
       echo "  --output-dir DIR         Exact output directory (overrides --output-base and --name)"
@@ -271,6 +284,26 @@ else
   binary_version=$("$binary" --version | head -n1 | awk '{print $NF}')
 fi
 
+# Display names. During development both binaries usually report the same
+# version, so the label (tag/sha) is what actually tells the results apart.
+reference_name="opengrep-$reference_version"
+if [ -n "$reference_label" ]; then
+  reference_name="$reference_name@$reference_label"
+fi
+binary_name="$binary_variant-$binary_version"
+if [ -n "$binary_label" ]; then
+  binary_name="$binary_name@$binary_label"
+fi
+
+if [ "$reference_name" = "$binary_name" ]; then
+  echo "Warning: reference and comparison are both named '$binary_name';" >&2
+  echo "  pass --reference-label/--binary-label to tell them apart in reports" >&2
+fi
+
+printf "  %-16s %s\n" "reference id:" "$reference_name"
+printf "  %-16s %s\n" "binary id:" "$binary_name"
+echo ""
+
 # Write metadata
 if [ -z "$dry_run" ]; then
   git_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
@@ -283,8 +316,12 @@ if [ -z "$dry_run" ]; then
   "git_commit": "$git_commit",
   "reference_binary": "$reference_binary",
   "reference_version": "$reference_version",
+  "reference_label": "$reference_label",
+  "reference_name": "$reference_name",
   "binary": "$binary",
   "binary_version": "$binary_version",
+  "binary_label": "$binary_label",
+  "binary_name": "$binary_name",
   "binary_variant": "$binary_variant",
   "rules_dir": "$rules_dir",
   "num_cpus": "$num_cpus",
@@ -380,8 +417,8 @@ for repo_config in "${repos[@]}"; do
     echo "  --export-markdown $output_dir/results_${repo}${suffix}.md \\"
     echo "  --reference \\"
     echo "  '$reference_cmd' \\"
-    echo "  --reference-name opengrep-$reference_version \\"
-    echo "  --command-name $binary_variant-$binary_version \\"
+    echo "  --reference-name $reference_name \\"
+    echo "  --command-name $binary_name \\"
     echo "  '$binary_cmd'"
   else
     hyperfine \
@@ -392,8 +429,8 @@ for repo_config in "${repos[@]}"; do
       --export-markdown "$output_dir/results_${repo}${suffix}.md" \
       --reference \
       "$reference_cmd" \
-      --reference-name "opengrep-$reference_version" \
-      --command-name "$binary_variant-$binary_version" \
+      --reference-name "$reference_name" \
+      --command-name "$binary_name" \
       "$binary_cmd"
 
     # Format output JSON files

--- a/perf/opengrep-scripts/benchmark-report.sh
+++ b/perf/opengrep-scripts/benchmark-report.sh
@@ -42,6 +42,10 @@ ref_version=$(jq -r '.reference_version // "unknown"' "$metadata_file")
 cmp_binary=$(jq -r '.binary // "unknown"' "$metadata_file")
 cmp_version=$(jq -r '.binary_version // "unknown"' "$metadata_file")
 cmp_variant=$(jq -r '.binary_variant // "unknown"' "$metadata_file")
+ref_label=$(jq -r '.reference_label // ""' "$metadata_file")
+cmp_label=$(jq -r '.binary_label // ""' "$metadata_file")
+git_branch=$(jq -r '.git_branch // ""' "$metadata_file")
+git_commit=$(jq -r '.git_commit // ""' "$metadata_file")
 rules_dir=$(jq -r '.rules_dir // "unknown"' "$metadata_file")
 num_cpus=$(jq -r '.num_cpus // "unknown"' "$metadata_file")
 max_time=$(jq -r '.max_time_minutes // "unknown"' "$metadata_file")
@@ -61,8 +65,22 @@ echo "Directory:  $OUTPUT_DIR"
 echo "Timestamp:  $timestamp"
 echo "Mode:       $mode"
 echo ""
-echo "Reference:  $ref_binary ($ref_version)"
-echo "Comparison: $cmp_binary ($cmp_version) [variant: $cmp_variant]"
+# Versions alone are ambiguous during development (main usually reports the
+# last released version), so show the tag/sha label whenever it is recorded.
+ref_id="$ref_version"
+if [[ -n "$ref_label" ]]; then
+    ref_id="$ref_version @ $ref_label"
+fi
+cmp_id="$cmp_version"
+if [[ -n "$cmp_label" ]]; then
+    cmp_id="$cmp_version @ $cmp_label"
+fi
+
+echo "Reference:  $ref_binary ($ref_id)"
+echo "Comparison: $cmp_binary ($cmp_id) [variant: $cmp_variant]"
+if [[ -n "$git_branch$git_commit" ]]; then
+    echo "Run from:   ${git_branch:-unknown} @ ${git_commit:-unknown}"
+fi
 echo ""
 echo "Rules:      $rules_dir"
 echo "CPUs:       $num_cpus"


### PR DESCRIPTION
At the moment, what is reported by the script is results attached to a aprticular version of Opengrep. But when comparing current development with main, we usually get the same Opengrep version, and it is not clear which result is for main and which for the current dev. This PR adds the commit id (and tag if the commit is tagged) to the reported results. E.g.,

```
sh bench-against-sha.sh main
```

now results in sth like:

```
Benchmark 1: opengrep-1.25.0@d77978ddc
  Time (mean ± σ):     27.201 s ±  0.540 s    [User: 161.586 s, System: 62.454 s]
  Range (min … max):   26.638 s … 27.715 s    3 runs

Benchmark 2: opengrep-1.25.0@30609c2c8
  Time (mean ± σ):     26.928 s ±  0.377 s    [User: 162.526 s, System: 61.055 s]
  Range (min … max):   26.494 s … 27.186 s    3 runs

Summary
  opengrep-1.25.0@d77978ddc ran
    1.01 ± 0.02 times slower than opengrep-1.25.0@30609c2c8
```