### PR TITLE
windows: ship only the DLLs opengrep-core links against

### DIFF
--- a/.github/workflows/build-test-windows-x86.yml
+++ b/.github/workflows/build-test-windows-x86.yml
@@ -369,23 +369,19 @@ jobs:
           mkdir artifacts
           cp _build/install/default/bin/opengrep-core.exe artifacts/
 
+          # The mingw runtime, plus the native libraries opengrep-core links
+          # against. Keep in sync with the ldd output printed by the
+          # opengrep-core test step; everything else it needs comes from
+          # System32.
           cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libstdc++-6.dll artifacts/
           cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libgcc_s_seh-1.dll artifacts/
           cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libwinpthread-1.dll artifacts/
           cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libpcre-1.dll artifacts/
           cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libgmp-10.dll artifacts/
           cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libpcre2-8-0.dll artifacts/
-          # cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libeay32.dll artifacts/
-          cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libidn2-0.dll artifacts/
-          cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libnghttp2-14.dll artifacts/
-          cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libssh2-1.dll artifacts/
-          # cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/ssleay32.dll artifacts/
           cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libzstd-1.dll artifacts/
-          cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/zlib1.dll artifacts/
-          cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/iconv.dll artifacts/
-          cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libintl-8.dll artifacts/
-          cp "c:/Program Files/Amazon/AWSCLIV2/libcrypto-3.dll" artifacts/
-          cp "c:/Program Files/Amazon/AWSCLIV2/libssl-3.dll" artifacts/
+          # cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/libeay32.dll artifacts/
+          # cp d:/cygwin/usr/x86_64-w64-mingw32/sys-root/mingw/bin/ssleay32.dll artifacts/
 
           tar czvf artifacts.tgz artifacts
 

--- a/scripts/cp_win_artifacts.sh
+++ b/scripts/cp_win_artifacts.sh
@@ -8,24 +8,16 @@ rm -f artifacts/*
 cp bin/* artifacts/
 cp artifacts/opengrep-core.exe artifacts/opengrep.exe
 
+# The mingw runtime, plus the native libraries opengrep-core links against.
+# Keep in sync with the ldd output printed by the opengrep-core test step in
+# build-test-windows-x86; everything else it needs comes from System32.
 cp $BASE/libstdc++-6.dll artifacts/
 cp $BASE/libgcc_s_seh-1.dll artifacts/
 cp $BASE/libwinpthread-1.dll artifacts/
 cp $BASE/libpcre-1.dll artifacts/
 cp $BASE/libgmp-10.dll artifacts/
 cp $BASE/libpcre2-8-0.dll artifacts/
-cp $BASE/libeay32.dll artifacts/
-cp $BASE/libidn2-0.dll artifacts/
-cp $BASE/libnghttp2-14.dll artifacts/
-cp $BASE/libssh2-1.dll artifacts/
-cp $BASE/ssleay32.dll artifacts/
 cp $BASE/libzstd-1.dll artifacts/
-cp $BASE/zlib1.dll artifacts/
-cp $BASE/iconv.dll artifacts/
-cp $BASE/libintl-8.dll artifacts/
-# Temporary hack, requires AWS CLI to be installed just for these .dll files:
-cp /cygdrive/c/Program\ Files/Amazon/AWSCLIV2/libcrypto-3.dll artifacts/
-cp /cygdrive/c/Program\ Files/Amazon/AWSCLIV2/libssl-3.dll artifacts/
 
 # For the wheel:
 cp artifacts/* cli/src/semgrep/bin


### PR DESCRIPTION
The Windows bundle shipped fifteen DLLs alongside opengrep-core.exe. Eight of
them are unused: libssh2, nghttp2 and idn2 from libcurl's dependency chain, the
iconv/intl/zlib libraries those pull in, and libcrypto-3 and libssl-3 copied out
of the AWS CLI installed on the runner.

Nothing depends on curl: no opam package, no dune library, no OCaml source
reference, and libcurl was never bundled. TLS is pure OCaml via tls-lwt. The
Python wrapper runs opengrep-core as a subprocess and never loads these DLLs.

The seven that remain are what ldd reports for opengrep-core.exe: the mingw
runtime plus libgmp, libpcre, libpcre2-8 and libzstd. This also removes the need
for AWS CLI on the build machine.
