### PR TITLE
opengrep-cli: fix the blocking-findings count in compiled ci builds

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -824,13 +824,15 @@ def ci(
             if match.is_ignored and not keep_ignored:
                 continue
 
-            applicable_result_list = (
-                cai_matches
-                if "r2c-internal-cai" in rule.id
-                else blocking_matches
-                if match.is_blocking
-                else nonblocking_matches
-            )
+            # Keep plain branches here: Nuitka miscompiles the nested
+            # conditional expression that used to select the list, losing
+            # the append in compiled builds.
+            if "r2c-internal-cai" in rule.id:
+                applicable_result_list = cai_matches
+            elif match.is_blocking:
+                applicable_result_list = blocking_matches
+            else:
+                applicable_result_list = nonblocking_matches
             applicable_result_list.append(match)
             if "r2c-internal-cai" not in rule.id:
                 non_cai_matches_by_rule[rule].append(match)


### PR DESCRIPTION
Fixes #481.

In release binaries, `opengrep ci` displayed blocking findings but the summary reported `Found 0 findings (0 blocking)` and the process exited 0, so CI never failed. Wheel installs of the same source behaved correctly.

Nuitka (2.8.9, the pinned version) miscompiles the nested conditional expression in `ci.py` that selects the destination list for each match: in compiled builds the subsequent `append` lands in none of the blocking/non-blocking/cai lists, while the adjacent append to the displayed map works, so the display and the count disagree. Rewriting the selection as plain `if/elif/else` branches makes the compiled build count correctly.

Verified by building the binary with `scripts/build-nuitka.sh` before and after: same repo and rule, the summary goes from `Found 0 findings (0 blocking)` / exit 0 to `Found 1 finding (1 blocking)` / exit 1, and a `# nosemgrep`-suppressed match is still excluded from both count and display.