### PR TITLE
ts: support .mts and .cts file extensions

### DIFF
--- a/libs/commons/File_type.ml
+++ b/libs/commons/File_type.ml
@@ -263,6 +263,8 @@ let file_type_of_file file =
   | "coffee" -> PL (Web Coffee)
   | "ts" -> PL (Web TypeScript)
   | "tsx" -> PL (Web TypeScript) (* Typescript with JSX enabled *)
+  | "mts" -> PL (Web TypeScript) (* TypeScript ESM module *)
+  | "cts" -> PL (Web TypeScript) (* TypeScript CJS module *)
   | "vue" -> PL (Web Vue)
   | "html"
   | "htm" ->

--- a/src/targeting/Unit_guess_lang.ml
+++ b/src/targeting/Unit_guess_lang.ml
@@ -26,6 +26,10 @@ let name_tests : (string * Lang.t * Fpath.t * success) list =
     ("jsx", Js, "foo.jsx", OK);
     ("typescript", Ts, "foo.ts", OK);
     ("typescript .d.ts", Ts, "foo.d.ts", XFAIL);
+    ("typescript mts", Ts, "foo.mts", OK);
+    ("typescript cts", Ts, "foo.cts", OK);
+    ("typescript .d.mts", Ts, "foo.d.mts", XFAIL);
+    ("typescript .d.cts", Ts, "foo.d.cts", XFAIL);
     ("crystal", Crystal, "foo.cr", OK);
     ("spaces", Ruby, " a b  c.rb", OK);
   ]


### PR DESCRIPTION
Fixes #691.

Add `.mts` and `.cts` (TypeScript ESM/CJS module variants) to the recognized TypeScript extensions, and `.d.mts`/`.d.cts` to the excluded declaration files.