### PR TITLE
workflows: nuitka 2.8.9 -> 4.1.3 with the onefile extra

### DIFF
--- a/.github/workflows/build-manylinux-binary.yml
+++ b/.github/workflows/build-manylinux-binary.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Install nuitka
         run: |
-          python3 -m pip install nuitka==2.8.9
+          python3 -m pip install "nuitka[onefile]==4.1.3"
           # /opt/python/cp39-cp39/bin/pip install pyinstaller
 
       - name: Install opengrep

--- a/.github/workflows/build-musllinux-binary.yml
+++ b/.github/workflows/build-musllinux-binary.yml
@@ -87,7 +87,7 @@ jobs:
               unzip dist.zip &&
               python3 -m venv venv &&
               . venv/bin/activate &&
-              python3 -m pip install nuitka==2.8.9 &&
+              python3 -m pip install 'nuitka[onefile]==4.1.3' &&
               python3 -m pip install dist/*.whl &&
               unzip dist/*.whl -d _wheel &&
               export OPENGREP_VERSION=\$(opengrep --version) &&

--- a/.github/workflows/build-osx-binary.yml
+++ b/.github/workflows/build-osx-binary.yml
@@ -48,7 +48,7 @@ jobs:
           pipenv --python 3.13
 
       - name: Install nuitka
-        run: pipenv run pip install nuitka==2.8.9 protobuf jaraco.text
+        run: pipenv run pip install "nuitka[onefile]==4.1.3" protobuf jaraco.text
 
       - name: install some dependencies for windows (pyinstaller only)
         run: pipenv run pip install chardet charset-normalizer

--- a/.github/workflows/build-windows-binary-x86.yml
+++ b/.github/workflows/build-windows-binary-x86.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Install setuptools with --upgrade
         run: pip3 install --upgrade setuptools
       - name: Install nuitka
-        run: pip3 install nuitka==2.8.9 protobuf
+        run: pip3 install "nuitka[onefile]==4.1.3" protobuf
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
Bumps the Nuitka pin in the four binary build workflows to 4.1.3 and adds the `onefile` extra, which guarantees zstandard so onefile payloads stay compressed.

Tested locally on macOS arm64: the build compiles with compression active and comes out at 48.1 MB (2.8.9: 44.9 MB).