### PR TITLE
Add expectation tests for with_experimental_flag

### DIFF
--- a/src/osemgrep/cli/CLI.ml
+++ b/src/osemgrep/cli/CLI.ml
@@ -91,8 +91,8 @@ let global_flags = [ "--experimental"; "--debug"; "--profile" ]
 (* Insert --experimental after the subcommand when there is one, else right
  * after argv0: the implicit 'scan' subcommand parses the flag wherever it
  * is, and the scanning roots stay untouched.
- * Used by Main.ml for the bare 'opengrep' binary. *)
-(* TODO[Issue #131]: Add some expectation tests for such functions. *)
+ * Used by Main.ml for the bare 'opengrep' binary.
+ * Expectation tests: src/osemgrep/tests/Unit_CLI.ml. *)
 let with_experimental_flag (argv : string array) : string array =
   let pos =
     if Array.length argv >= 2 && List.mem argv.(1) known_subcommands then 2
@@ -104,11 +104,6 @@ let with_experimental_flag (argv : string array) : string array =
       [| "--experimental" |];
       Array.sub argv pos (Array.length argv - pos);
     ]
-
-(* let _ = assert (with_experimental_flag [| "opengrep"; "scan"; "--help" |]
-                   = [| "opengrep"; "scan"; "--experimental"; "--help" |])
-   let _ = assert (with_experimental_flag [| "opengrep"; "-c"; "rules"; "libs" |]
-                   = [| "opengrep"; "--experimental"; "-c"; "rules"; "libs" |]) *)
 
 let dispatch_subcommand (caps : caps) (argv : string array) =
   match Array.to_list argv with

--- a/src/osemgrep/tests/Unit_CLI.ml
+++ b/src/osemgrep/tests/Unit_CLI.ml
@@ -5,7 +5,6 @@ let t = Testo.create
 let check_argv msg ~expected (actual : string array) =
   Alcotest.(check (array string)) msg expected actual
 
-(* coupling: these two cases used to be commented-out asserts in CLI.ml *)
 let test_scan_help () =
   check_argv "opengrep scan --help"
     ~expected:[| "opengrep"; "scan"; "--experimental"; "--help" |]

--- a/src/osemgrep/tests/Unit_CLI.ml
+++ b/src/osemgrep/tests/Unit_CLI.ml
@@ -1,0 +1,62 @@
+(* Expectation tests for CLI.with_experimental_flag (see issue #131). *)
+
+let t = Testo.create
+
+let check_argv msg ~expected (actual : string array) =
+  Alcotest.(check (array string)) msg expected actual
+
+(* coupling: these two cases used to be commented-out asserts in CLI.ml *)
+let test_scan_help () =
+  check_argv "opengrep scan --help"
+    ~expected:[| "opengrep"; "scan"; "--experimental"; "--help" |]
+    (CLI.with_experimental_flag [| "opengrep"; "scan"; "--help" |])
+
+let test_dash_c () =
+  check_argv "opengrep -c rules libs"
+    ~expected:[| "opengrep"; "--experimental"; "-c"; "rules"; "libs" |]
+    (CLI.with_experimental_flag [| "opengrep"; "-c"; "rules"; "libs" |])
+
+let test_bare_subcommand () =
+  (* the bug fixed by #802: a bare 'opengrep ci' used to scan a target
+     named "ci" instead of running the ci subcommand *)
+  check_argv "opengrep ci, no other args"
+    ~expected:[| "opengrep"; "ci"; "--experimental" |]
+    (CLI.with_experimental_flag [| "opengrep"; "ci" |])
+
+let test_unknown_first_arg () =
+  check_argv "first arg is not a known subcommand"
+    ~expected:[| "opengrep"; "--experimental"; "myproject" |]
+    (CLI.with_experimental_flag [| "opengrep"; "myproject" |])
+
+let test_multiple_flags () =
+  check_argv "multiple flags: inserted after the subcommand"
+    ~expected:[| "opengrep"; "scan"; "--experimental"; "--verbose"; "--json" |]
+    (CLI.with_experimental_flag [| "opengrep"; "scan"; "--verbose"; "--json" |])
+
+let test_flag_before_subcommand () =
+  check_argv "flag before the subcommand"
+    ~expected:[| "opengrep"; "--experimental"; "--json"; "scan" |]
+    (CLI.with_experimental_flag [| "opengrep"; "--json"; "scan" |])
+
+let test_flag_after_subcommand () =
+  check_argv "flag after the subcommand"
+    ~expected:[| "opengrep"; "scan"; "--experimental"; "--json" |]
+    (CLI.with_experimental_flag [| "opengrep"; "scan"; "--json" |])
+
+let test_argv0_only () =
+  check_argv "only argv[0], no subcommand"
+    ~expected:[| "opengrep"; "--experimental" |]
+    (CLI.with_experimental_flag [| "opengrep" |])
+
+let tests =
+  [
+    t "with_experimental_flag: opengrep scan --help" test_scan_help;
+    t "with_experimental_flag: opengrep -c rules libs" test_dash_c;
+    t "with_experimental_flag: bare subcommand" test_bare_subcommand;
+    t "with_experimental_flag: unknown first arg" test_unknown_first_arg;
+    t "with_experimental_flag: multiple flags" test_multiple_flags;
+    t "with_experimental_flag: flag before subcommand"
+      test_flag_before_subcommand;
+    t "with_experimental_flag: flag after subcommand" test_flag_after_subcommand;
+    t "with_experimental_flag: argv[0] only" test_argv0_only;
+  ]

--- a/src/osemgrep/tests/Unit_CLI.mli
+++ b/src/osemgrep/tests/Unit_CLI.mli
@@ -1,0 +1,1 @@
+val tests : Testo.t list

--- a/src/tests/Test.ml
+++ b/src/tests/Test.ml
@@ -149,6 +149,7 @@ let tests (caps : Cap.all_caps) =
       Unit_jsonnet.tests (caps :> < Cap.time_limit >);
       Unit_metachecking.tests (caps :> Core_scan.caps);
       (* osemgrep unit tests *)
+      Unit_CLI.tests;
       Unit_LS.tests (caps :> Session.caps);
       (* Unit_Login.tests caps; *)
       Unit_Fetching.tests (caps :> < Cap.network ; Cap.tmp >);


### PR DESCRIPTION
CLI.with_experimental_flag only had two commented-out asserts, with no real test coverage.

Adds expectation tests for the function, covering:

- opengrep scan --help
- opengrep -c rules libs
- a bare subcommand (see #802)
- an unrecognised first argument
- multiple flags
- a flag before the subcommand
- a flag after the subcommand
- argv[0] alone

Testing: `make build-core-test` and `./test -s with_experimental_flag`.

Fixes #131
