### PR TITLE
Warn when --diff-depth is set, since it is ignored

### DIFF
--- a/cli/src/semgrep/commands/ci.py
+++ b/cli/src/semgrep/commands/ci.py
@@ -272,6 +272,9 @@ def ci(
             "WARNING: --inline-metavariables is set but will be ignored."
         )
 
+    if ctx.get_parameter_source("diff_depth") != click.core.ParameterSource.DEFAULT:
+        logger.info("WARNING: --diff-depth is set but will be ignored.")
+
     state.error_handler.configure(suppress_errors)
     capture_core_stderr = not debug
 

--- a/cli/src/semgrep/commands/scan.py
+++ b/cli/src/semgrep/commands/scan.py
@@ -568,6 +568,12 @@ def scan(
             "WARNING: --oss-only is set but will be ignored: opengrep only runs the open source engine."
         )
 
+    if (
+        click.get_current_context().get_parameter_source("diff_depth")
+        != click.core.ParameterSource.DEFAULT
+    ):
+        logger.info("WARNING: --diff-depth is set but will be ignored.")
+
     # Define engine_type for later use in the scan output messages
     engine_type: Optional[EngineType] = None
 


### PR DESCRIPTION
## What

`--diff-depth` is accepted by `opengrep scan` and `opengrep ci`, but nothing reads it. This adds a warning so users find that out from the CLI rather than from confusing scan results.

## Why

Grepping the value through the Python path shows only declarations and plumbing — it reaches `run_scan()` and stops:

```
commands/scan.py:352    --diff-depth option definition
commands/scan.py:496    scan() param
commands/scan.py:782    passed to run_scan(diff_depth=diff_depth)
commands/ci.py:187      ci() param
commands/ci.py:437      passed via run_scan_args
run_scan.py:501         keyword-only param, never referenced in the body
```

Its only consumer used to be:

```python
if engine_type.is_interfile:
    target_mode_config = TargetModeConfig.pro_diff_scan(
        target_manager.get_all_files(), diff_depth,
    )
else:
    target_mode_config = TargetModeConfig.diff_scan()
```

That branch and the `ProDiffScan` type went away in 0187d7c ("Remove the pro engine types"), and nothing replaced the read. The flag has been inert since — no crash, no warning, identical behaviour at `-1`, `0` or `50`.

Note this is only about the *inter-file* depth knob. Per-file differential scanning via `--baseline-commit` is untouched and works fine; the warning says so explicitly, so it isn't misread as "diff scanning is off".

## Approach

Mirrors the existing `--oss-only` warning in each file, and in `ci.py` joins the cluster next to `--force-exclude` / `--inline-metavariables`.

The check uses click's parameter source rather than comparing against `DEFAULT_DIFF_DEPTH`, because the default is `-1` — a value comparison would stay silent for someone who explicitly typed `--diff-depth -1`, who is just as wrong about what the flag does. There's precedent for the idiom at `scan.py:665`.

The flag itself is left in place; removing it would break invocations that currently pass it harmlessly.

## Testing

Built the CLI and ran it against a two-commit git repo:

| invocation | warning | findings |
|---|---|---|
| `scan --config rule.yaml .` | no | 2 |
| `scan --config rule.yaml --diff-depth 2 .` | yes | 2 |
| `scan --baseline-commit <base> .` | no | 1 (`new.py`) |
| `scan --baseline-commit <base> --diff-depth 2 .` | yes | 1 (`new.py`) |
| `ci --config rule.yaml` | no | 2 blocking, exit 1 |
| `ci --config rule.yaml --diff-depth 2` | yes | 2 blocking, exit 1 |

Rows 3 and 4 are the ones that matter: identical results with and without the flag, which is the point.

Existing suites pass:

```
tests/default/e2e-other/test_ci.py                      4 passed
tests/default/e2e/test_baseline.py + unit/test_baseline.py  29 passed
```

## Two things worth a maintainer's call

1. **`--quiet`.** In `ci.py` the warnings sit after `state.terminal.configure(...)`, so `--quiet` suppresses this one. In `scan.py` the `--oss-only` warning fires *before* `configure(...)`, so the new warning prints even under `--quiet`. I matched the neighbour in each file rather than introduce a third pattern, but moving the `scan.py` block below `configure(...)` would make it consistent and quiet-respecting — happy to do that if preferred.

2. **osemgrep.** `Scan_CLI.ml:299` parses `--diff-depth` into `conf.targeting_conf.diff_depth`, which nothing reads either; `Diff_scan.ml:214` uses the hardcoded `Differential_scan_config.default_depth`. I left the OCaml path alone since there's no ignored-flag warning convention there (`--oss-only` is silent too), but it's the same gap if you want parity.
