### PR TITLE
Use lazy-with-restart in `lazy_content` and `lazy_ast_and_errors`

### DIFF
--- a/libs/commons/Lazy_with_restart.ml
+++ b/libs/commons/Lazy_with_restart.ml
@@ -1,0 +1,27 @@
+(* See Lazy_with_restart.mli for the rationale (a lazy that restarts its
+   computation instead of memoizing an exception). *)
+
+type 'a state =
+  | Not_forced of (unit -> 'a)
+  | Forced of 'a
+
+type 'a t = { mutable state : 'a state }
+
+let from_fun f = { state = Not_forced f }
+
+let from_val v = { state = Forced v }
+
+let force t =
+  match t.state with
+  | Forced v -> v
+  | Not_forced f ->
+      (* If [f ()] raises, we never reach the assignment below, so [t.state]
+         stays [Not_forced] and the next [force] re-runs [f]. *)
+      let v = f () in
+      t.state <- Forced v;
+      v
+
+let is_val t =
+  match t.state with
+  | Forced _ -> true
+  | Not_forced _ -> false

--- a/libs/commons/Lazy_with_restart.mli
+++ b/libs/commons/Lazy_with_restart.mli
@@ -1,0 +1,46 @@
+(* A lazy value that does NOT memoize exceptions.
+
+   [Stdlib.Lazy] stores the exception raised while forcing into the thunk, so
+   every subsequent [Lazy.force] re-raises that same exception (see the note in
+   the manual: "If it raised an exception, the same exception is raised again").
+   That is a problem when the forced computation can be interrupted by an
+   *asynchronous* exception (e.g. a per-rule timeout interrupt from
+   memprof-limits): a transient failure gets baked into the thunk permanently
+   and is re-raised by every later reader of the shared value.
+
+   [Lazy_with_restart] only memoizes on *success*. If forcing raises, the thunk
+   is left unforced, so the next [force] re-runs ("restarts") the computation.
+
+   Because forcing can restart, the suspended computation may run more than once
+   (whenever a previous force raised), so it should be free of non-idempotent
+   side effects.
+
+   NOT concurrency-safe. This module is meant to be forced by a single forcer at
+   a time (opengrep forces each [Xtarget] from a single task/domain). A
+   concurrent [force] will not crash and will not observe a torn value (under the
+   OCaml 5 memory model a reader sees either the unforced thunk or a fully
+   initialised result). But it also does nothing to prevent two forcers from
+   both running the computation and each installing its own result: for a large
+   value such as an AST that silently yields two live copies for the same target
+   (extra memory charged against [--max-memory], and physically distinct tokens
+   handed to different callers), with no error to signal it — precisely the
+   situation [Stdlib.Lazy] turns into a loud [Lazy.Undefined]. Do not force the
+   same value from multiple threads or domains. *)
+
+type 'a t
+
+val from_fun : (unit -> 'a) -> 'a t
+(** [from_fun f] is a suspension of [f]. [f] is not run until the value is forced.
+    Replaces the [lazy (expr)] keyword: write [from_fun (fun () -> expr)]. *)
+
+val from_val : 'a -> 'a t
+(** [from_val v] is an already-forced suspension of the value [v]. *)
+
+val force : 'a t -> 'a
+(** [force t] returns the value of the suspension, computing it on the first
+    call. If the computation raises, the exception is propagated and the
+    suspension is left unforced, so a later [force] retries it. *)
+
+val is_val : 'a t -> bool
+(** [is_val t] is [true] iff [t] has already been forced successfully (i.e. its
+    computation returned without raising). *)

--- a/libs/commons/tests/Commons_tests.ml
+++ b/libs/commons/tests/Commons_tests.ml
@@ -12,4 +12,5 @@ let tests =
       Unit_String_.tests;
       Unit_List_.tests;
       Unit_File.tests;
+      Unit_Lazy_with_restart.tests;
     ]

