### PR TITLE
Load rules from a remote git repository via `--config git+<url>`

### DIFF
--- a/libs/commons/CapTmp.ml
+++ b/libs/commons/CapTmp.ml
@@ -1,6 +1,9 @@
 let with_temp_file ?contents ?persist ?prefix ?suffix ?temp_dir _caps f =
   UTmp.with_temp_file ?contents ?persist ?prefix ?suffix ?temp_dir f
 
+let with_temp_dir ?persist ?prefix ?suffix ?temp_dir _caps f =
+  UTmp.with_temp_dir ?persist ?prefix ?suffix ?temp_dir f
+
 let get_temp_dir_name _caps = UTmp.get_temp_dir_name ()
 let erase_temp_files _caps = UTmp.erase_temp_files ()
 

--- a/libs/commons/CapTmp.mli
+++ b/libs/commons/CapTmp.mli
@@ -10,6 +10,15 @@ val with_temp_file :
   (Fpath.t -> 'a) ->
   'a
 
+val with_temp_dir :
+  ?persist:bool ->
+  ?prefix:string ->
+  ?suffix:string ->
+  ?temp_dir:Fpath.t ->
+  Cap.FS.tmp ->
+  (Fpath.t -> 'a) ->
+  'a
+
 val get_temp_dir_name : Cap.FS.tmp -> Fpath.t
 
 val new_temp_file :

--- a/libs/commons/UTmp.ml
+++ b/libs/commons/UTmp.ml
@@ -105,6 +105,35 @@ let erase_this_temp_file f =
     Log.info (fun m -> m "deleting: %s" !!f);
     USys.remove !!f)
 
+(* ex: new_temp_dir ~prefix:"opengrep-git-" ()
+   will create a fresh empty directory and return its path. *)
+let new_temp_dir ?(prefix = default_temp_file_prefix) ?(suffix = "") ?temp_dir ()
+    =
+  let dir =
+    UFilename.temp_dir
+      ?temp_dir:(Option.map Fpath.to_string temp_dir)
+      prefix suffix
+    |> Fpath.v
+  in
+  Log.debug (fun m -> m "creating temp dir %s" !!dir);
+  dir
+
+(* Symlink-aware recursive removal: we [lstat] each entry so that a symlink is
+ * unlinked rather than followed (we must never delete outside [path]). *)
+let rec remove_dir_recursive (path : Fpath.t) : unit =
+  match (UUnix.lstat !!path).st_kind with
+  | UUnix.S_DIR ->
+      USys.readdir !!path
+      |> Array.iter (fun entry -> remove_dir_recursive Fpath.(path / entry));
+      UUnix.rmdir !!path
+  | _ -> USys.remove !!path
+  | exception UUnix.Unix_error (UUnix.ENOENT, _, _) -> ()
+
+let erase_this_temp_dir (dir : Fpath.t) =
+  if not !save_temp_files then (
+    Log.info (fun m -> m "deleting dir: %s" !!dir);
+    remove_dir_recursive dir)
+
 let with_temp_file ?(contents = "") ?(persist = false) ?prefix ?suffix ?temp_dir
     (f : Fpath.t -> 'a) : 'a =
   let temp_file_path = new_temp_file ?prefix ?suffix ?temp_dir () in
@@ -121,6 +150,16 @@ let with_temp_file ?(contents = "") ?(persist = false) ?prefix ?suffix ?temp_dir
         !temp_file_cleanup_hooks
         |> List.iter (fun cleanup -> cleanup temp_file_path);
         erase_this_temp_file temp_file_path))
