### PR TITLE
Honor `OPENGREP_*` environment variables alongside legacy `SEMGREP_*`

### DIFF
--- a/libs/commons/Logs_.ml
+++ b/libs/commons/Logs_.ml
@@ -127,9 +127,17 @@ let has_nonempty_intersection tag_str_list tag_set =
       ok || List.mem (Logs.Tag.name def) tag_str_list)
     tag_set false
 
-(* Consult environment variables from left-to-right in order of precedence. *)
+(* Consult environment variables left-to-right in order of precedence; the
+   first one that is set to a non-empty value wins. An empty value is treated as
+   unset so it doesn't shadow the lower-precedence variables (e.g. an empty
+   OPENGREP_LOG_SRCS still lets SEMGREP_LOG_SRCS win). *)
 let read_str_from_env_vars (vars : string list) : string option =
-  List.find_map (fun var -> USys.getenv_opt var) vars
+  List.find_map
+    (fun var ->
+      match USys.getenv_opt var with
+      | Some "" | None -> None
+      | Some _ as v -> v)
+    vars
 
 let read_comma_sep_strs_from_env_vars (vars : string list) : string list option
     =
@@ -248,10 +256,16 @@ let log_level_of_string_opt (str : string) : Logs.level option option =
   | "none" -> Some None
   | _ -> None
 
