### PR TITLE
JS/TS: Taint `..rest` of object in destructuring

### DIFF
--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -1005,6 +1005,32 @@ and assign_to_record env (tok1, fields, tok2) rhs_exp lhs_orig : stmts * exp =
           mk_s (Instr (mk_i (Assign (vari_lval, ei)) (related_tok tok)))
         in
         ([ instr ], Field (fldi, mk_e (Fetch vari_lval) (related_tok tok)))
+    | G.F
+        {
+          s =
+            G.ExprStmt
+              ( {
+                  e =
+                    G.Call
+                      ( { e = G.IdSpecial (G.Spread, _); _ },
+                        (_, [ G.Arg { e = G.N (G.Id (id, ii)); _ } ], _) );
+                  _;
+                },
+                _ );
+          _;
+        } ->
+        let tok = snd id in
+        let vari = var_of_id_info id ii in
+        let vari_lval = lval_of_base (Var vari) in
+        let ei =
+          mk_e
+            (Fetch { base = Var tmp; rev_offset = acc_rev_offsets })
+            (related_tok tok)
+        in
+        let instr =
+          mk_s (Instr (mk_i (Assign (vari_lval, ei)) (related_tok tok)))
+        in
+        ([ instr ], Spread (mk_e (Fetch vari_lval) (related_tok tok)))
     | field ->
         (* TODO: What other patterns could be nested ? *)
         (* __FIXME_AST_to_IL__: FixmeExp ToDo *)

--- a/src/analyzing/AST_to_IL.ml
+++ b/src/analyzing/AST_to_IL.ml
@@ -934,12 +934,31 @@ and assign_to_record env (tok1, fields, tok2) rhs_exp lhs_orig : stmts * exp =
    *     vN = tmp.xN
    *)
   let aux_ss, tmp, _tmp_lval = aux_var env tok1 rhs_exp in
+  (* The property name captured by a non-rest field binding, i.e. the key that
+   * a sibling `...rest` in the same object pattern excludes. [None] for a rest
+   * binding or any shape we do not lower into a keyed field. *)
+  let field_key_name (f : G.field) : name option =
+    match f with
+    | G.F
+        {
+          s = G.DefStmt ({ name = EN (G.Id (id1, ii1)); _ }, G.FieldDefColon _);
+          _;
+        } ->
+        Some (var_of_id_info id1 ii1)
+    | G.F { s = G.ExprStmt ({ e = G.LetPattern (G.PatId (id, ii), _); _ }, _); _ }
+      ->
+        Some (var_of_id_info id ii)
+    | _ -> None
+  in
   let rec do_fields acc_rev_offsets fs =
-    let results = List.map (fun x -> do_field acc_rev_offsets x) fs in
+    let sibling_keys = List.filter_map field_key_name fs in
+    let results =
+      List.map (fun x -> do_field acc_rev_offsets sibling_keys x) fs
+    in
     let ss = List.concat_map fst results in
     let fields = List.map snd results in
     (ss, fields)
