### PR TITLE
JS/TS: a `for..in` pattern must not match `for..of` code

### DIFF
--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2931,8 +2931,30 @@ and m_for_header a b =
       fail ()
 
 and m_for_each (a1, at, a2) (b1, bt, b2) =
-  m_pattern a1 b1 >>= fun () ->
-  m_tok at bt >>= fun () -> m_expr a2 b2
+  (* JS/TS desugars `for (x of xs)` into a ForEach whose iterated expression is
+   * wrapped in a `ForOf` IdSpecial marker (see js_to_generic.ml), while
+   * `for (x in xs)` is left bare. A pattern written `for ($K in $OBJ)`
+   * therefore puts a bare metavariable in the iterated position, and that
+   * metavariable binds to the whole marker call — so a for-in pattern also
+   * matches for-of code. The opposite direction is already correct, because a
+   * for-of pattern carries a marker that for-in code does not have.
+   *
+   * `for..of` over an array is one of the most common loops in modern JS, so
+   * any rule keying on for-in to mean "iterating object keys" over-matches
+   * badly. Note this cannot be worked around in a rule: `pattern-not` on the
+   * for-of form is subject to the same conflation.
+   *
+   * Languages that never emit the marker (Python's `for x in xs`, Go, PHP,
+   * Java, Scala) are unaffected, since neither side is wrapped. *)
+  let is_for_of e =
+    match e.G.e with
+    | G.Call ({ e = G.IdSpecial (G.ForOf, _); _ }, _) -> true
+    | _ -> false
+  in
+  if is_for_of b2 && not (is_for_of a2) then fail ()
+  else
+    m_pattern a1 b1 >>= fun () ->
+    m_tok at bt >>= fun () -> m_expr a2 b2
 
 and m_multi_for_each a b =
   match (a, b) with

--- a/tests/patterns/js/misc_forin_not_forof.js
+++ b/tests/patterns/js/misc_forin_not_forof.js
@@ -1,0 +1,17 @@
+// A for-in pattern must match for-in and NOT for-of. Both loops below have the
+// same body shape, so only the loop keyword can tell them apart.
+function copyKeys(src, target) {
+    //ERROR: match
+    for (const k in src) {
+        target[k] = src[k];
+    }
+    return target;
+}
+
+function copyItems(list, target) {
+    // for-of is a different loop and must not match a for-in pattern.
+    for (const k of list) {
+        target[k] = list[k];
+    }
+    return target;
+}

--- a/tests/patterns/js/misc_forin_not_forof.sgrep
+++ b/tests/patterns/js/misc_forin_not_forof.sgrep
@@ -1,0 +1,3 @@
+for ($K in $OBJ) {
+  $TARGET[$K] = $VAL;
+}


### PR DESCRIPTION
### Summary

A pattern written `for ($K in $OBJ)` also matches `for..of` source in JavaScript/TypeScript. Since `for..of` over an array is one of the commonest loops in modern JS, any rule keying on for-in to mean *"iterating object keys"* over-matches heavily.

### Reproduction (1.22.0)

```yaml
# rule.yaml
rules:
  - id: forin-only
    languages: [javascript]
    severity: WARNING
    message: matched a for-IN loop
    patterns:
      - pattern: |
          for ($K in $OBJ) { ... }
```

```js
// forof.js
const arr = [1, 2, 3];
for (const x of arr) {
  console.log(x);
}
```

```
$ opengrep scan -f rule.yaml forof.js
1 finding     # expected 0
```

The conflation is one-directional — a `for..of` pattern correctly does **not** match `for..in` source:

| pattern | vs `for..in` source | vs `for..of` source |
|---|---|---|
| `for ($K in $OBJ)` | 1 ✅ | **1 ❌ (expected 0)** |
| `for ($K of $OBJ)` | 0 ✅ | 1 ✅ |

### Cause

`js_to_generic.ml` desugars both loops into `ForEach`, but asymmetrically:

```ocaml
| ForIn (v1, t, v2) -> ... G.ForEach (pattern, t, v2)                       (* bare *)
| ForOf (v1, t, v2) -> ... G.ForEach (pattern, t,
      G.Call (G.IdSpecial (G.ForOf, t) |> G.e, fb [ G.Arg v2 ]) |> G.e)     (* wrapped *)
```

So a for-in pattern has a bare metavariable in the iterated position, and `$OBJ` binds to the entire marker call. The reverse works because a for-of pattern carries a marker that for-in code lacks.

### Why this can't be worked around in a rule

Adding `pattern-not` for the for-of form does not suppress it — the negation is subject to the same conflation. Only a text-level `pattern-not-regex: 'for\s*\([^)]*\bof\b'` works, which rule authors are unlikely to discover.

### Fix

In `m_for_each`: if the target is a for-of and the pattern is not, they are different loops, so fail before matching. Languages that never emit the marker (Python's `for x in xs`, Go, PHP, Java, Scala) are unaffected — neither side is wrapped.

I considered instead marking `for..in` symmetrically in `js_to_generic`, which is arguably tidier, but that changes the generic AST shape for every JS for-in loop and so touches `Meta_AST`, `AST_generic_to_v1`, `AST_to_IL` and the v1 interface. This fix is contained to the matcher. Happy to switch approaches if you'd prefer the AST-level one.

### Tests

`tests/patterns/js/misc_forin_not_forof.{sgrep,js}` — one for-in loop and one for-of loop with identical bodies, so only the loop keyword can distinguish them.

### What I verified, and what I did not

Verified: the defect and its direction empirically against 1.22.0; the cause by reading `js_to_generic.ml` and `m_for_each`; that the patched `Generic_vs_generic.ml` parses (`ocamlc -stop-after parsing`), including confirming that check rejects a deliberately broken edit.

**Not verified: I did not build opengrep locally** — the opam switch and submodule fetch were more than the shared machine I'm on could reasonably take — so I have not type-checked the change or run the test suite. I'm relying on CI, and I'll iterate promptly on anything it reports.

### How I found it

While measuring false-positive rates for a rule pack across a corpus of open-source repositories. Three prototype-pollution rules keyed on for-in were producing large numbers of false positives; roughly half traced to this.