--- a/libs/commons/tests/Unit_Lazy_with_restart.ml
+++ b/libs/commons/tests/Unit_Lazy_with_restart.ml
@@ -1,0 +1,54 @@
+(*
+   Tests for our Lazy_with_restart module.
+*)
+
+let t = Testo.create
+
+exception Boom
+
+(* The whole point of the module: forcing raises the first time, then the next
+   force restarts the computation and succeeds; [is_val] stays false as long as
+   no force has succeeded. *)
+let test_restart_on_exception () =
+  let calls = ref 0 in
+  let lz =
+    Lazy_with_restart.from_fun (fun () ->
+        incr calls;
+        if !calls = 1 then raise Boom;
+        !calls)
+  in
+  Alcotest.(check bool) "not forced initially" false (Lazy_with_restart.is_val lz);
+  (try
+     ignore (Lazy_with_restart.force lz);
+     Alcotest.fail "expected the first force to raise"
+   with Boom -> ());
+  Alcotest.(check bool) "not forced after a failed force" false
+    (Lazy_with_restart.is_val lz);
+  Alcotest.(check int) "force restarts and succeeds" 2 (Lazy_with_restart.force lz);
+  Alcotest.(check bool) "forced after success" true (Lazy_with_restart.is_val lz)
+
+(* A successful result is memoized: the thunk runs exactly once. *)
+let test_memoize_on_success () =
+  let calls = ref 0 in
+  let lz =
+    Lazy_with_restart.from_fun (fun () ->
+        incr calls;
+        42)
+  in
+  Alcotest.(check int) "first force" 42 (Lazy_with_restart.force lz);
+  Alcotest.(check int) "second force (cached)" 42 (Lazy_with_restart.force lz);
+  Alcotest.(check int) "thunk ran once" 1 !calls
+
+(* [from_val] is an already-forced suspension. *)
+let test_from_val () =
+  let lz = Lazy_with_restart.from_val "x" in
+  Alcotest.(check bool) "from_val implies is_val" true (Lazy_with_restart.is_val lz);
+  Alcotest.(check string) "from_val value" "x" (Lazy_with_restart.force lz)
+
+let tests =
+  Testo.categorize "Lazy_with_restart"
+    [
+      t "restart on exception" test_restart_on_exception;
+      t "memoize on success" test_memoize_on_success;
+      t "from_val" test_from_val;
+    ]

--- a/libs/commons/tests/Unit_Lazy_with_restart.mli
+++ b/libs/commons/tests/Unit_Lazy_with_restart.mli
@@ -1,0 +1,5 @@
+(*
+   Tests for our Lazy_with_restart module.
+*)
+
+val tests : Testo.t list

--- a/src/core_scan/Core_scan.ml
+++ b/src/core_scan/Core_scan.ml
@@ -831,8 +831,8 @@ let mk_target_handler (caps : < Cap.time_limit >) (config : Core_scan_config.t)
            Option.map
              (fun (p : Core_profiling.partial_profiling) ->
                 let p_file_size_bytes =
-                  if Lazy.is_val xtarget.lazy_content then
-                    Some (String.length (Lazy.force xtarget.lazy_content))
+                  if Lazy_with_restart.is_val xtarget.lazy_content then
+                    Some (String.length (Lazy_with_restart.force xtarget.lazy_content))
                   else None
                 in
                 {p with Core_profiling.p_file_size_bytes})

--- a/src/engine/Match_rules.ml
+++ b/src/engine/Match_rules.ml
@@ -139,7 +139,7 @@ let is_relevant_rule_for_xtarget r xconf xtarget =
           (* NOTE: If [lazy_content] is shared in > 1 thread, then this is not
            * thread-safe. However, each [Xtarget.t] is only accessed in 1 worker
            * task, so there should be no race. *)
-          let content = Lazy.force lazy_content in
+          let content = Lazy_with_restart.force lazy_content in
           Log.info (fun m ->
               let s = Semgrep_prefilter_j.string_of_formula prefilter_formula in
               m "looking for %s in %s" s !!internal_path_to_content);
@@ -295,10 +295,7 @@ let check
   | Profiling.ProfAll, Xlang.L (_lang, []) ->
       Log.debug (fun m ->
           m "forcing parsing of AST outside of rules, for better profile");
-      (* XXX: Can result in [CamlinternalLazy.Undefined] error.
-       * But it should not be the case, as we parse in the worker thread, which
-       * is running alone in the domain. *)
-      Lazy.force lazy_ast_and_errors |> ignore
+      Lazy_with_restart.force lazy_ast_and_errors |> ignore
   | _else_ -> ());
 
   let per_rule_boilerplate_fn = per_rule_boilerplate_fn timeout file in

--- a/src/engine/Match_search_mode.ml
+++ b/src/engine/Match_search_mode.ml
@@ -149,7 +149,7 @@ let error_with_rule_id rule_id (error : Core_error.t) =
   | PartialParsing _ -> error
   | _ -> { error with rule_id = Some rule_id }
 
