### PR TITLE
Improve install scripts

### DIFF
--- a/.github/workflows/test-install-ps1.yml
+++ b/.github/workflows/test-install-ps1.yml
@@ -1,43 +1,98 @@
 name: test-install-ps1
 
 on:
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - 'install.ps1'
-  # pull_request:
-  #   paths:
-  #     - 'install.ps1'
+  push:
+    branches:
+      - main
+    paths:
+      - 'install.ps1'
+      - '.github/workflows/test-install-ps1.yml'
+  pull_request:
+    paths:
+      - 'install.ps1'
+      - '.github/workflows/test-install-ps1.yml'
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   test-install-script:
     runs-on: windows-2022
+    strategy:
+      fail-fast: false
+      matrix:
+        # 'powershell' is Windows PowerShell 5.1, 'pwsh' is PowerShell 7;
+        # they differ in TLS negotiation and HTTP error handling.
+        shell: [pwsh, powershell]
+    defaults:
+      run:
+        # Step-level shell does not receive the matrix context.
+        shell: ${{ matrix.shell }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
           submodules: false
+          persist-credentials: false
 
       # Test help output
       - name: Test -Help flag
-        shell: pwsh
         run: .\install.ps1 -Help
 
       # Test listing versions
       - name: Test -List flag
-        shell: pwsh
         run: .\install.ps1 -List
 
-      # Test installing latest version
+      # A nonexistent version must fail with a non-zero exit; the not-found
+      # message is advisory, as PS 5.1 can lose the connection before the 404.
+      - name: Install nonexistent version (expect failure)
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $output = & ${{ matrix.shell }} -NoProfile -ExecutionPolicy Bypass -File .\install.ps1 -Version v9.9.9 2>&1 | Out-String
+          Write-Host $output
+          if ($LASTEXITCODE -eq 0) {
+            Write-Error "Expected the install of a nonexistent version to fail"
+            exit 1
+          }
+          if ($output -notmatch 'not found') {
+            Write-Host "::notice::No not-found message; the download failed at transport level"
+          }
+          # The runner appends `exit $LASTEXITCODE`; the child's expected
+          # non-zero exit code must not fail the step.
+          exit 0
+
+      - name: Resolve latest release tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $tag = gh api repos/opengrep/opengrep/releases/latest --jq .tag_name
+          if (-not $tag) {
+            Write-Error "Failed to resolve the expected latest tag via gh"
+            exit 1
+          }
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+
+      # Test installing latest version; it must resolve to the latest stable
+      # release, never a pre-release
       - name: Install latest version
-        shell: pwsh
-        run: .\install.ps1
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $output = & ${{ matrix.shell }} -NoProfile -ExecutionPolicy Bypass -File .\install.ps1 2>&1 | Out-String
+          Write-Host $output
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Default install failed"
+            exit 1
+          }
+          $latestTag = '${{ steps.latest.outputs.tag }}'
+          if ($output -notmatch [regex]::Escape("Installing Opengrep $latestTag")) {
+            Write-Error "Default install did not resolve the latest stable version ($latestTag)"
+            exit 1
+          }
 
       # Verify installation
       - name: Verify installation
-        shell: pwsh
         run: |
           $binary = "$env:USERPROFILE\.opengrep\cli\latest\opengrep.exe"
           if (Test-Path $binary) {
@@ -47,14 +102,18 @@ jobs:
             exit 1
           }
 
-      # Test specific version install (re-install same or older version)
+      # Test specific version install (re-install same or older version);
+      # v1.11.2 is older than the GitHub API's first page of releases
       - name: Install specific version
-        shell: pwsh
-        run: .\install.ps1 -Version v1.15.0
+        run: .\install.ps1 -Version v1.11.2
+
+      # Pre-releases are never the default but must be installable explicitly;
+      # disabled because it pins a tag that may be deleted after a rebuild
+      # - name: Install pre-release version
+      #   run: .\install.ps1 -Version v1.28.0-interfile.alpha.1
 
       # Test remote execution style (one-liner simulation)
       - name: Test script from stdin
