### PR TITLE
fix: force-remove baseline worktree so EOL-normalizing repos don't fail scans

### DIFF
--- a/cli/src/semgrep/git.py
+++ b/cli/src/semgrep/git.py
@@ -353,8 +353,14 @@ class BaselineHandler:
             finally:
                 os.chdir(cwd)
                 logger.debug("Cleaning up git worktree")
-                # Remove the working tree
-                git_check_output(["git", "worktree", "remove", tmpdir])
+                # Remove the working tree. --force is required because the
+                # worktree can be "dirty" through no fault of ours: repos whose
+                # .gitattributes normalize line endings (e.g. `* text=auto`
+                # with files committed as CRLF) produce phantom modifications
+                # on a fresh checkout, and `git worktree remove` refuses to
+                # delete such a worktree. The worktree is a throwaway temporary
+                # directory, so forcing removal is always safe here.
+                git_check_output(["git", "worktree", "remove", "--force", tmpdir])
                 logger.debug("Finished cleaning up git worktree")
 
     def print_git_log(self) -> None:

--- a/cli/tests/default/e2e/test_baseline.py
+++ b/cli/tests/default/e2e/test_baseline.py
@@ -680,6 +680,32 @@ def test_staged_changes(git_tmp_path, snapshot):
     assert_err_match(snapshot, output, "error.txt")
 
 
+def test_baseline_worktree_dirty_from_eol_normalization(git_tmp_path, snapshot):
+    # A fresh checkout of the baseline commit can be "dirty" without any real
+    # modification when .gitattributes normalizes line endings but files were
+    # committed unnormalized (e.g. CRLF blobs later covered by `*.py text eol=lf`).
+    # `git worktree remove` refuses to delete such a worktree unless --force is
+    # used, which previously aborted the entire scan (exit 2) after the scan
+    # itself had already completed successfully.
+    foo = git_tmp_path / "foo.py"
+    foo.write_bytes(b"x = 1\r\n")  # CRLF blob, committed before any attributes
+    subprocess.run(["git", "add", "."], check=True, capture_output=True)
+    _git_commit(1)
+
+    # Normalization rule added after the fact: from now on every fresh
+    # checkout of the commit above reports foo.py as phantom-modified.
+    (git_tmp_path / ".gitattributes").write_text("*.py text eol=lf\n")
+    subprocess.run(["git", "add", "."], check=True, capture_output=True)
+    base_commit = _git_commit(2)
+
+    foo.write_bytes(f"x = 1\r\ny = {SENTINEL_1}\r\n".encode())
+    subprocess.run(["git", "add", "."], check=True, capture_output=True)
+    _git_commit(3)
+
+    output = run_sentinel_scan(base_commit=base_commit, check=False)
+    assert output.returncode == 0
+
+
 # TODO
 # def test_baseline_has_head_untracked(git_tmp_path, snapshot):
 #    pass


### PR DESCRIPTION
## Problem

Diff-aware scans (`--baseline-commit`) fail with a fatal error (exit code 2) on repositories whose `.gitattributes` normalize line endings — e.g. `* text=auto` or `*.cs text eol=crlf` — when blobs were committed unnormalized. This is very common in Windows-oriented C#/.NET repositories.

## Mechanism

1. `BaselineHandler.baseline_context` creates a temporary `git worktree` at the baseline commit.
2. On such repos, the fresh worktree is **instantly dirty**: git reports phantom modifications because the committed blobs don't match their attribute-normalized form. No file was actually touched.
3. The scan itself completes fine — findings are computed and baseline matches removed.
4. The `finally` cleanup runs `git worktree remove <tmpdir>`, which refuses:
   ```
   fatal: '/tmp/tmpXXXX' contains modified or untracked files, use --force to delete it
   ```
5. `git_check_output` raises a fatal `SemgrepError` → the whole scan exits 2, **after** results were already computed (and already written when `-o` is used).

With `--json` output the underlying git error is never printed to the terminal, which makes this failure mode very hard to diagnose in CI — we chased it for a while before finding it.

## Fix

Use `git worktree remove --force`. The worktree is a throwaway `tempfile.TemporaryDirectory`; there is nothing in it worth protecting, so forcing removal is always safe.

## Reproduction

```bash
mkdir demo && cd demo && git init -q
printf 'x = 1\r\n' > foo.py                 # CRLF blob, no attributes yet
git add . && git commit -qm one
echo '*.py text eol=lf' > .gitattributes    # normalization added after the fact
git add . && git commit -qm two
printf 'x = 1\r\ny = 23478921\r\n' > foo.py
git add . && git commit -qm three
semgrep scan -e '$X = 23478921' -l python --baseline-commit HEAD~1 .
# => exits 2 with the worktree removal error; with this fix: exits 0
```

Added an e2e regression test (`test_baseline_worktree_dirty_from_eol_normalization`) covering exactly this shape.