-let lazy_force x = Lazy.force x [@@profiling]
+let lazy_force x = Lazy_with_restart.force x [@@profiling]
 
 (* `fold_with_expls` is a left fold across a list of things, while
    accumulating an explanation for each item. it preserves the
@@ -718,7 +718,7 @@ let rec filter_ranges (env : env) (xs : (RM.t * MV.bindings list) list)
                    | Xlang.LAliengrep ->
                        raise Impossible
                  in
-                 let ast, _ = Lazy.force env.xtarget.lazy_ast_and_errors in
+                 let ast, _ = Lazy_with_restart.force env.xtarget.lazy_ast_and_errors in
                  (* This call iterates over the program's top-level statements, and
                     thus incurs some cost, but it shouldn't be much.
                  *)

--- a/src/engine/Match_taint_spec.ml
+++ b/src/engine/Match_taint_spec.ml
@@ -226,13 +226,13 @@ let spec_matches_of_taint_rule ~per_file_formula_cache xconf file ast_and_errors
   let file = Fpath.v file in
   let formula_cache = per_file_formula_cache in
   let xconf = Match_env.adjust_xconfig_with_rule_options xconf rule.options in
-  let lazy_ast_and_errors = lazy ast_and_errors in
+  let lazy_ast_and_errors = Lazy_with_restart.from_val ast_and_errors in
   (* TODO: should this function just take a target, rather than a file? *)
   let xtarget : Xtarget.t =
     {
       path = { origin = File file; internal_path_to_content = file };
       xlang = rule.target_analyzer;
-      lazy_content = lazy (UFile.read_file file);
+      lazy_content = Lazy_with_restart.from_fun (fun () -> UFile.read_file file);
       lazy_ast_and_errors;
     }
   in

--- a/src/engine/Match_tainting_mode.ml
+++ b/src/engine/Match_tainting_mode.ml
@@ -82,7 +82,7 @@ let get_source_requires src =
 (* Testing whether some matches a taint spec *)
 (*****************************************************************************)
 
-let lazy_force x = Lazy.force x [@@profiling]
+let lazy_force x = Lazy_with_restart.force x [@@profiling]
 
 (*****************************************************************************)
 (* Pattern match from finding *)

--- a/src/engine/Metavariable_pattern.ml
+++ b/src/engine/Metavariable_pattern.ml
@@ -205,8 +205,8 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                               env.xtarget.path with
                               internal_path_to_content = file;
                             };
-                          lazy_ast_and_errors = lazy (mast', []);
-                          lazy_content = lazy contents;
+                          lazy_ast_and_errors = Lazy_with_restart.from_val (mast', []);
+                          lazy_content = Lazy_with_restart.from_val contents;
                         }
                       in
                       (* Persist the bindings from inside the `metavariable-pattern`
@@ -286,7 +286,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                                        to fully parse the content of %s"
                                       (Rule_ID.to_string (fst env.rule.Rule.id))
                                       mvar);
-                              Ok (lazy (ast, skipped_tokens))
+                              Ok (Lazy_with_restart.from_val (ast, skipped_tokens))
                             with
                             | Parsing_error.Syntax_error tk ->
                                 Error (Tok.content_of_tok tk))
@@ -294,8 +294,8 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                         | LSpacegrep
                         | LAliengrep ->
                             Ok
-                              (lazy
-                                (failwith
+                              (Lazy_with_restart.from_fun (fun () ->
+                                 failwith
                                    "requesting generic AST for \
                                     LRegex|LSpacegrep|LAliengrep"))
                       in
@@ -318,7 +318,7 @@ let get_nested_metavar_pattern_bindings get_nested_formula_matches env r mvar
                                 };
                               xlang;
                               lazy_ast_and_errors;
-                              lazy_content = lazy contents;
+                              lazy_content = Lazy_with_restart.from_val contents;
                             }
                           in
                           (* Persist the bindings from inside the `metavariable-pattern`

--- a/src/engine/Xpattern_match_aliengrep.ml
+++ b/src/engine/Xpattern_match_aliengrep.ml
@@ -43,7 +43,7 @@ let matches_of_aliengrep patterns lazy_contents (file : Fpath.t) origin =
   let init _ =
     (* TODO: ignore binary files like spacegrep? *)
     (* TODO: preprocess and remove comments like spacegrep does *)
-    Some (Lazy.force lazy_contents)
+    Some (Lazy_with_restart.force lazy_contents)
   in
   Xpattern_matcher.matches_of_matcher patterns
     { init; matcher = aliengrep_matcher }

--- a/src/engine/Xpattern_match_aliengrep.mli
+++ b/src/engine/Xpattern_match_aliengrep.mli
@@ -3,7 +3,7 @@
 *)
 val matches_of_aliengrep :
   (Aliengrep.Pat_compile.t * Xpattern.pattern_id * string) list ->