+
+(* Directory equivalent of [with_temp_file]: create a fresh temporary
+ * directory, invoke [f] on it, and remove it recursively once done (unless
+ * [persist] or the global save-temp-files flag is set). *)
+let with_temp_dir ?(persist = false) ?prefix ?suffix ?temp_dir
+    (f : Fpath.t -> 'a) : 'a =
+  let temp_dir_path = new_temp_dir ?prefix ?suffix ?temp_dir () in
+  Common.finalize
+    (fun () -> f temp_dir_path)
+    (fun () -> if not persist then erase_this_temp_dir temp_dir_path)
 
 (* TODO[Issue #129] Is [Filename.open_temp_file] thread-safe? See comments
  * on [new_temp_file] above. Note that the function does not seem used,

--- a/libs/commons/UTmp.mli
+++ b/libs/commons/UTmp.mli
@@ -51,6 +51,26 @@ val with_temp_file :
   (Fpath.t -> 'a) ->
   'a
 
+(* Directory equivalent of [with_temp_file]: create a fresh temporary
+   directory, invoke the passed function on it, and remove it recursively once
+   done (unless [persist] or the global save-temp-files flag is set).
+
+   Options:
+   - persist: keep the directory instead of deleting it when done. Useful for
+              debugging.
+   - prefix: a prefix for the directory name. Default: derived from argv[0].
+   - suffix: an optional suffix for the directory name. Default: empty.
+   - temp_dir: folder containing the temporary directory. Defaults to the
+               system-defined temporary folder e.g. '/tmp'.
+*)
+val with_temp_dir :
+  ?persist:bool ->
+  ?prefix:string ->
+  ?suffix:string ->
+  ?temp_dir:Fpath.t ->
+  (Fpath.t -> 'a) ->
+  'a
+
 (* The hooks below are run just before a tmp file created by with_temp_file()
  * is deleted. Multiple hooks can be added, but the order in which they are
  * called is unspecified.

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -484,6 +484,43 @@ let sparse_checkout_add ?cwd folders =
   | Ok (`Exited 0) -> Ok ()
   | _ -> Error "Could not add sparse checkout"
 
+(* Plain shallow clone that actually materializes the whole tree (unlike
+ * [sparse_shallow_filtered_checkout] which deliberately avoids checking out
+ * files). Used to fetch a remote repository of rules for --config.
+ *
+ * Opengrep is non-interactive by design: we never want a clone to block a
+ * scan on a credential / passphrase / host-key prompt. We set
+ * GIT_TERMINAL_PROMPT=0 (and, unless the user already customized it,
+ * GIT_SSH_COMMAND with ssh BatchMode) so that git fails fast instead of
+ * hanging when auth cannot be resolved non-interactively. Credentials
+ * themselves are entirely git's business (ssh-agent, credential helpers,
+ * .netrc, ...); we neither read nor forward any secret.
+ *)
+let shallow_clone ?ref_ (url : Uri.t) (dst : Fpath.t) : (unit, string) result =
+  UUnix.putenv "GIT_TERMINAL_PROMPT" "0";
+  (match USys.getenv_opt "GIT_SSH_COMMAND" with
+  | Some _ -> ()
+  | None -> UUnix.putenv "GIT_SSH_COMMAND" "ssh -oBatchMode=yes");
+  let branch_args =
+    match ref_ with
+    | Some r -> [ "--branch"; r ]
+    | None -> []
+  in
+  let cmd =
+    ( git,
+      [ "clone"; "--depth=1" ]
+      @ branch_args
+      @ [ Uri.to_string url; Fpath.to_string dst ] )
+  in
+  match UCmd.status_of_run ~quiet:true cmd with
+  | Ok (`Exited 0) -> Ok ()
+  | _ ->
+      Error
+        (spf
+           "Could not clone git repo %s (ensure it is accessible \
+            non-interactively: ssh-agent / credential helper)"
+           (Uri.to_string url))
+
 (* TODO: use better types? sha1? *)
 let merge_base (commit : string) : string =
   let cmd = (git, [ "merge-base"; commit; "HEAD" ]) in

--- a/libs/git_wrapper/Git_wrapper.ml
+++ b/libs/git_wrapper/Git_wrapper.ml
@@ -503,14 +503,19 @@ let shallow_clone ?ref_ (url : Uri.t) (dst : Fpath.t) : (unit, string) result =
   | None -> UUnix.putenv "GIT_SSH_COMMAND" "ssh -oBatchMode=yes");
   let branch_args =
     match ref_ with
-    | Some r -> [ "--branch"; r ]
+    (* use the '--opt=value' form so a ref starting with '-' cannot be
+     * mistaken for another option *)
+    | Some r -> [ "--branch=" ^ r ]
     | None -> []
   in
   let cmd =
     ( git,
       [ "clone"; "--depth=1" ]
       @ branch_args
-      @ [ Uri.to_string url; Fpath.to_string dst ] )
+      (* '--' terminates option parsing: without it a URL such as '--help' or
+       * '--upload-pack=...' would be interpreted by git as an option rather
+       * than the repository to clone *)
+      @ [ "--"; Uri.to_string url; Fpath.to_string dst ] )
   in
   match UCmd.status_of_run ~quiet:true cmd with
   | Ok (`Exited 0) -> Ok ()

--- a/libs/git_wrapper/Git_wrapper.mli
+++ b/libs/git_wrapper/Git_wrapper.mli
@@ -147,6 +147,13 @@ val sparse_shallow_filtered_checkout : Uri.t -> Fpath.t -> (unit, string) result
 val sparse_checkout_add : ?cwd:Fpath.t -> Fpath.t list -> (unit, string) result
 (** Add the given files to the sparse-checkout config *)
 
+val shallow_clone :
+  ?ref_:string -> Uri.t -> Fpath.t -> (unit, string) result
+(** [shallow_clone ?ref_ url dst] does a depth-1 clone of [url] into [dst],
+    checking out the whole tree. If [ref_] is given, that branch or tag is
+    checked out. Runs non-interactively (fails fast rather than prompting for
+    credentials); auth is left entirely to git's own mechanisms. *)
+
 (* precondition: cwd must be a directory *)
 val dirty_lines_of_file :
   ?cwd:Fpath.t -> ?git_ref:string -> Fpath.t -> (int * int) array option

--- a/src/osemgrep/cli/Help.ml
+++ b/src/osemgrep/cli/Help.ml
@@ -78,5 +78,5 @@ let print_semgrep_dashdash_help (stdout : Cap.Console.stdout) =
   @{<cyan>scan@}                 Run Opengrep rules on local folders or files
   @{<cyan>show@}                 Show various types of information
   @{<cyan>test@}                 Test the rules
-  @{<cyan>validate@}             Validate the rules
+  @{<cyan>validate@}             Validate rules in local files/directories
 |}

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -784,7 +784,14 @@ let o_config : string list Term.t =
       ~env:(Cmd.Env.info "SEMGREP_RULES")
       ~doc:
         {|YAML configuration file, directory of YAML files ending in
-.yml|.yaml, URL of a configuration file, or Semgrep registry entry name.
+.yml|.yaml, URL of a configuration file, remote git repository of rules, or
+Semgrep registry entry name.
+
+A remote git repository of rules is given as `git+<url>`; it is cloned and
+scanned as a directory of rules. Append `#<branch-or-tag>` to pin a ref, e.g.
+`--config git+https://github.com/org/rules#v1.2.0`. Cloning uses git's own
+credentials (ssh-agent, credential helpers, ...) and runs non-interactively.
+REQUIRES --experimental
 
 Use --config auto to automatically obtain rules tailored to this project;
 your project URL will be used to log in to the Semgrep registry.

--- a/src/osemgrep/cli_scan/Scan_CLI.ml
+++ b/src/osemgrep/cli_scan/Scan_CLI.ml
@@ -41,6 +41,9 @@ type conf = {
   (* Other configuration options *)
   error_on_findings : bool;
   rewrite_rule_ids : bool;
+  (* skip rule files that fail to parse (e.g. non-rule YAML found in a
+   * directory or cloned git repo) instead of aborting the scan *)
+  skip_invalid_configs : bool;
   matching_conf : Match_patterns.matching_conf;
   (* Engine selection *)
   engine_type : Engine_type.t;
@@ -103,6 +106,7 @@ let default : conf =
     incremental_output = false;
     incremental_output_postprocess = false;
     rewrite_rule_ids = true;
+    skip_invalid_configs = false;
     matching_conf = Match_patterns.default_matching_conf;
     (* will send metrics only if the user uses the registry or the app *)
     version_check = true;
@@ -1023,6 +1027,18 @@ let o_project_root : string option Term.t =
   in
   Arg.value (Arg.opt Arg.(some string) None info)
 
+let o_skip_invalid_configs : bool Term.t =
+  let info =
+    Arg.info [ "skip-invalid-configs" ]
+      ~doc:
+        {|When loading rules from a directory or a remote git repository
+        (git+<url>), skip files that fail to parse as a rule config, such as
+        unrelated YAML files (e.g. GitHub workflows), emitting a warning for
+        each instead of aborting the scan. Explicitly named config files still
+        cause an error if invalid. REQUIRES --experimental|}
+  in
+  Arg.value (Arg.flag info)
+
 let o_remote : string option Term.t =
   let info =
     Arg.info [ "remote" ]
@@ -1396,6 +1412,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       output output_enclosing_context pattern pro project_root taint_intrafile
       effect_guards pro_path_sensitive remote replacement rewrite_rule_ids sarif sarif_outputs
       scan_unknown_extensions secrets semgrepignore_filename severity show_supported_languages
+      skip_invalid_configs
       strict target_roots test test_ignore_todo text text_outputs time_flag timeout
       _timeout_interfileTODO timeout_threshold (*  trace trace_endpoint *) use_git
       validate version version_check vim vim_outputs
@@ -1599,6 +1616,7 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
       incremental_output_postprocess;
       engine_type;
       rewrite_rule_ids;
+      skip_invalid_configs;
       matching_conf;
       common;
       (* ugly: *)
@@ -1637,7 +1655,8 @@ let cmdline_term caps ~allow_empty_config : conf Term.t =
     $ o_effect_guards
     $ o_pro_path_sensitive $ o_remote $ o_replacement
     $ o_rewrite_rule_ids $ o_sarif $ o_sarif_outputs $ o_scan_unknown_extensions
-    $ o_secrets $ o_semgrepignore_filename $ o_severity $ o_show_supported_languages $ o_strict
+    $ o_secrets $ o_semgrepignore_filename $ o_severity $ o_show_supported_languages
+    $ o_skip_invalid_configs $ o_strict
     $ o_target_roots $ o_test $ Test_CLI.o_test_ignore_todo $ o_text
     $ o_text_outputs $ o_time $ o_timeout $ o_timeout_interfile
     $ o_timeout_threshold $ (* o_trace $ o_trace_endpoint $ *) o_use_git $ o_validate

--- a/src/osemgrep/cli_scan/Scan_CLI.mli
+++ b/src/osemgrep/cli_scan/Scan_CLI.mli
@@ -17,6 +17,9 @@ type conf = {
   (* Other configuration options *)
   error_on_findings : bool;
   rewrite_rule_ids : bool;
+  (* skip rule files that fail to parse (e.g. non-rule YAML found in a
+   * directory or cloned git repo) instead of aborting the scan *)
+  skip_invalid_configs : bool;
   matching_conf : Match_patterns.matching_conf;
   engine_type : Engine_type.t;
   autofix : bool;

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -361,8 +361,8 @@ let mk_core_run_for_osemgrep (caps : < Core_scan.caps ; .. >)
   in
   core_run_for_osemgrep
 
-let rules_from_rules_source ~rewrite_rule_ids ~strict caps
-    rules_source =
+let rules_from_rules_source ?(skip_invalid_configs = false) ~rewrite_rule_ids
+    ~strict caps rules_source =
   (* Create the wait hook for our progress indicator *)
   let spinner_ls =
     if Console_Spinner.should_show_spinner () then
@@ -371,8 +371,8 @@ let rules_from_rules_source ~rewrite_rule_ids ~strict caps
   in
   (* Fetch the rules *)
   let rules_and_origins =
-    Rule_fetching.rules_from_rules_source_async ~rewrite_rule_ids
-      ~strict
+    Rule_fetching.rules_from_rules_source_async ~skip_invalid_configs
+      ~rewrite_rule_ids ~strict
       (caps :> < Cap.network ; Cap.tmp >)
       rules_source
   in
@@ -683,6 +683,7 @@ let run_scan_conf (caps : < caps ; .. >) (conf : Scan_CLI.conf) : Exit_code.t =
   let rules_and_origins, fatal_errors =
     rules_from_rules_source
       (caps :> < Cap.network ; Cap.tmp >)
+      ~skip_invalid_configs:conf.skip_invalid_configs
       ~rewrite_rule_ids:conf.rewrite_rule_ids
       ~strict:conf.core_runner_conf.strict conf.rules_source
   in

--- a/src/osemgrep/cli_scan/Scan_subcommand.ml
+++ b/src/osemgrep/cli_scan/Scan_subcommand.ml
@@ -297,22 +297,34 @@ let print_feature_section (* ~(includes_token : bool) ~(engine : Engine_type.t) 
 let display_rule_source ~(rule_source : Rules_source.t) : unit =
   let msg =
     match rule_source with
-    | Configs xs
-      when List.exists
-             (function
-               | C.A _
-               | R _ ->
-                   true
-               | _ -> false)
-             (List_.map
-                (fun str ->
-                  Rules_config.parse_config_string ~in_docker:false str)
-                xs) ->
-        Ocolor_format.asprintf {|@{<bold>  %s@}|}
-          "Loading rules from registry..."
-    | Configs _ ->
-        Ocolor_format.asprintf {|@{<bold>  %s@}|}
-          "Loading rules from local config..."
+    | Configs xs -> (
+        let kinds =
+          List_.map
+            (fun str -> Rules_config.parse_config_string ~in_docker:false str)
+            xs
+        in
+        let has = function
+          | `Registry ->
+              List.exists
+                (function
+                  | C.A _
+                  | C.R _ ->
+                      true
+                  | _ -> false)
+                kinds
+          | `Git ->
+              List.exists (function C.Git _ -> true | _ -> false) kinds
+        in
+        match () with
+        | _ when has `Registry ->
+            Ocolor_format.asprintf {|@{<bold>  %s@}|}
+              "Loading rules from registry..."
+        | _ when has `Git ->
+            Ocolor_format.asprintf {|@{<bold>  %s@}|}
+              "Loading rules from git repository..."
+        | _ ->
+            Ocolor_format.asprintf {|@{<bold>  %s@}|}
+              "Loading rules from local config...")
     | Pattern _ -> Ocolor_format.asprintf {|@{  %s@}|} "Using custom pattern."
   in
   Logs.app (fun m -> m "%s" msg);

--- a/src/osemgrep/cli_test/Test_subcommand.ml
+++ b/src/osemgrep/cli_test/Test_subcommand.ml
@@ -181,6 +181,7 @@ let rules_and_targets (kind : Test_CLI.target_kind) (errors : error list ref) :
       | File rule_file -> [ (rule_file, targets) ]
       | Dir _
       | URL _
+      | Git _
       | R _
       | A _ ->
           (* stricter: *)
@@ -209,6 +210,7 @@ let rules_and_targets (kind : Test_CLI.target_kind) (errors : error list ref) :
                    Some (rule_file, targets)))
       | File _
       | URL _
+      | Git _
       | R _
       | A _ ->
           (* stricter: *)

--- a/src/osemgrep/cli_validate/Validate_subcommand.ml
+++ b/src/osemgrep/cli_validate/Validate_subcommand.ml
@@ -149,7 +149,8 @@ let find_targets_rules (caps : < caps ; .. >) ~(strict : bool)
            | CLI_argument
            | Registry
            | App
-           | Untrusted_remote _ ->
+           | Untrusted_remote _
+           | Git_repo _ ->
                (* TODO: stricter: warn if we didn't validate since it
                 * wasn't in a local file already (e.g., registry or other
                 * remote URI)

--- a/src/osemgrep/cli_validate/Validate_subcommand.ml
+++ b/src/osemgrep/cli_validate/Validate_subcommand.ml
@@ -46,6 +46,15 @@ module Out = Semgrep_output_v1_t
  *  (4) TODO Other errors that can't be detected easily using Semgrep rules. We
  *    detect those thanks to Check_rule.ml.
  *
+ * IMPORTANT: 'validate' is meant to validate *local* rules (a file or a
+ * directory of rules). The metachecks in (3) run on the rule files on disk,
+ * so only rules that come from a local config are fully validated. Rules
+ * fetched from a non-local config (registry 'p/...'/'r/...', a URL, or a
+ * 'git+<url>' repo) are still parsed, so (1) and (2) apply, but they provide
+ * no persistent file to metacheck and are therefore skipped in (3). When no
+ * config is local we emit a warning (see find_targets_rules) so this is not
+ * silent.
+ *
  * For more info see
  * https://semgrep.dev/docs/writing-rules/testing-rules#validating-rules
  *
@@ -151,12 +160,22 @@ let find_targets_rules (caps : < caps ; .. >) ~(strict : bool)
            | App
            | Untrusted_remote _
            | Git_repo _ ->
-               (* TODO: stricter: warn if we didn't validate since it
-                * wasn't in a local file already (e.g., registry or other
-                * remote URI)
-                *)
+               (* These origins don't provide a local rule file to run the
+                * metachecks against (registry/URL/git+ rules are fetched into
+                * transient files that are already gone). They are still parsed
+                * above, but not metachecked. See the warning below. *)
                None)
   in
+  (* Metachecks run on the rule *files*, which only local configs provide. If
+   * no config resolved to a local file, no rule is metachecked at all. The
+   * rules were still parsed (a first form of validation), but warn so this
+   * weaker gate is not silent. *)
+  if List_.null targets && not (List_.null rules) then
+    Logs.warn (fun m ->
+        m
+          "no rules were metachecked: none of the given configs is a local \
+           file or directory (registry, URL and git+ configs are parsed but \
+           not metachecked)");
   ( targets,
     List.length rules,
     List.length fatal_errors,

--- a/src/osemgrep/core/Rules_config.ml
+++ b/src/osemgrep/core/Rules_config.ml
@@ -29,8 +29,19 @@ type t =
   | Dir of Fpath.t
   (* ex: 'https://raw.githubusercontent.com/r2c/semgrep-rules/template.yaml' *)
   | URL of Uri.t
+  (* ex: 'git+https://github.com/org/rules', 'git+ssh://git@host/org/rules#v1'
+   * A whole remote git repository of rules, cloned locally and then loaded
+   * like a Dir. *)
+  | Git of git_config
   | R of registry_config_kind
   | A of app_config_kind
+
+(* the config string after the 'git+' prefix, split into the clone URL and
+ * an optional branch/tag given as a '#'-fragment (e.g. '...#v1.2.0'). *)
+and git_config = {
+  url : Uri.t;
+  ref_ : string option;
+}
 
 (* Not a great name but at least when one sees 'registry_config_kind',
  * it is a bit less ambiguous than 'registry_config' which could be some
@@ -64,6 +75,20 @@ let parse_config_string ~in_docker (config_str : config_string) : t =
   | s when s =~ "^r/\\(.*\\)" -> R (Registry (Common.matched1 s))
   | s when s =~ "^p/\\(.*\\)" -> R (Pack (Common.matched1 s))
   | s when s =~ "^s/\\(.*\\)" -> R (Snippet (Common.matched1 s))
+  (* A remote git repo of rules: 'git+<url>' with an optional '#<ref>'
+   * fragment selecting a branch or tag. We use a '#'-fragment (rather than a
+   * pip-style '@ref') because '#' cannot appear in a git URL, so this stays
+   * unambiguous even for scp-like ('git@host:org/repo') and ssh URLs. *)
+  | s when s =~ "^git[+]\\(.*\\)" ->
+      let rest = Common.matched1 s in
+      let url_str, ref_ =
+        match String.index_opt rest '#' with
+        | Some i ->
+            ( String.sub rest 0 i,
+              Some (String.sub rest (i + 1) (String.length rest - i - 1)) )
+        | None -> (rest, None)
+      in
+      Git { url = Uri.of_string url_str; ref_ }
   (* TODO? could not find a Uri.is_url helper function *)
   | s when s =~ "^http[s]?://" -> URL (Uri.of_string s)
   (* TOPORT? handle inline rules "rules:..." see python: utils.is_rules() *)

--- a/src/osemgrep/core/Rules_config.ml
+++ b/src/osemgrep/core/Rules_config.ml
@@ -88,6 +88,19 @@ let parse_config_string ~in_docker (config_str : config_string) : t =
               Some (String.sub rest (i + 1) (String.length rest - i - 1)) )
         | None -> (rest, None)
       in
+      (* Reject empty or option-looking components early with a clear config
+       * error, rather than handing something like '--upload-pack=...' to git.
+       * (git clone is also called with a '--' separator as defense in depth.) *)
+      let reject what =
+        raise
+          (E.Semgrep_error
+             ( spf "invalid `git+` config %s in `%s`" what s,
+               Some (Exit_code.missing_config ~__LOC__) ))
+      in
+      if url_str = "" || Char.equal url_str.[0] '-' then reject "url";
+      (match ref_ with
+      | Some r when r = "" || Char.equal r.[0] '-' -> reject "ref"
+      | _ -> ());
       Git { url = Uri.of_string url_str; ref_ }
   (* TODO? could not find a Uri.is_url helper function *)
   | s when s =~ "^http[s]?://" -> URL (Uri.of_string s)

--- a/src/osemgrep/core/Rules_config.mli
+++ b/src/osemgrep/core/Rules_config.mli
@@ -9,8 +9,19 @@ type t =
   | Dir of Fpath.t
   (* ex: 'https://raw.githubusercontent.com/r2c/semgrep-rules/template.yaml' *)
   | URL of Uri.t
+  (* ex: 'git+https://github.com/org/rules', 'git+ssh://git@host/org/rules#v1'
+   * A whole remote git repository of rules, cloned locally then loaded
+   * like a Dir. *)
+  | Git of git_config
   | R of registry_config_kind
   | A of app_config_kind
+
+(* the config string after the 'git+' prefix: the clone URL and an optional
+ * branch/tag given as a '#'-fragment (e.g. '...#v1.2.0'). *)
+and git_config = {
+  url : Uri.t;
+  ref_ : string option;
+}
 
 and registry_config_kind =
   (* r/... *)

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -115,6 +115,24 @@ let partition_rules_and_invalid (xs : rules_and_origin list) :
   in
   (rules, invalid_rules)
 
+(* When [skip_invalid_configs] is set (via --skip-invalid-configs), files that
+ * fail to parse as a rule config (such as unrelated YAML files found in a
+ * directory or a cloned git repo, e.g. GitHub workflows) are dropped with a
+ * warning instead of aborting the whole scan. Only used for the discovery-
+ * based sources (Dir, Git); explicitly-named configs still fail loudly. *)
+let partition_or_skip ~skip_invalid_configs
+    (results : (rules_and_origin, Rule_error.t) result list) :
+    rules_and_origin list * Rule_error.t list =
+  let oks, errs = Result_.partition Fun.id results in
+  if skip_invalid_configs then (
+    errs
+    |> List.iter (fun (e : Rule_error.t) ->
+           Logs.warn (fun m ->
+               m "skipping invalid rule config %s: %s" !!(e.file)
+                 (Rule_error.string_of_error e)));
+    (oks, []))
+  else (oks, errs)
+
 let fetch_content_from_url_async caps (url : Uri.t) : string Lwt.t =
   (* TOPORT? _nice_semgrep_url() *)
   Logs.info (fun m -> m "trying to download from %s" (Uri.to_string url));
@@ -349,7 +367,8 @@ let load_rules_from_url ~origin ?(ext = "yaml") caps url :
 [@@profiling]
 
 (* TODO: merge caps and token_opt and caps_opt? *)
-let rules_from_dashdash_config_async ~rewrite_rule_ids caps kind :
+let rules_from_dashdash_config_async ?(skip_invalid_configs = false)
+    ~rewrite_rule_ids caps kind :
     (* alt: (rules_and_origin list, Rule.Error.t list) result
        here and below:
        we could do this, but it lacks flexibility compared with this output type
@@ -380,7 +399,7 @@ let rules_from_dashdash_config_async ~rewrite_rule_ids caps kind :
       |> List_.map (fun file ->
              load_rules_from_file ~rewrite_rule_ids ~origin:(Local_file file)
                caps file)
-      |> Result_.partition Fun.id |> Lwt.return
+      |> partition_or_skip ~skip_invalid_configs |> Lwt.return
   | C.URL url ->
       (* TODO: Re-enable passing in our token to trusted remote urls.
          * This is currently disabled because we don't want to pass our token
@@ -409,7 +428,7 @@ let rules_from_dashdash_config_async ~rewrite_rule_ids caps kind :
              load_rules_from_file ~rewrite_rule_ids ~origin:(Git_repo url) caps
                file
              |> Result.map (fun r -> { r with origin = Git_repo url }))
-      |> Result_.partition Fun.id |> Lwt.return
+      |> partition_or_skip ~skip_invalid_configs |> Lwt.return
   | C.R rkind ->
       let url = Semgrep_Registry.url_of_registry_config_kind rkind in
       let%lwt contents =
@@ -426,10 +445,11 @@ let rules_from_dashdash_config_async ~rewrite_rule_ids caps kind :
   | C.A SupplyChain ->
       failwith "TODO: SupplyChain not handled yet"
 
-let rules_from_dashdash_config ~rewrite_rule_ids caps kind :
-    rules_and_origin list * Rule_error.t list =
+let rules_from_dashdash_config ?(skip_invalid_configs = false) ~rewrite_rule_ids
+    caps kind : rules_and_origin list * Rule_error.t list =
   Lwt_platform.run
-    (rules_from_dashdash_config_async ~rewrite_rule_ids caps kind)
+    (rules_from_dashdash_config_async ~skip_invalid_configs ~rewrite_rule_ids
+       caps kind)
 [@@profiling]
 
 (*****************************************************************************)
@@ -480,8 +500,9 @@ let rules_and_origin_of_rule rule =
   { rules = [ rule ]; invalid_rules = []; origin = CLI_argument }
 
 (* python: mix of resolver_config.get_config() and get_rules() *)
-let rules_from_rules_source_async ~rewrite_rule_ids ~strict:_ caps
-    (src : Rules_source.t) : (rules_and_origin list * Rule_error.t list) Lwt.t =
+let rules_from_rules_source_async ?(skip_invalid_configs = false)
+    ~rewrite_rule_ids ~strict:_ caps (src : Rules_source.t) :
+    (rules_and_origin list * Rule_error.t list) Lwt.t =
   let%lwt rules_and_origins, errors =
     match src with
     | Configs xs ->
@@ -490,8 +511,8 @@ let rules_from_rules_source_async ~rewrite_rule_ids ~strict:_ caps
           |> Lwt_list.map_p (fun str ->
                  let in_docker = !Semgrep_envvars.v.in_docker in
                  let config = Rules_config.parse_config_string ~in_docker str in
-                 rules_from_dashdash_config_async ~rewrite_rule_ids
-                   caps config)
+                 rules_from_dashdash_config_async ~skip_invalid_configs
+                   ~rewrite_rule_ids caps config)
         in
         let rules_and_origins_nested, errors_nested =
           Common2.unzip pairs_list
@@ -554,8 +575,10 @@ let rules_from_rules_source_async ~rewrite_rule_ids ~strict:_ caps
  * to use the _async variant above mixed with a spinner as in
  * Scan_subcommand.rules_from_rules_source()
  *)
-let rules_from_rules_source ~rewrite_rule_ids ~strict caps
-    (src : Rules_source.t) : rules_and_origin list * Rule_error.t list =
+let rules_from_rules_source ?(skip_invalid_configs = false) ~rewrite_rule_ids
+    ~strict caps (src : Rules_source.t) :
+    rules_and_origin list * Rule_error.t list =
   Lwt_platform.run
-    (rules_from_rules_source_async ~rewrite_rule_ids ~strict caps src)
+    (rules_from_rules_source_async ~skip_invalid_configs ~rewrite_rule_ids
+       ~strict caps src)
 [@@profiling]

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -412,23 +412,25 @@ let rules_from_dashdash_config_async ?(skip_invalid_configs = false)
       [ rules ] |> Result_.partition Fun.id |> Lwt.return
   | C.Git { url; ref_ } ->
       (* Clone the repo into a fresh temp dir, then load every rule file in it
-       * like a Dir. Auth is entirely git's business (see Git_wrapper); we run
+       * like a Dir. The temp dir (including the .git it contains) is removed
+       * as soon as the rules are parsed into memory, thanks to with_temp_dir.
+       * Auth is entirely git's business (see Git_wrapper); we run
        * non-interactively and fail fast rather than prompt. *)
-      let reserved = CapTmp.new_temp_file ~prefix:"opengrep-git-" caps#tmp in
-      let checkout_dir = Fpath.v (!!reserved ^ "-checkout") in
-      (match Git_wrapper.shallow_clone ?ref_ url checkout_dir with
-      | Ok () -> ()
-      | Error msg -> Error.abort msg);
-      (* We stamp the origin as [Git_repo url] rather than [Local_file <tmp>]
-       * so that rule-ids are not prefixed with the temp path and the true
-       * (untrusted) origin is tracked. *)
-      List_files.list checkout_dir
-      |> List.filter Rule_file.is_valid_rule_filename
-      |> List_.map (fun file ->
-             load_rules_from_file ~rewrite_rule_ids ~origin:(Git_repo url) caps
-               file
-             |> Result.map (fun r -> { r with origin = Git_repo url }))
-      |> partition_or_skip ~skip_invalid_configs |> Lwt.return
+      CapTmp.with_temp_dir ~prefix:"opengrep-git-" caps#tmp (fun checkout_dir ->
+          (match Git_wrapper.shallow_clone ?ref_ url checkout_dir with
+          | Ok () -> ()
+          | Error msg -> Error.abort msg);
+          (* We stamp the origin as [Git_repo url] rather than [Local_file
+           * <tmp>] so that rule-ids are not prefixed with the temp path and
+           * the true (untrusted) origin is tracked. *)
+          List_files.list checkout_dir
+          |> List.filter Rule_file.is_valid_rule_filename
+          |> List_.map (fun file ->
+                 load_rules_from_file ~rewrite_rule_ids ~origin:(Git_repo url)
+                   caps file
+                 |> Result.map (fun r -> { r with origin = Git_repo url }))
+          |> partition_or_skip ~skip_invalid_configs)
+      |> Lwt.return
   | C.R rkind ->
       let url = Semgrep_Registry.url_of_registry_config_kind rkind in
       let%lwt contents =

--- a/src/osemgrep/networking/Rule_fetching.ml
+++ b/src/osemgrep/networking/Rule_fetching.ml
@@ -52,6 +52,10 @@ and origin =
   | Registry
   | App
   | Untrusted_remote of Uri.t
+  (* For rules cloned from a remote git repository passed as 'git+<url>'.
+   * Like Untrusted_remote, these are third-party rules and do not get the
+   * trust granted to registry/app rules. *)
+  | Git_repo of Uri.t
 [@@deriving show]
 
 (*****************************************************************************)
@@ -178,7 +182,8 @@ let mk_import_callback (caps : < Cap.network ; Cap.tmp ; .. >) base str =
            * factorize with rules_from_dashdash_config?
            *)
           | C.Dir _
-          | C.File _ ->
+          | C.File _
+          | C.Git _ ->
               None
         with
         | E.Semgrep_error _ -> None
@@ -224,7 +229,8 @@ let modify_registry_provided_metadata (origin : origin) (rule : Rule.t) =
       rule
   | CLI_argument
   | Local_file _
-  | Untrusted_remote _ ->
+  | Untrusted_remote _
+  | Git_repo _ ->
       let replace obj key v =
         match (obj : JSON.t) with
         | Object members ->
@@ -385,6 +391,25 @@ let rules_from_dashdash_config_async ~rewrite_rule_ids caps kind :
         load_rules_from_url_async ~origin:(Untrusted_remote url) caps url
       in
       [ rules ] |> Result_.partition Fun.id |> Lwt.return
+  | C.Git { url; ref_ } ->
+      (* Clone the repo into a fresh temp dir, then load every rule file in it
+       * like a Dir. Auth is entirely git's business (see Git_wrapper); we run
+       * non-interactively and fail fast rather than prompt. *)
+      let reserved = CapTmp.new_temp_file ~prefix:"opengrep-git-" caps#tmp in
+      let checkout_dir = Fpath.v (!!reserved ^ "-checkout") in
+      (match Git_wrapper.shallow_clone ?ref_ url checkout_dir with
+      | Ok () -> ()
+      | Error msg -> Error.abort msg);
+      (* We stamp the origin as [Git_repo url] rather than [Local_file <tmp>]
+       * so that rule-ids are not prefixed with the temp path and the true
+       * (untrusted) origin is tracked. *)
+      List_files.list checkout_dir
+      |> List.filter Rule_file.is_valid_rule_filename
+      |> List_.map (fun file ->
+             load_rules_from_file ~rewrite_rule_ids ~origin:(Git_repo url) caps
+               file
+             |> Result.map (fun r -> { r with origin = Git_repo url }))
+      |> Result_.partition Fun.id |> Lwt.return
   | C.R rkind ->
       let url = Semgrep_Registry.url_of_registry_config_kind rkind in
       let%lwt contents =

--- a/src/osemgrep/networking/Rule_fetching.mli
+++ b/src/osemgrep/networking/Rule_fetching.mli
@@ -60,6 +60,7 @@ val langs_of_pattern : string * Xlang.t option -> Xlang.t list
  * Note that this also handles the experiment rules in jsonnet!
  *)
 val rules_from_rules_source :
+  ?skip_invalid_configs:bool ->
   rewrite_rule_ids:bool ->
   strict:bool ->
   < Cap.network ; Cap.tmp > ->
@@ -68,6 +69,7 @@ val rules_from_rules_source :
 
 (* TODO: make cap network an option (with token) *)
 val rules_from_rules_source_async :
+  ?skip_invalid_configs:bool ->
   rewrite_rule_ids:bool ->
   strict:bool ->
   < Cap.network ; Cap.tmp > ->
@@ -77,6 +79,7 @@ val rules_from_rules_source_async :
 (* internals *)
 
 val rules_from_dashdash_config_async :
+  ?skip_invalid_configs:bool ->
   rewrite_rule_ids:bool ->
   < Cap.network ; Cap.tmp ; .. > ->
   Rules_config.t ->
@@ -87,6 +90,7 @@ val rules_from_dashdash_config_async :
  * rules_and_origin per files in this folder.
  *)
 val rules_from_dashdash_config :