+(* Scalar setting: resolved by precedence, i.e. the first variable that is set
+   to a recognized level wins. An empty or unrecognized value is skipped so it
+   doesn't shadow the lower-precedence variables. *)
 let read_level_from_env (vars : string list) : Logs.level option option =
-  match read_str_from_env_vars vars with
-  | None -> None
-  | Some str -> log_level_of_string_opt str
+  List.find_map
+    (fun var ->
+      match USys.getenv_opt var with
+      | Some "" | None -> None
+      | Some str -> log_level_of_string_opt str)
+    vars
 
 (*****************************************************************************)
 (* Entry points *)

--- a/libs/commons/Opengrep_env.ml
+++ b/libs/commons/Opengrep_env.ml
@@ -1,0 +1,30 @@
+(* Opengrep was forked from Semgrep, so many environment variables are named
+ * named SEMGREP_* (e.g., SEMGREP_RULES). We now also honor the OPENGREP_*
+ * equivalents (e.g., OPENGREP_RULES) for those variables, and give the
+ * OPENGREP_* name precedence when both are set.
+ *
+ * The mapping is a plain textual substitution of the "SEMGREP" substring by
+ * "OPENGREP", so "SEMGREP_URL" maps to "OPENGREP_URL" and
+ * "PYTEST_SEMGREP_LOG_LEVEL" maps to "PYTEST_OPENGREP_LOG_LEVEL". Variables
+ * without a "SEMGREP" substring (e.g., HOME, NO_COLOR) have no alias and are
+ * looked up as-is.
+ *)
+
+let opengrep_alias (var : string) : string option =
+  let alias = Str.global_replace (Str.regexp_string "SEMGREP") "OPENGREP" var in
+  if String.equal alias var then None else Some alias
+
+(* Like [Sys.getenv_opt] but treats an empty value as unset, matching the rest
+ * of Opengrep's environment handling. *)
+let getenv_nonempty (var : string) : string option =
+  match USys.getenv_opt var with
+  | Some "" -> None
+  | x -> x
+
+let getenv_opt (var : string) : string option =
+  match opengrep_alias var with
+  | Some alias -> (
+      match getenv_nonempty alias with
+      | Some _ as v -> v
+      | None -> getenv_nonempty var)
+  | None -> getenv_nonempty var

--- a/libs/commons/Opengrep_env.mli
+++ b/libs/commons/Opengrep_env.mli
@@ -1,0 +1,20 @@
+(** Compatibility between the legacy Semgrep environment variable names and the
+    Opengrep ones.
+
+    Opengrep is a fork of Semgrep, so historically many environment variables
+    are named SEMGREP_*. We now also support OPENGREP_* variants, giving them
+    precedence over the legacy SEMGREP_* names when both are set. *)
+
+val opengrep_alias : string -> string option
+(** [opengrep_alias var] is the OPENGREP_* name corresponding to a legacy
+    SEMGREP_* [var], obtained by replacing the "SEMGREP" substring with
+    "OPENGREP" (e.g., "SEMGREP_URL" -> "OPENGREP_URL",
+    "PYTEST_SEMGREP_LOG_LEVEL" -> "PYTEST_OPENGREP_LOG_LEVEL"), or [None] when
+    [var] contains no "SEMGREP" substring. *)
+
+val getenv_opt : string -> string option
+(** [getenv_opt var] looks up [var] in the environment, preferring its
+    OPENGREP_* alias (see {!opengrep_alias}) when that alias is set, so that
+    OPENGREP_* variables take precedence over the legacy SEMGREP_* ones. Empty
+    values are treated as unset. Its signature matches the [~env] lookup
+    expected by {!Cmdliner.Cmd.eval_value}. *)

--- a/src/core/Log_semgrep.ml
+++ b/src/core/Log_semgrep.ml
@@ -61,10 +61,25 @@ let setup ?log_to_file ?require_one_of_these_tags
      filter by log level, so maybe we should send all? But that'll be expensive
      ... *)
   Logs_.setup ?log_to_file ?require_one_of_these_tags 
+    (* We accept both the OPENGREP_* names and the legacy SEMGREP_* ones, with
+     * the OPENGREP_* name winning when both are set (the lists are consulted in
+     * order of precedence). An empty (or, for the level, unrecognized) value is
+     * skipped so it doesn't shadow the lower-precedence SEMGREP_* fallback. *)
     ~read_level_from_env_vars:
-      [ "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL" ]
-    ~read_srcs_from_env_vars:[ "PYTEST_SEMGREP_LOG_SRCS"; "SEMGREP_LOG_SRCS" ]
-    ~read_tags_from_env_vars:[ "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS" ]
+      [
+        "PYTEST_OPENGREP_LOG_LEVEL"; "OPENGREP_LOG_LEVEL";
+        "PYTEST_SEMGREP_LOG_LEVEL"; "SEMGREP_LOG_LEVEL";
+      ]
+    ~read_srcs_from_env_vars:
+      [
+        "PYTEST_OPENGREP_LOG_SRCS"; "OPENGREP_LOG_SRCS";
+        "PYTEST_SEMGREP_LOG_SRCS"; "SEMGREP_LOG_SRCS";
+      ]
+    ~read_tags_from_env_vars:
+      [
+        "PYTEST_OPENGREP_LOG_TAGS"; "OPENGREP_LOG_TAGS";
+        "PYTEST_SEMGREP_LOG_TAGS"; "SEMGREP_LOG_TAGS";
+      ]
     ~level ();
   Logs.debug (fun m -> m "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!");
   Logs.debug (fun m -> m "%s" help_msg);

--- a/src/core_cli/Core_CLI.ml
+++ b/src/core_cli/Core_CLI.ml
@@ -800,7 +800,8 @@ let main_exn (caps : Cap.all_caps) (argv : string array) : unit =
   let argv =
     Array.to_list argv
     @
-    match Sys.getenv_opt env_extra with
+    (* honors OPENGREP_CORE_EXTRA, falling back to the legacy SEMGREP_CORE_EXTRA *)
+    match Opengrep_env.getenv_opt env_extra with
     | Some s -> String_.split ~sep:"[ \t]+" s
     | None -> []
   in

--- a/src/osemgrep/configuring/Semgrep_envvars.ml
+++ b/src/osemgrep/configuring/Semgrep_envvars.ml
@@ -43,11 +43,12 @@ let%test_unit "Semgrep_envvars.(/)" =
    Since OCaml doesn't provide an 'unsetenv' function (which exists in libc),
    tests that that set environment variable temporarily can't unset them,
    leaving them with the empty value instead.
+
+   For every legacy SEMGREP_* variable this also honors its OPENGREP_* alias,
+   which wins when both are set (see Opengrep_env). Non-SEMGREP variables
+   (e.g., HOME, NO_COLOR) have no alias and are looked up as-is.
 *)
-let env_opt var =
-  match Sys.getenv_opt var with
-  | Some "" -> None
-  | x -> x
+let env_opt var = Opengrep_env.getenv_opt var
 
 (*****************************************************************************)
 (* Don't use Sys.getenv* or Unix.getenv* starting from here!  *)
@@ -145,7 +146,7 @@ let of_current_sys_env () : t =
     user_home_dir;
     user_dot_semgrep_dir;
     user_log_file =
-      env_or Fpath.v "OPENGREEP_LOG_FILE" (user_dot_semgrep_dir / "semgrep.log");
+      env_or Fpath.v "SEMGREP_LOG_FILE" (user_dot_semgrep_dir / "semgrep.log");
     no_color = env_truthy "NO_COLOR" || env_truthy "SEMGREP_COLOR_NO_COLOR";
     is_ci = in_env "CI";
     in_docker = in_env "SEMGREP_IN_DOCKER";

--- a/src/osemgrep/core/CLI_common.ml
+++ b/src/osemgrep/core/CLI_common.ml
@@ -130,7 +130,10 @@ let eval_value ~argv cmd =
   (* the ~catch:false is to let non-cmdliner exn (e.g., Error.Semgrep_error)
    * to bubble up; those exns will then be caught in CLI.safe_run.
    *)
-  match Cmd.eval_value ~catch:false ~argv cmd with
+  (* ~env makes cmdliner honor the OPENGREP_* alias of every SEMGREP_* env var
+   * referenced via Cmd.Env.info (e.g., SEMGREP_RULES, SEMGREP_BASELINE_COMMIT),
+   * with the OPENGREP_* name taking precedence when both are set. *)
+  match Cmd.eval_value ~catch:false ~env:Opengrep_env.getenv_opt ~argv cmd with
   (* alt: could define a new Exit_code for those kinds of errors *)
   | Error (`Term | `Parse) -> Error.exit_code_exn (Exit_code.fatal ~__LOC__)
   (* this should never happen, because of the ~catch:false above *)


### PR DESCRIPTION
## Summary

Opengrep is a fork of Semgrep, so most environment variables it reads are still named `SEMGREP_*`. This PR adds `OPENGREP_*` equivalents for every such variable in the OCaml frontend, keeping the `SEMGREP_*` names working for backwards compatibility. When both are set, the `OPENGREP_*` name wins.

The alias is a plain textual substitution of `SEMGREP` → `OPENGREP` in the variable name (so `SEMGREP_RULES` → `OPENGREP_RULES`, and `PYTEST_SEMGREP_LOG_LEVEL` → `PYTEST_OPENGREP_LOG_LEVEL`).

## Implementation

A single helper covers all three ways env vars are read, since cmdliner's `Cmd.eval_value` accepts a custom `~env` lookup:

- **New `libs/commons/Opengrep_env.ml`** — `getenv_opt var` looks up `var` but first checks its `OPENGREP_*` alias, which wins when both are set. Variables with no `SEMGREP` substring (`HOME`, `NO_COLOR`, already-migrated `OPENGREP_*` vars) are looked up unchanged, so it's a safe no-op for them.
- **`Semgrep_envvars.ml`** — `env_opt` delegates to `Opengrep_env.getenv_opt`, so all vars in that file gain their alias (`SEMGREP_URL`, `SEMGREP_APP_URL`, `SEMGREP_IN_DOCKER`, `SEMGREP_GIT_COMMAND_TIMEOUT`, `SEMGREP_SRC_DIRECTORY`, `SEMGREP_COLOR_NO_COLOR`, `SEMGREP_GHA_MIN_FETCH_DEPTH`, `SEMGREP_LOG_FILE`).
- **`CLI_common.eval_value`** — passes `~env:Opengrep_env.getenv_opt`, covering the cmdliner `Cmd.Env.info` vars (`SEMGREP_RULES`, `SEMGREP_BASELINE_COMMIT`, `SEMGREP_FORCE_COLOR`) across scan/test/show/validate/lsp.
- **`Log_semgrep.ml`** — prepends `OPENGREP_*` (and `PYTEST_OPENGREP_*`) names to the log-level/srcs/tags lists; the list is consulted in order, so `OPENGREP_*` wins.
- **`Core_CLI.ml`** — `SEMGREP_CORE_EXTRA` read via the alias helper.

Also fixes a pre-existing typo: `user_log_file` read `OPENGREEP_LOG_FILE` (double E), so neither the correct `OPENGREP_LOG_FILE` nor the legacy `SEMGREP_LOG_FILE` worked. It now reads `OPENGREP_LOG_FILE` with a `SEMGREP_LOG_FILE` fallback.

## Testing

Built with `make core` and smoke-tested the real binary:

- `OPENGREP_RULES` is honored, and beats `SEMGREP_RULES` when both are set.
- Legacy `SEMGREP_RULES` still works on its own.
- `OPENGREP_LOG_LEVEL=debug` enables debug logging (no `--debug` flag needed).

## Notes

- The `ci` subcommand's `SEMGREP_REPO_*`/`SEMGREP_PR_*`/... variables in `Git_metadata.ml` are intentionally left untouched: `ci` is not wired into osemgrep (it falls back to pysemgrep) and that cmdliner term is never evaluated, so aliasing it would have no effect.