-        shell: pwsh
         run: |
           $script = Get-Content -Raw .\install.ps1
           & ([scriptblock]::Create($script)) -Help
@@ -66,6 +125,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: false
+          persist-credentials: false
 
       - name: Install cosign
         uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
@@ -90,6 +150,7 @@ jobs:
         with:
           fetch-depth: 1
           submodules: false
+          persist-credentials: false
 
       # Test that ARM64 gets a warning but still installs
       - name: Install on ARM64 (should warn and use x86 emulation)

--- a/.github/workflows/test-install-sh.yml
+++ b/.github/workflows/test-install-sh.yml
@@ -1,0 +1,153 @@
+name: test-install-sh
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'install.sh'
+      - '.github/workflows/test-install-sh.yml'
+  pull_request:
+    paths:
+      - 'install.sh'
+      - '.github/workflows/test-install-sh.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test-install-script:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      # Test help output
+      - name: Test -h flag
+        run: bash ./install.sh -h
+
+      # Test listing versions
+      - name: Test -l flag
+        run: bash ./install.sh -l
+
+      # A nonexistent version must fail with the not-found message
+      - name: Install nonexistent version (expect failure)
+        run: |
+          set +e
+          output=$(bash ./install.sh -v v9.9.9 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if [ "$status" -eq 0 ]; then
+            echo "Expected the install of a nonexistent version to fail" 1>&2
+            exit 1
+          fi
+          echo "$output" | grep -q "not found" || {
+            echo "Expected a version-not-found message" 1>&2
+            exit 1
+          }
+
+      - name: Resolve latest release tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          latest_tag=$(gh api repos/opengrep/opengrep/releases/latest --jq .tag_name)
+          if [ -z "$latest_tag" ]; then
+            echo "Failed to resolve the expected latest tag via gh" 1>&2
+            exit 1
+          fi
+          echo "tag=$latest_tag" >> "$GITHUB_OUTPUT"
+
+      # Test installing latest version; it must resolve to the latest stable
+      # release, never a pre-release
+      - name: Install latest version
+        run: |
+          set +e
+          output=$(bash ./install.sh 2>&1)
+          status=$?
+          set -e
+          echo "$output"
+          if [ "$status" -ne 0 ]; then
+            echo "Default install failed" 1>&2
+            exit 1
+          fi
+          latest_tag='${{ steps.latest.outputs.tag }}'
+          echo "$output" | grep -qF "Installing Opengrep $latest_tag" || {
+            echo "Default install did not resolve the latest stable version ($latest_tag)" 1>&2
+            exit 1
+          }
+
+      # Verify installation
+      - name: Verify installation
+        run: |
+          binary="$HOME/.opengrep/cli/latest/opengrep"
+          if [ -f "$binary" ]; then
+            "$binary" --version
+          else
+            echo "Binary not found at $binary" 1>&2
+            exit 1
+          fi
+
+      # Test specific version install (re-install same or older version);
+      # v1.11.2 is older than the GitHub API's first page of releases
+      - name: Install specific version
+        run: bash ./install.sh -v v1.11.2
+
+      # Pre-releases are never the default but must be installable explicitly;
+      # disabled because it pins a tag that may be deleted after a rebuild
+      # - name: Install pre-release version
+      #   run: bash ./install.sh -v v1.28.0-interfile.alpha.1
+
+      # Test remote execution style (one-liner simulation)
+      - name: Test script from stdin
+        run: bash -s -- -h < ./install.sh
+
+  test-musllinux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      # Alpine exercises the musl detection path, which selects the
+      # musllinux asset
+      - name: Install and verify on Alpine (musl)
+        run: |
+          docker run --rm -v "$PWD:/work" alpine:3.21 sh -c '
+            apk add --no-cache bash curl
+            bash /work/install.sh
+            "$HOME/.opengrep/cli/latest/opengrep" --version
+          '
+
+  test-with-cosign:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3.9.1
+
+      - name: Verify cosign installed
+        run: cosign version
+
+      - name: Install with signature verification
+        run: bash ./install.sh --verify-signatures
+
+      - name: Verify installation
+        run: |
+          "$HOME/.opengrep/cli/latest/opengrep" --version

--- a/install.ps1
+++ b/install.ps1
@@ -64,7 +64,22 @@ param(
     [switch]$Help
 )
 
+# Session-global under irm | iex, like SecurityProtocol below; both are
+# restored at the end of the run.
+$originalErrorActionPreference = $ErrorActionPreference
 $ErrorActionPreference = "Stop"
+
+# PowerShell 5.1's SystemDefault protocol negotiation can be aborted by
+# github.com ("connection was closed unexpectedly"), which also masks HTTP
+# status codes such as 404. The same happens when TLS 1.3 is enabled, as
+# .NET Framework's TLS 1.3 support is unreliable; force TLS 1.2 only.
+# The setting is process-global, so it is restored at the end of the run:
+# under the documented one-liners the script executes in the caller's
+# session, which must not stay pinned to TLS 1.2.
+$originalSecurityProtocol = [Net.ServicePointManager]::SecurityProtocol
+if ($PSVersionTable.PSEdition -ne 'Core') {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+}
 
 $ScriptName = if ($MyInvocation.MyCommand.Name) { $MyInvocation.MyCommand.Name } else { "install.ps1" }
 
@@ -90,29 +105,84 @@ function Print-Usage {
     Write-Host "  - '-List' and '-Help' cannot be combined with other options."
 }
 
-function Get-AvailableVersions {
-    try {
-        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/opengrep/opengrep/releases" -UseBasicParsing
-        return $response | ForEach-Object { $_.tag_name }
-    }
-    catch {
-        Write-Error "Failed to fetch available versions: $_"
-        exit 1
+# The version is interpolated into the install path and download URL, so accept
+# only a release tag. Same semver shape as validate-inputs in rolling-release,
+# with the suffix restricted to tag characters so no path separator gets through.
+# [.] rather than \. to match the regex literal in install.sh; \z rather
+# than $ because .NET $ accepts a trailing newline where bash rejects it.
+$ReleaseTagRegex = '^v[0-9]+[.][0-9]+[.][0-9]+(-[A-Za-z0-9._-]+)?\z'
+
+function Test-VersionFormat {
+    param([string]$Version)
+
+    if ($Version -cnotmatch $ReleaseTagRegex) {
+        throw "Invalid version '$Version'. Expected a release tag such as v1.27.1."
     }
 }
 
-function Validate-Version {
-    param([string]$VersionToValidate)
+function Throw-FetchFailed {
+    param([string]$Reason)
 
-    $availableVersions = Get-AvailableVersions
-    if ($availableVersions -contains $VersionToValidate) {
-        return $true
+    if ($Reason) { throw "Failed to fetch available versions from GitHub: $Reason" }
+    throw "Failed to fetch available versions from GitHub."
+}
+
+# Lists the Count most recent releases, newest first, marking pre-releases.
+# Throws on failure so a caller mid-install can still clean up.
+function Get-VersionList {
+    param([int]$Count)
+
+    try {
+        $response = Invoke-RestMethod -Uri "https://api.github.com/repos/opengrep/opengrep/releases?per_page=$Count" -UseBasicParsing
     }
-    else {
-        Write-Host "Error: Version $VersionToValidate not found" -ForegroundColor Red
-        Write-Host "Available versions (latest 3):"
-        $availableVersions | Select-Object -First 3 | ForEach-Object { Write-Host "  $_" }
-        exit 1
+    catch {
+        $reason = $_.Exception.Message
+        if ($_.Exception.Response) {
+            $status = [int]$_.Exception.Response.StatusCode
+            # GitHub API error bodies explain the failure in a "message" field.
+            $detail = $null
+            try { $detail = (ConvertFrom-Json $_.ErrorDetails.Message).message } catch {}
+            $reason = if ($detail) { "HTTP status $status ($detail)." } else { "HTTP status $status." }
+        }
+        Throw-FetchFailed $reason
+    }
+    # Tags that are not release tags are not listed.
+    $versions = @($response | Where-Object { $_.tag_name -cmatch $ReleaseTagRegex } | ForEach-Object {
+        if ($_.prerelease) { "$($_.tag_name) (pre-release)" } else { $_.tag_name }
+    })
+    if ($versions.Count -eq 0) {
+        Throw-FetchFailed
+    }
+    return $versions
+}
+
+function Show-VersionList {
+    param([int]$Count)
+
+    Write-Host "Available versions (latest $Count):"
+    Get-VersionList -Count $Count | ForEach-Object { Write-Host "  $_" }
+}
+
+# The /releases/latest web redirect never points to a pre-release or draft,
+# and does not use the rate-limited API.
+function Get-LatestVersion {
+    try {
+        $response = Invoke-WebRequest -Uri "https://github.com/opengrep/opengrep/releases/latest" -Method Head -UseBasicParsing
+        $finalUri = if ($PSVersionTable.PSEdition -eq 'Core') {
+            # PowerShell 7+ (HttpResponseMessage)
+            $response.BaseResponse.RequestMessage.RequestUri.AbsoluteUri
+        }
+        else {
+            # PowerShell 5.1 (HttpWebResponse)
+            $response.BaseResponse.ResponseUri.AbsoluteUri
+        }
+        if ($finalUri -match '/releases/tag/([^/]+)$') {
+            return $Matches[1]
+        }
+        throw "unexpected final URL $finalUri"
+    }
+    catch {
+        throw "Failed to determine the latest version: $_"
     }
 }
 
@@ -169,9 +239,8 @@ function Validate-Signature {
             Write-Host "Signature valid."
         }
         else {
-            Write-Host "Error: Signature validation error." -ForegroundColor Red
             Write-Host $result.Trim()
-            exit 1
+            throw "Signature validation error."
         }
     }
     else {
@@ -185,6 +254,7 @@ function Cleanup-OnFailure {
 
     Write-Host "An error occurred during the installation. Cleaning up $InstallPath..." -ForegroundColor Yellow
     Remove-Item -Path "$InstallPath\opengrep.exe" -ErrorAction SilentlyContinue
+    Remove-Item -Path "$InstallPath\opengrep.exe.download" -ErrorAction SilentlyContinue
     Remove-Item -Path "$InstallPath\opengrep.sig" -ErrorAction SilentlyContinue
     Remove-Item -Path "$InstallPath\opengrep.cert" -ErrorAction SilentlyContinue
     Remove-Item -Path $InstallPath -ErrorAction SilentlyContinue
@@ -243,8 +313,7 @@ function Main {
         $dist = "opengrep_windows_x86.exe"
     }
     else {
-        Write-Host "Error: Architecture '$arch' is unsupported." -ForegroundColor Red
-        exit 1
+        throw "Architecture '$arch' is unsupported."
     }
 
     $url = "https://github.com/opengrep/opengrep/releases/download/$VersionToInstall/$dist"
@@ -272,7 +341,24 @@ function Main {
             # Download the binary
             Write-Host "Downloading $url..."
             $progressPreference = 'SilentlyContinue'  # Speeds up Invoke-WebRequest
-            Invoke-WebRequest -Uri $url -OutFile $binaryPath -UseBasicParsing
+            # The download also validates the version, avoiding the rate-limited
+            # GitHub API: a 404 means the tag does not exist or has no asset for
+            # this platform. A temporary name, renamed only on success, so an
+            # interrupted download is never mistaken for an installed binary.
+            $downloadPath = "$binaryPath.download"
+            try {
+                Invoke-WebRequest -Uri $url -OutFile $downloadPath -UseBasicParsing
+            }
+            catch {
+                if ($_.Exception.Response.StatusCode -eq 404) {
+                    Write-Host "Error: Version $VersionToInstall not found, or it has no $dist asset." -ForegroundColor Red
+                    # A listing failure must not mask the diagnosis above.
+                    try { Show-VersionList -Count 3 } catch { Write-Host "  ($_)" }
+                    throw "Version not found"
+                }
+                throw "Failed to download $url`: $_"
+            }
+            Move-Item -Force -Path $downloadPath -Destination $binaryPath
 
             $sigExists = $true
 
@@ -385,70 +471,77 @@ function Main {
 
 # --- Main script execution ---
 
-# Check for cosign
-$script:HasCosign = Test-CosignInstalled
+# Failures are thrown and reported once in the catch below; `exit` happens
+# only at the very end, and only when running as a script file. Under the
+# documented one-liners the script executes at session scope, where an
+# early exit would close the caller's console; the failure is rethrown
+# instead, so callers still observe a terminating error.
+$failed = $false
+try {
+    # Check for cosign
+    $script:HasCosign = Test-CosignInstalled
 
-# Validate argument combinations
-if ($Help -and ($List -or $Version -or $VerifySignatures)) {
-    Write-Host "Error: incorrect arguments:" -ForegroundColor Red
-    Print-Usage
-    exit 1
-}
+    # Validate argument combinations
+    if (($Help -and ($List -or $Version -or $VerifySignatures)) -or
+        ($List -and ($Version -or $VerifySignatures))) {
+        Print-Usage
+        throw "incorrect arguments"
+    }
 
-if ($List -and ($Version -or $VerifySignatures)) {
-    Write-Host "Error: incorrect arguments:" -ForegroundColor Red
-    Print-Usage
-    exit 1
-}
-
-if ($VerifySignatures -and -not $script:HasCosign) {
-    Write-Host "Error: cosign is required for -VerifySignatures but is not installed." -ForegroundColor Red
-    Write-Host "Go to https://github.com/sigstore/cosign to install it or run without the -VerifySignatures flag to install without signature verification."
-    exit 1
-}
-elseif (-not $script:HasCosign) {
-    Write-Host "Warning: cosign is required for -VerifySignatures but is not installed. Skipping signature validation." -ForegroundColor Yellow
-    Write-Host "Go to https://github.com/sigstore/cosign to install it."
-}
-elseif ($script:HasCosign) {
-    $cosignMajor = Get-CosignMajorVersion
-    if ($null -eq $cosignMajor) {
-        if ($VerifySignatures) {
-            Write-Host "Error: could not determine cosign version and -VerifySignatures was requested." -ForegroundColor Red
-            Write-Host "Your cosign binary may have been built without version metadata (e.g. distro packages)."
-            Write-Host "Install cosign from https://github.com/sigstore/cosign or run without -VerifySignatures."
-            exit 1
+    if ($VerifySignatures -and -not $script:HasCosign) {
+        throw "cosign is required for -VerifySignatures but is not installed.`nGo to https://github.com/sigstore/cosign to install it or run without the -VerifySignatures flag to install without signature verification."
+    }
+    elseif (-not $script:HasCosign) {
+        Write-Host "Warning: cosign is required for -VerifySignatures but is not installed. Skipping signature validation." -ForegroundColor Yellow
+        Write-Host "Go to https://github.com/sigstore/cosign to install it."
+    }
+    elseif ($script:HasCosign) {
+        $cosignMajor = Get-CosignMajorVersion
+        if ($null -eq $cosignMajor) {
+            if ($VerifySignatures) {
+                throw "could not determine cosign version and -VerifySignatures was requested.`nYour cosign binary may have been built without version metadata (e.g. distro packages).`nInstall cosign from https://github.com/sigstore/cosign or run without -VerifySignatures."
+            }
+            else {
+                Write-Host "Warning: could not determine cosign version. Signature validation may not work correctly." -ForegroundColor Yellow
+            }
         }
-        else {
-            Write-Host "Warning: could not determine cosign version. Signature validation may not work correctly." -ForegroundColor Yellow
+        elseif ($cosignMajor -lt 2) {
+            Write-Host "Warning: cosign version is less than 2.0.0, signature validation may fail." -ForegroundColor Yellow
         }
     }
-    elseif ($cosignMajor -lt 2) {
-        Write-Host "Warning: cosign version is less than 2.0.0, signature validation may fail." -ForegroundColor Yellow
+
+    if ($Help) {
+        Print-Usage
+    }
+    elseif ($List) {
+        Show-VersionList -Count 3
+    }
+    else {
+        # Determine version to install; an explicit empty -Version is
+        # rejected by the format check, as in install.sh
+        if (-not $PSBoundParameters.ContainsKey('Version')) {
+            $Version = Get-LatestVersion
+        }
+        Test-VersionFormat -Version $Version
+        Main -VersionToInstall $Version -DoVerifySignatures $VerifySignatures.IsPresent
+    }
+}
+catch {
+    if ($MyInvocation.MyCommand.Path) {
+        Write-Host "Error: $_" -ForegroundColor Red
+        $failed = $true
+    }
+    else {
+        throw
+    }
+}
+finally {
+    $ErrorActionPreference = $originalErrorActionPreference
+    if ($PSVersionTable.PSEdition -ne 'Core') {
+        [Net.ServicePointManager]::SecurityProtocol = $originalSecurityProtocol
     }
 }
 
-if ($Help) {
-    Print-Usage
-    exit 0
+if ($failed) {
+    exit 1
 }
-
-if ($List) {
-    Write-Host "Available versions (latest 3):"
-    Get-AvailableVersions | Select-Object -First 3 | ForEach-Object { Write-Host "  $_" }
-    exit 0
-}
-
-# Determine version to install
-if (-not $Version) {
-    $Version = (Get-AvailableVersions | Select-Object -First 1)
-    if (-not $Version) {
-        Write-Host "Error: Could not determine latest version." -ForegroundColor Red
-        exit 1
-    }
-}
-else {
-    Validate-Version -VersionToValidate $Version
-}
-
-Main -VersionToInstall $Version -DoVerifySignatures $VerifySignatures.IsPresent

--- a/install.sh
+++ b/install.sh
@@ -38,31 +38,75 @@ check_has_curl() {
     }
 }
 
-# Function to get available versions - already checked when running main
-get_available_versions() {
+fetch_failed() {
+    echo "Error: Failed to fetch available versions from GitHub${1:+: $1}." 1>&2
+    exit 1
+}
+
+# Lists the COUNT most recent releases, newest first, marking pre-releases.
+list_versions() {
+    local COUNT="$1"
     check_has_curl
-    local VERSIONS
-    VERSIONS=$(curl -sS https://api.github.com/repos/opengrep/opengrep/releases |
-        grep '"tag_name":' |
-        sed -E 's/.*"([^"]+)".*/\1/') || true
+    local RESPONSE HTTP_STATUS BODY REASON VERSIONS
+    RESPONSE=$(curl -sS -w '\n%{http_code}' \
+        "https://api.github.com/repos/opengrep/opengrep/releases?per_page=${COUNT}") || {
+        # curl -sS has already printed its error on stderr.
+        fetch_failed
+    }
+    HTTP_STATUS="${RESPONSE##*$'\n'}"
+    BODY="${RESPONSE%$'\n'*}"
+    if [ "$HTTP_STATUS" != "200" ]; then
+        # GitHub API error bodies explain the failure in a "message" field.
+        REASON=$(echo "$BODY" | awk -F'"' '$2 == "message" { print $4; exit }')
+        fetch_failed "HTTP status ${HTTP_STATUS}${REASON:+ (${REASON})}"
+    fi
+    # Split on double quotes, so $2 is the JSON key and $4 its string value.
+    # Tags that are not release tags are not listed.
+    VERSIONS=$(echo "$BODY" | awk -F'"' -v TAG_RE="$RELEASE_TAG_REGEX" '
+        $2 == "tag_name" && $4 ~ TAG_RE { TAG = $4 }
+        $2 == "prerelease" && TAG != "" {
+            if ($3 ~ /true/) { print TAG " (pre-release)" } else { print TAG }
+            TAG = ""
+        }')
     if [ -z "$VERSIONS" ]; then
-        echo "Error: Failed to fetch available versions from GitHub." 1>&2
-        exit 1
+        fetch_failed
     fi
     echo "$VERSIONS"
 }
 
-# Function to validate version
-validate_version() {
-    local VERSION="$1"
-    local AVAILABLE_VERSIONS
-    AVAILABLE_VERSIONS=$(get_available_versions)
-    if echo "$AVAILABLE_VERSIONS" | grep -q "^$VERSION$"; then
-        return 0
+print_available_versions() {
+    local COUNT="$1"
+    echo "Available versions (latest ${COUNT}):"
+    list_versions "$COUNT"
+}
+
+# Function to get the latest version. The /releases/latest web redirect never
+# points to a pre-release or draft, and does not use the rate-limited API.
+# curl's exit status is ignored: even if the connection dies after the
+# redirect was followed, url_effective already holds the tag URL.
+get_latest_version() {
+    check_has_curl
+    local FINAL_URL
+    FINAL_URL=$(curl -ILsS -o /dev/null -w '%{url_effective}' \
+        https://github.com/opengrep/opengrep/releases/latest) || true
+    if [[ "$FINAL_URL" =~ /releases/tag/([^/]+)$ ]]; then
+        echo "${BASH_REMATCH[1]}"
     else
-        echo "Error: Version $VERSION not found"
-        echo "Available versions (latest 3):"
-        echo "$AVAILABLE_VERSIONS" | head -3
+        echo "Error: Failed to determine the latest version from GitHub." 1>&2
+        exit 1
+    fi
+}
+
+# The version is interpolated into the install path and download URL, so accept
+# only a release tag. Same semver shape as validate-inputs in rolling-release,
+# with the suffix restricted to tag characters so no path separator gets through.
+# [.] rather than \. so the same regex works in bash =~ and as an awk -v value.
+readonly RELEASE_TAG_REGEX='^v[0-9]+[.][0-9]+[.][0-9]+(-[A-Za-z0-9._-]+)?$'
+
+validate_version_format() {
+    local VERSION="$1"
+    if ! [[ "$VERSION" =~ $RELEASE_TAG_REGEX ]]; then
+        echo "Error: Invalid version '${VERSION}'. Expected a release tag such as v1.27.1." 1>&2
         exit 1
     fi
 }
@@ -97,6 +141,7 @@ cleanup_on_failure() {
     local P="$1"
     echo "An error occurred during the installation. Cleaning up ${P}..."
     rm -f "${P}/opengrep" || true
+    rm -f "${P}/opengrep.download" || true
     rm -f "${P}/opengrep.sig" || true
     rm -f "${P}/opengrep.cert" || true
     rmdir "${P}" || true
@@ -160,7 +205,7 @@ main() {
         echo "*** Installing Opengrep ${VERSION} for ${OS} (${ARCH}) ***"
 
         # cleanup on error
-        trap '[ "$?" -eq 0 ] || cleanup_on_failure $INST' EXIT
+        trap '[ "$?" -eq 0 ] || cleanup_on_failure "$INST"' EXIT
 
         mkdir -p "${INST}"
         if [ ! -d "${INST}" ]; then
@@ -168,7 +213,27 @@ main() {
             exit 1
         fi
 
-        curl --fail --show-error --location --progress-bar "${URL}" > "${INST}/opengrep"
+        # The download also validates the version, avoiding the rate-limited
+        # GitHub API: a 404 means the tag does not exist or has no asset for
+        # this platform. A temporary name, renamed only on success, so an
+        # interrupted download is never mistaken for an installed binary.
+        HTTP_STATUS=$(curl --show-error --location --progress-bar \
+            --write-out '%{http_code}' --output "${INST}/opengrep.download" "${URL}") || HTTP_STATUS=""
+
+        if [[ -z "$HTTP_STATUS" ]]; then
+            # curl has already printed its error on stderr.
+            echo "Error: Failed to download ${URL}." 1>&2
+            exit 1
+        elif [[ "$HTTP_STATUS" == "404" ]]; then
+            echo "Error: Version ${VERSION} not found, or it has no ${DIST} asset." 1>&2
+            # Subshell, so a listing failure cannot mask the diagnosis above.
+            (print_available_versions 3) 1>&2 || true
+            exit 1
+        elif [[ "$HTTP_STATUS" != 200 ]]; then
+            echo "Error: Failed to download ${URL}: HTTP status ${HTTP_STATUS}." 1>&2
+            exit 1
+        fi
+        mv "${INST}/opengrep.download" "${INST}/opengrep"
 
         local SIG_EXISTS=true
 
@@ -340,7 +405,7 @@ if $VERIFY_SIGNATURES && ! $HAS_COSIGN; then
     exit 1
 elif ! $HAS_COSIGN; then
     echo "Warning: cosign is required for --verify-signatures but is not installed. Skipping signature validation."
-    echo "Go to https:/github.com/sigstore/cosign to install it."
+    echo "Go to https://github.com/sigstore/cosign to install it."
 elif [[ -z "$COSIGN_MAJOR_VERSION" ]]; then
     if $VERIFY_SIGNATURES; then
         echo "Error: could not determine cosign version and --verify-signatures was requested."
@@ -360,19 +425,13 @@ if "$HELP"; then
 fi
 
 if $LIST; then
-    echo "Available versions (latest 3):"
-    AVAILABLE_VERSIONS=$(get_available_versions)
-    echo "$AVAILABLE_VERSIONS" | head -3
+    print_available_versions 3
     exit 0
 fi
 
-shift $((OPTIND - 1))
-
 if [ -z "$VERSION" ]; then
-    AVAILABLE_VERSIONS=$(get_available_versions)
-    VERSION=$(echo "$AVAILABLE_VERSIONS" | head -1)
-else
-    validate_version "$VERSION"
+    VERSION=$(get_latest_version)
 fi
+validate_version_format "$VERSION"
 
 main "$VERSION" "$VERIFY_SIGNATURES"


### PR DESCRIPTION
Closes #792.

The install scripts validated `-v` versions against the unpaginated GitHub releases listing, so versions past the first API page were rejected. The default install picked the newest release by creation date, which is currently an alpha pre-release.

- The default version now comes from the `releases/latest` web redirect, which never points to a pre-release and does not use the rate-limited API.
- `-v` / `-Version` is validated by the download itself: a 404 reports the version as not found. The API is only used by `-l` / `-List` and for the not-found hint.
- `-l` / `-List` marks pre-releases; they can still be installed explicitly by tag.
- install.ps1 forces TLS 1.2 on Windows PowerShell 5.1, where the default and TLS 1.3 negotiation are aborted by github.com and mask HTTP status codes.
- test-install-ps1 now runs when install.ps1 changes, also on Windows PowerShell 5.1, and asserts the not-found and latest-stable paths. New test-install-sh covers Linux, macOS, musl via Alpine, and cosign.