+  ?skip_invalid_configs:bool ->
   rewrite_rule_ids:bool ->
   < Cap.network ; Cap.tmp ; .. > ->
   Rules_config.t ->

--- a/src/osemgrep/networking/Rule_fetching.mli
+++ b/src/osemgrep/networking/Rule_fetching.mli
@@ -38,6 +38,7 @@ and origin =
    * additional flags to opt-in, due to security considerations.
    *)
   | Untrusted_remote of Uri.t
+  | Git_repo of Uri.t
 [@@deriving show]
 
 val partition_rules_and_invalid :


### PR DESCRIPTION
## TLDR

- add `--config git+URL` to load rules directly from a git repo
- add `--skip-invalid-configs` flag to skip `yaml` files that do not contain rules
- update the `validate` subcommand to warn if no validation is run (i.e., when all rules come from remote repos)

## Summary

Adds the ability to point `--config` at a **remote git repository of rules** in the `--experimental` (osemgrep) frontend, plus a companion flag to tolerate non-rule YAML files that such repositories inevitably contain.

```
opengrep scan --experimental --config git+https://github.com/org/rules
opengrep scan --experimental --config git+https://github.com/org/rules#v1.2.0
opengrep scan --experimental --config git+ssh://git@github.com/org/private-rules
opengrep scan --experimental --skip-invalid-configs --config git+https://github.com/org/rules
```