-  and do_field acc_rev_offsets f =
+  and do_field acc_rev_offsets sibling_keys f =
     match f with
     | G.F
         {
@@ -1030,7 +1049,25 @@ and assign_to_record env (tok1, fields, tok2) rhs_exp lhs_orig : stmts * exp =
         let instr =
           mk_s (Instr (mk_i (Assign (vari_lval, ei)) (related_tok tok)))
         in
-        ([ instr ], Spread (mk_e (Fetch vari_lval) (related_tok tok)))
+        (* `rest` excludes the sibling keys destructured at this level. After
+         * copying the whole (sub-)scrutinee, strong-update each such key on
+         * `rest` to a clean value, so field-specific taint on a taken key does
+         * not leak into `rest`. Whole-object (root) taint survives, as it
+         * covers `rest`'s other/unknown fields. *)
+        let clear_instrs =
+          List.map
+            (fun key ->
+              let clear_lval =
+                { base = Var vari; rev_offset = [ { o = Dot key; oorig = NoOrig } ] }
+              in
+              let clean_exp =
+                mk_e (Literal (G.Null (Tok.unsafe_fake_tok "_"))) NoOrig
+              in
+              mk_s
+                (Instr (mk_i (Assign (clear_lval, clean_exp)) (related_tok tok))))
+            sibling_keys
+        in
+        (instr :: clear_instrs, Spread (mk_e (Fetch vari_lval) (related_tok tok)))
     | field ->
         (* TODO: What other patterns could be nested ? *)
         (* __FIXME_AST_to_IL__: FixmeExp ToDo *)

--- a/tests/tainting_rules/js/destructuring_default.js
+++ b/tests/tainting_rules/js/destructuring_default.js
@@ -70,12 +70,29 @@ function renamedAndShorthandMixed(params) {
 
 function withRest(params) {
   const { a = 0, ...rest } = params;
-  // the default binding is tainted even when a rest element follows
   // ruleid: destructuring-default-taint-loss
   sink(a);
-  // object-rest bindings drop taint via a separate code path (FieldSpread);
-  // that is a distinct pre-existing gap, tracked here as a known TODO.
-  // todoruleid: destructuring-default-taint-loss
+  // ruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function restOnly(params) {
+  const { ...rest } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function restAfterPlain(params) {
+  const { a, b, ...rest } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function nestedRest(params) {
+  const { outer: { ...rest } } = params;
+  // ruleid: destructuring-default-taint-loss
   sink(rest);
 }
 
@@ -91,4 +108,10 @@ function noTaintMulti() {
   sink(a);
   // ok: destructuring-default-taint-loss
   sink(b);
+}
+
+function noTaintRest() {
+  const { a, ...rest } = {}; // RHS is not a parameter: must stay untainted
+  // ok: destructuring-default-taint-loss
+  sink(rest);
 }

--- a/tests/tainting_rules/js/destructuring_rest_field_sensitive.js
+++ b/tests/tainting_rules/js/destructuring_rest_field_sensitive.js
@@ -1,0 +1,39 @@
+// Field-sensitivity for object-rest destructuring (JS shares the TS path).
+// When only a specific field is tainted and that field is destructured out,
+// the `...rest` binding must NOT carry its taint (rest excludes taken keys).
+// When the whole object is tainted, rest stays tainted via its other/unknown
+// fields (soundness).
+
+function restExcludesTaintedKey() {
+  const obj = {};
+  obj.a = source(); // only field a is tainted
+  const { a, ...rest } = obj;
+  // ruleid: rest-field-sensitive
+  sink(a);
+  // ok: rest-field-sensitive
+  sink(rest);
+  // ok: rest-field-sensitive
+  sink(rest.a);
+}
+
+function restKeepsOtherTaintedField() {
+  const obj = {};
+  obj.a = source();
+  obj.b = source();
+  const { a, ...rest } = obj; // rest still holds tainted b
+  // ruleid: rest-field-sensitive
+  sink(rest);
+  // ruleid: rest-field-sensitive
+  sink(rest.b);
+  // ok: rest-field-sensitive
+  sink(rest.a);
+}
+
+function multipleTakenKeysCleared() {
+  const obj = {};
+  obj.a = source();
+  obj.b = source();
+  const { a, b, ...rest } = obj; // both tainted keys destructured out
+  // ok: rest-field-sensitive
+  sink(rest);
+}

--- a/tests/tainting_rules/js/destructuring_rest_field_sensitive.yaml
+++ b/tests/tainting_rules/js/destructuring_rest_field_sensitive.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: rest-field-sensitive
+    languages: [javascript]
+    severity: ERROR
+    message: taint reached sink
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)

--- a/tests/tainting_rules/ts/destructuring_default.ts
+++ b/tests/tainting_rules/ts/destructuring_default.ts
@@ -71,12 +71,29 @@ function renamedAndShorthandMixed(params) {
 
 function withRest(params) {
   const { a = 0, ...rest } = params;
-  // the default binding is tainted even when a rest element follows
   // ruleid: destructuring-default-taint-loss
   sink(a);
-  // object-rest bindings drop taint via a separate code path (FieldSpread);
-  // that is a distinct pre-existing gap, tracked here as a known TODO.
-  // todoruleid: destructuring-default-taint-loss
+  // ruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function restOnly(params) {
+  const { ...rest } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function restAfterPlain(params) {
+  const { a, b, ...rest } = params;
+  // ruleid: destructuring-default-taint-loss
+  sink(a);
+  // ruleid: destructuring-default-taint-loss
+  sink(rest);
+}
+
+function nestedRest(params) {
+  const { outer: { ...rest } } = params;
+  // ruleid: destructuring-default-taint-loss
   sink(rest);
 }
 
@@ -92,4 +109,10 @@ function noTaintMulti() {
   sink(a);
   // ok: destructuring-default-taint-loss
   sink(b);
+}
+
+function noTaintRest() {
+  const { a, ...rest } = {}; // RHS is not a parameter: must stay untainted
+  // ok: destructuring-default-taint-loss
+  sink(rest);
 }

--- a/tests/tainting_rules/ts/destructuring_rest_field_sensitive.ts
+++ b/tests/tainting_rules/ts/destructuring_rest_field_sensitive.ts
@@ -1,0 +1,39 @@
+// Field-sensitivity for object-rest destructuring.
+// When only a specific field is tainted and that field is destructured out,
+// the `...rest` binding must NOT carry its taint (rest excludes taken keys).
+// When the whole object is tainted, rest stays tainted via its other/unknown
+// fields (soundness).
+
+function restExcludesTaintedKey() {
+  const obj = {};
+  obj.a = source(); // only field a is tainted
+  const { a, ...rest } = obj;
+  // ruleid: rest-field-sensitive
+  sink(a);
+  // ok: rest-field-sensitive
+  sink(rest);
+  // ok: rest-field-sensitive
+  sink(rest.a);
+}
+
+function restKeepsOtherTaintedField() {
+  const obj = {};
+  obj.a = source();
+  obj.b = source();
+  const { a, ...rest } = obj; // rest still holds tainted b
+  // ruleid: rest-field-sensitive
+  sink(rest);
+  // ruleid: rest-field-sensitive
+  sink(rest.b);
+  // ok: rest-field-sensitive
+  sink(rest.a);
+}
+
+function multipleTakenKeysCleared() {
+  const obj = {};
+  obj.a = source();
+  obj.b = source();
+  const { a, b, ...rest } = obj; // both tainted keys destructured out
+  // ok: rest-field-sensitive
+  sink(rest);
+}

--- a/tests/tainting_rules/ts/destructuring_rest_field_sensitive.yaml
+++ b/tests/tainting_rules/ts/destructuring_rest_field_sensitive.yaml
@@ -1,0 +1,10 @@
+rules:
+  - id: rest-field-sensitive
+    languages: [typescript]
+    severity: ERROR
+    message: taint reached sink
+    mode: taint
+    pattern-sources:
+      - pattern: source()
+    pattern-sinks:
+      - pattern: sink(...)


### PR DESCRIPTION
E.g. when `x` is tainted, we want `rest` to be tainted after

```js
const { a, b, ...rest } = x;
```

Field sensitivity is achieved by:
- `rest` gets all the taints from `x`
- the other fields (`a` and `b` in the example`) are cleared from `rest` by setting them to untainted constant nulls.