-  string Lazy.t ->
+  string Lazy_with_restart.t ->
   Fpath.t ->
   Origin.t ->
   Core_profiling.times Core_result.match_result

--- a/src/engine/Xpattern_match_regexp.ml
+++ b/src/engine/Xpattern_match_regexp.ml
@@ -153,7 +153,7 @@ let regexp_matcher ?(base_offset = 0) regex_functions big_str (file : Fpath.t)
 let matches_of_regexs regexps lazy_content (file : Fpath.t) origin =
   matches_of_matcher regexps
     {
-      init = (fun _fpath -> assert Fpath.(equal _fpath file); Some (Lazy.force lazy_content));
+      init = (fun _fpath -> assert Fpath.(equal _fpath file); Some (Lazy_with_restart.force lazy_content));
       matcher = regexp_matcher pcre2_regex_functions;
     }
     file origin

--- a/src/engine/Xpattern_match_regexp.mli
+++ b/src/engine/Xpattern_match_regexp.mli
@@ -32,7 +32,7 @@ val regexp_matcher :
 
 val matches_of_regexs :
   (Pcre2_.t * Xpattern.pattern_id * string) list ->
-  string Lazy.t ->
+  string Lazy_with_restart.t ->
   Fpath.t ->
   Origin.t ->
   Core_profiling.times Core_result.match_result

--- a/src/target/Xtarget.ml
+++ b/src/target/Xtarget.ml
@@ -18,8 +18,11 @@
 type t = {
   path : Target.path;
   xlang : Xlang.t;
-  lazy_content : string lazy_t; (* TODO: Check concurrent usage; also below. *)
-  lazy_ast_and_errors : (AST_generic.program * Tok.location list) lazy_t;
+  (* [Lazy_with_restart] rather than [Stdlib.Lazy]: forcing these can be
+   * interrupted by a per-rule timeout, and we must not memoize that exception
+   * and re-raise it for the next rule (see Lazy_with_restart.mli). *)
+  lazy_content : string Lazy_with_restart.t;
+  lazy_ast_and_errors : (AST_generic.program * Tok.location list) Lazy_with_restart.t;
 }
 
 let parse_file parser (analyzer : Xlang.t) path =
@@ -42,15 +45,15 @@ let resolve_with_ast ast (target : Target.regular) : t =
   {
     path = target.path;
     xlang = target.analyzer;
-    (* TODO: Check if used concurrently, lazy is not thread-safe. However, we
-     * only spawn one parallel task per target. *)
-    lazy_content = lazy (UFile.read_file target.path.internal_path_to_content);
+    lazy_content =
+      Lazy_with_restart.from_fun (fun () ->
+          UFile.read_file target.path.internal_path_to_content);
     lazy_ast_and_errors = ast;
   }
 
 let resolve parser (target : Target.regular) : t =
   let ast =
-    lazy
-      (parse_file parser target.analyzer target.path.internal_path_to_content)
+    Lazy_with_restart.from_fun (fun () ->
+        parse_file parser target.analyzer target.path.internal_path_to_content)
   in
   resolve_with_ast ast target

--- a/src/target/Xtarget.mli
+++ b/src/target/Xtarget.mli
@@ -7,8 +7,9 @@
 type t = {
   path : Target.path;
   xlang : Xlang.t;  (** The analyzer to use when scanning this target. *)
-  lazy_content : string lazy_t;
-  lazy_ast_and_errors : (AST_generic.program * Tok.location list) lazy_t;
+  lazy_content : string Lazy_with_restart.t;
+  lazy_ast_and_errors :
+    (AST_generic.program * Tok.location list) Lazy_with_restart.t;
       (** This is valid only for xlang = Xlang.L ..., not for LRegex|LGeneric *)
 }
 
@@ -23,4 +24,6 @@ val resolve :
  * easy construction of Xtargets in contexts where the client has already parsed
  * the file in question. *)
 val resolve_with_ast :