The repo is shallow-cloned into a temp dir and then loaded exactly like a local directory of rules.

## Motivation

Previously `--config` accepted a local file, a local directory, a single HTTP(S) URL (a *single* downloadable rule file), and registry/app shortcuts (`p/`, `r/`, `s/`, `auto`, ...). There was no way to consume a whole remote repository of rules — a common way teams share and version their rulesets. A bare `https://github.com/org/rules` URL was treated as a single-file download and simply failed.

## What's included

### 1. `git+<url>` config source

- New `Git of git_config` variant in `Rules_config.t`, parsed from a `git+` prefix. An optional `#<ref>` fragment pins a branch or tag (e.g. `...#v1.2.0`).
  - The `#`-fragment syntax is used (rather than a pip-style `@ref`) because `#` cannot appear in a git URL, so it stays unambiguous for scp-like (`git@host:org/repo`) and `ssh://` URLs.
- New `Git_wrapper.shallow_clone ?ref_ url dst` helper: a depth-1 clone that materializes the whole tree (unlike the existing `sparse_shallow_filtered_checkout`, which deliberately avoids checkout).
- New `Git_repo of Uri.t` origin in `Rule_fetching`. Rules cloned from a repo are treated as **untrusted** (same as other non-registry/app rules — secrets validators stay disabled), and rule-ids are not prefixed with the temp path.
- The `C.Git` case clones into a temp dir and reuses the directory-loading path.

