### PR TITLE
AST-to-IL: Translate record destructuing with default values

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -978,6 +978,33 @@ and assign_to_record env (tok1, fields, tok2) rhs_exp lhs_orig : stmts * exp =
         let offset = { o = Dot fldi; oorig = NoOrig } in
         let ss, fields = do_fields (offset :: acc_rev_offsets) fields in
         (ss, Field (fldi, mk_e (RecordOrDict fields) (related_tok tok)))
+    | G.F
+        {
+          s =
+            G.ExprStmt
+              ({ e = G.LetPattern (G.PatId (id, ii), _default); _ }, _);
+          _;
+        } ->
+        (* JS/TS object-shorthand destructure with a default value:
+         * `{ fld = default }`. The binding name and the field name are the
+         * same identifier `fld`; lower as [fld := tmp. ... .fld], exactly
+         * like the no-default `{ fld }` case above. The default is a fallback
+         * taken only when the field is absent, so for taint (a may-analysis)
+         * the field-present value dominates; ignoring it here matches the
+         * lowering of the renamed form `{ fld: v = default }`. *)
+        let tok = snd id in
+        let fldi = var_of_id_info id ii in
+        let offset = { o = Dot fldi; oorig = NoOrig } in
+        let vari_lval = lval_of_id_info id ii in
+        let ei =
+          mk_e
+            (Fetch { base = Var tmp; rev_offset = offset :: acc_rev_offsets })
+            (related_tok tok)
+        in
+        let instr =
+          mk_s (Instr (mk_i (Assign (vari_lval, ei)) (related_tok tok)))
+        in
+        ([ instr ], Field (fldi, mk_e (Fetch vari_lval) (related_tok tok)))
     | field ->
         (* TODO: What other patterns could be nested ? *)
         (* __FIXME_AST_to_IL__: FixmeExp ToDo *)

--- a/tests/tainting_rules/js/destructuring_default.js
+++ b/tests/tainting_rules/js/destructuring_default.js
@@ -1,0 +1,94 @@
+// Object destructuring with a default value must not drop taint.
+// JS shares the same frontend/IL-lowering path as TS; this mirrors the
+// regression coverage in tests/tainting_rules/ts/destructuring_default.ts.
+
+function shorthandDefault(params) {
+  const { a = 0 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+}
+
+function plain(params) {
+  const { a } = params; // no default (control)
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+}
+
+function renamedDefault(params) {
+  const { a: b = 0 } = params; // renamed + default (control)
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function ternary(params) {
+  const a = params.a === undefined ? 0 : params.a; // desugared control
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+}
+
+function nestedDefault(params) {
+  const { outer: { inner = 0 } = {} } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(inner);
+}
+
+// --- Patterns with more than one element ------------------------------------
+
+function twoDefaults(params) {
+  const { a = 0, b = 1 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function defaultThenPlain(params) {
+  const { a = 0, b } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function plainThenDefault(params) {
+  const { a, b = 1 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function renamedAndShorthandMixed(params) {
+  const { a: x = 0, b, c: z = 2 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(x);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+  // ruleid: destructuring-default-taint-loss
+  sink(z);
+}
+
+function withRest(params) {
+  const { a = 0, ...rest } = params;
+  // the default binding is tainted even when a rest element follows
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // object-rest bindings drop taint via a separate code path (FieldSpread);
+  // that is a distinct pre-existing gap, tracked here as a known TODO.
+  // todoruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function noTaint() {
+  const { a = 0 } = {}; // RHS is not a parameter: must stay untainted
+  // ok: destructuring-default-taint-loss
+  sink(a);
+}
+
+function noTaintMulti() {
+  const { a = 0, b = 1 } = {}; // multiple defaults, still untainted
+  // ok: destructuring-default-taint-loss
+  sink(a);
+  // ok: destructuring-default-taint-loss
+  sink(b);
+}

--- a/tests/tainting_rules/js/destructuring_default.yaml
+++ b/tests/tainting_rules/js/destructuring_default.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: destructuring-default-taint-loss
+    languages: [javascript]
+    severity: ERROR
+    message: taint reached sink
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-inside: |
+              function $_(..., $INPUT, ...) {
+                ...
+              }
+          - focus-metavariable: $INPUT
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/tainting_rules/ts/destructuring_default.ts
+++ b/tests/tainting_rules/ts/destructuring_default.ts
@@ -1,0 +1,95 @@
+// Object destructuring with a default value must not drop taint.
+// Regression test: `const { a = 0 } = params;` used to lose taint because
+// the `{ a = default }` shorthand lowered to a record field shape that
+// `assign_to_record` did not handle, dropping the field fetch.
+
+function shorthandDefault(params) {
+  const { a = 0 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+}
+
+function plain(params) {
+  const { a } = params; // no default (control)
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+}
+
+function renamedDefault(params) {
+  const { a: b = 0 } = params; // renamed + default (control)
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function ternary(params) {
+  const a = params.a === undefined ? 0 : params.a; // desugared control
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+}
+
+function nestedDefault(params) {
+  const { outer: { inner = 0 } = {} } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(inner);
+}
+
+// --- Patterns with more than one element ------------------------------------
+
+function twoDefaults(params) {
+  const { a = 0, b = 1 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function defaultThenPlain(params) {
+  const { a = 0, b } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function plainThenDefault(params) {
+  const { a, b = 1 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+}
+
+function renamedAndShorthandMixed(params) {
+  const { a: x = 0, b, c: z = 2 } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(x);
+  // ruleid: destructuring-default-taint-loss
+  sink(b);
+  // ruleid: destructuring-default-taint-loss
+  sink(z);
+}
+
+function withRest(params) {
+  const { a = 0, ...rest } = params;
+  // the default binding is tainted even when a rest element follows
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // object-rest bindings drop taint via a separate code path (FieldSpread);
+  // that is a distinct pre-existing gap, tracked here as a known TODO.
+  // todoruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function noTaint() {
+  const { a = 0 } = {}; // RHS is not a parameter: must stay untainted
+  // ok: destructuring-default-taint-loss
+  sink(a);
+}
+
+function noTaintMulti() {
+  const { a = 0, b = 1 } = {}; // multiple defaults, still untainted
+  // ok: destructuring-default-taint-loss
+  sink(a);
+  // ok: destructuring-default-taint-loss
+  sink(b);
+}

--- a/tests/tainting_rules/ts/destructuring_default.yaml
+++ b/tests/tainting_rules/ts/destructuring_default.yaml
@@ -1,0 +1,15 @@
+rules:
+  - id: destructuring-default-taint-loss
+    languages: [typescript]
+    severity: ERROR
+    message: taint reached sink
+    mode: taint
+    pattern-sources:
+      - patterns:
+          - pattern-inside: |
+              function $_(..., $INPUT, ...) {
+                ...
+              }
+          - focus-metavariable: $INPUT
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
Fix incorrect translation of code that appears after parsing destructuring of records with default values in js/ts, e.g.

```ts
const { a = 0, b } = params;
```