-  (AST_generic.program * Tok.location list) Lazy.t -> Target.regular -> t
+  (AST_generic.program * Tok.location list) Lazy_with_restart.t ->
+  Target.regular ->
+  t


### PR DESCRIPTION
A per-rule timeout could take down the scan of the *whole file* — surfacing as an unhandled, rule-less fatal instead of a normal `Timeout` on the single rule that ran out of time. This happened because a timeout is delivered as an asynchronous exception, and when it interrupted the forcing of a **shared per-file `lazy`** (the parsed AST or file contents), OCaml's `Lazy` **memoized that exception** and re-raised it for every subsequent rule that touched the same value.

The fix introduces a small `Lazy_with_restart` module (a lazy that memoizes only on *success* and re-runs its computation after an interrupted force) and uses it for the two `Xtarget` fields that are shared across all rules on a file.

## The bug

- **Symptom:** intermittently, a timeout surfaces as an unhandled, rule-less `Memprof_limits.Limit_reached: token set` fatal (recorded as a generic file error such as "Other syntax error") instead of the normal per-rule `Timeout`.
- **Root cause:** per-rule timeouts are implemented with `memprof-limits`, which raises an *asynchronous* exception at an allocation point when the time budget is exceeded. The parsed AST lives in `Xtarget.lazy_ast_and_errors`, a `lazy` built once per file and forced on demand by the first rule that needs it — inside that rule's timeout scope. If the timeout fires while that force is in progress, the exception propagates, and `Stdlib.Lazy` stores a *re-raising closure* in the thunk (`Lazy.mli`: "If it raised an exception, the same exception is raised again"). Every later rule that forces the same thunk then re-raises that stored interrupt. Because `Memprof_limits.Limit_reached` is a private exception, no downstream handler recognizes it, so it escapes as a rule-less fatal. In other words: **one rule's timeout kills the other rules on that file.**
- **When it triggers:** whenever the time to force a shared lazy exceeds the per-rule timeout — in practice a very small `-timeout`, or a large enough file that parsing alone runs past the timeout.

## The fix

- **New module `libs/commons/Lazy_with_restart`** — a lazy that only memoizes a *successful* result. If forcing raises, the thunk is left unforced, so the next `force` re-runs ("restarts") the computation. (`Stdlib.Lazy` offers no way to avoid memoizing the exception, and `Lazy.force_val` leaves the thunk in an `Undefined` state instead — neither retries.) API: `make`, `from_val`, `force`, `is_val`.
- **Use it for `Xtarget.lazy_content` and `Xtarget.lazy_ast_and_errors`.** Now if a rule's timeout interrupts the read/parse, the shared value is not poisoned: a later (often simpler/faster) rule simply re-runs the computation, and the rule that was interrupted is reported as a normal `Timeout`. As a bonus, unlike `Stdlib.Lazy`, `Lazy_with_restart` does not raise `Lazy.Undefined` on concurrent forcing — at worst it recomputes — which matches the existing behavior of `Common.memoized`.

The success path is unchanged from `Lazy` (compute once, then return the cached value), so this only changes behavior in the exceptional case.

## Why only these two fields, and not every `lazy` in the engine

The bug needs a lazy that is **both**:

1. **shared across rules** — so that a *later* rule can force it again and inherit the poisoned thunk; and
2. **forced inside a per-rule timeout** — so the async interrupt can strike mid-computation.

Only `Xtarget`'s per-file fields (`lazy_ast_and_errors`, `lazy_content`) satisfy both: they are built once per target and read by every rule during matching.

The other lazy values do not qualify, so converting them would be needless churn (and, for some, a behavior change):

- **Per-match `tokens` lazies** (`Match_patterns`, `Match_search_mode`, …) are created per match, not shared across rules; a poisoned one dies with the rule that created it and can't reach another rule.
- **The report / code-snippet path** reads file content through `Common.memoized` (a Kcas hashtable), which — unlike `lazy` — does **not** memoize exceptions, so it is already safe.
- **Module-level / global lazies** (e.g. compiled regexes) are computed once, typically before matching, and are not tied to a rule's timeout.
- **`Lockfile_xtarget`'s** `lazy_content` / `lazy_dependencies` are a separate SCA-only type; left as-is here and can be migrated if the same pattern is confirmed for lockfile scanning.

Keeping the surface minimal also keeps the change low-risk.