### 2. Credentials / non-interactive behavior

Opengrep manages **no credentials of its own**. Because the clone shells out to the real `git` binary, git resolves auth exactly as it does in the user's terminal (ssh-agent, credential helpers, `.netrc`, ...). If `git clone <url>` works in your terminal, it works here.

To keep the tool batch-oriented and never hang, `shallow_clone` sets `GIT_TERMINAL_PROMPT=0` (and `GIT_SSH_COMMAND=ssh -oBatchMode=yes` unless the user already customized it) so a clone that would otherwise prompt for a password / passphrase / host-key confirmation **fails fast** with an actionable error instead.

### 3. `--skip-invalid-configs` flag

Remote repos (and local directories) commonly contain YAML that isn't a rule config — GitHub workflows, `docker-compose.yml`, etc. Without help, the first such file aborts the scan with "invalid configuration file found".

`--skip-invalid-configs` skips files that fail to parse as a rule config, emitting a per-file `WARNING`, and proceeds with the valid ones. Scope:

- Applies to **discovery-based sources only** — directories and `git+` repos.
- **Explicitly named** configs (`--config foo.yaml`, URLs) still fail loudly if invalid — naming a broken file is a real error, not something to drop silently.
- Individual invalid *rules* inside an otherwise-valid file keep their existing `invalid_rules` handling.

### 4. UX

- `--config` help text (osemgrep frontend) documents the `git+<url>` form and the `#<ref>` pin. (The Python frontend's `--config` has no help string, so the two are independent.)
- The rule-fetching status line now reads **"Loading rules from git repository..."** for `git+` configs, distinct from the local/registry messages.
- New flags are marked `REQUIRES --experimental`, following the existing convention for osemgrep-only options.

### 5. Temp-directory lifecycle (no leaks)

The clone must not be left behind on disk. Registry/URL configs already get this for free via `CapTmp.with_temp_file` (download → parse → delete), but that helper only handles single files; a git clone produces a whole directory (including `.git`).

Added a directory analogue, `CapTmp.with_temp_dir` (wrapping new `UTmp.with_temp_dir`), that mirrors `with_temp_file`: it creates a fresh temp dir, runs the callback, and removes the dir recursively in a `Common.finalize` — so it is cleaned up even if the clone or parse raises. The removal is symlink-safe (`lstat` per entry, so symlinks are unlinked rather than followed) and honors the global save-temp-files flag (`--save-temp-files` preserves the checkout for debugging). We deliberately avoid using `Bos` at the call site (and it is shadowed inside `commons` anyway), so the recursive delete is hand-rolled on `USys`/`UUnix`.

The `git+` path now wraps clone-and-load in `with_temp_dir`: rules are fully parsed into memory before the callback returns, so the checkout is deleted immediately afterward — the same "fetch → parse → delete" lifecycle the registry path already has. Net result: **zero leaked temp directories** after a scan.

### 6. Argument-injection hardening

`git+<url>` text was previously handed to `git clone` as-is. A value like `git+--upload-pack=...` could be interpreted by git as an *option* rather than a repository. Fixed on two levels:

- `shallow_clone` now terminates option parsing with `--` before the positional repo/dir arguments, and passes the ref as `--branch=<ref>` (the `=` form) so a ref starting with `-` cannot be read as an option.
- `Rules_config` rejects empty or option-looking (`-…`) url/ref components while parsing the `git+` string, so bad input fails early with a clear configuration error instead of reaching git.

### 7. `validate` warns when nothing is metachecked

`opengrep validate` runs metachecks against the rule *files*, which only local (file/dir) configs provide; registry, URL, and now `git+` configs are parsed but produce no file to metacheck (their fetched files are transient). This was already the behavior for registry/URL, silently. We keep those origins non-metacheckable (no behavior change to *what* is validated) but now emit a warning when the resulting target set is empty — i.e. when none of the given configs is local — so the weaker gate is no longer silent. This also implements a long-standing `TODO` in that code.
