### PR TITLE
const-prop: stamp svalues on assignment RHS and array indices

### DIFF
--- a/src/analyzing/Constant_propagation.ml
+++ b/src/analyzing/Constant_propagation.ml
@@ -92,7 +92,10 @@ let is_private attr =
   | _ -> false
 
 (* TODO: incomplete, e.g. Record is not handled *)
-let rec lvars_in_lhs expr =
+(* [base] is set while peeling the receiver of a subscript/field store: a
+   Container there is a temporary literal (`[x][0] = v`), not a
+   destructuring target, and the variables inside it are not written. *)
+let rec lvars_in_lhs ?(base = false) expr =
   match expr.e with
   | N (Id (id, { id_resolved = { contents = Some (_kind, sid) }; _ }))
   | DotAccess
@@ -100,7 +103,16 @@ let rec lvars_in_lhs expr =
         _,
         FN (Id (id, { id_resolved = { contents = Some (_kind, sid) }; _ })) ) ->
       [ (id, sid) ]
-  | Container ((Tuple | Array), (_, es, _)) -> List.concat_map lvars_in_lhs es
+  | Container ((Tuple | Array), (_, es, _)) when not base ->
+      List.concat_map lvars_in_lhs es
+  (* A store through a subscript or a field (`a[i] = v`, `a.f = v`,
+     `a[i].f = v`) mutates the container/object held by the base variable,
+     so it must count as a write to it: otherwise `a = {}; a[k] = v` leaves
+     `a` "assigned just once" and its stale initial value gets propagated
+     into later reads of `a`. *)
+  | ArrayAccess (e, _)
+  | DotAccess (e, _, _) ->
+      lvars_in_lhs ~base:true e
   | __else__ -> []
 
 class ['self] no_cycles_in_sym_prop_visitor =
@@ -600,7 +612,11 @@ class ['self] propagate_basic_visitor lang stats =
                   && no_cycles_in_sym_prop sid rexp
                 then add_constant_env id (sid, Sym rexp) env;
                 ());
-          super#visit_expr (env, ctx) rexp
+          (* Let Iter_with_context's Assign branch dispatch the children: it
+             sends [rexp] back through [self#visit_expr], so an RHS that is
+             exactly an Id (q = SOME_CONST) gets its svalue stamped, like the
+             same id in argument position would. *)
+          super#visit_expr (env, ctx) x
       | __else__ -> super#visit_expr (env, ctx) x
   end
 

--- a/src/analyzing/Iter_with_context.ml
+++ b/src/analyzing/Iter_with_context.ml
@@ -33,6 +33,14 @@ let initial_context =
 (* In principle you should just override the 'visit_xyz' methods and call
  * 'super#visit_xyz' to recurse, so you could mostly ignore the
  * 'with_context_visit_xyz' methods.
+ *
+ * Note that 'with_context_visit_expr' is only a fallback: ArrayAccess,
+ * Assign and AssignOp nodes dispatch their children through
+ * 'self#visit_expr' directly and never reach 'with_context_visit_expr'
+ * themselves. Their children still do (via the '__else__' arm), so an
+ * override of 'with_context_visit_expr' observes every expression except
+ * those three node kinds. This differs from 'with_context_visit_definition',
+ * which is applied to every definition, including ClassDef and FuncDef.
  *)
 class virtual ['self] iter_with_context =
   object (self : 'self)
@@ -72,12 +80,19 @@ class virtual ['self] iter_with_context =
 
     method! visit_expr (env, ctx) x =
       match x.e with
+      (* The sub-expressions are dispatched through [self#visit_expr] so that
+         subclass overrides apply to them; [with_context_visit_expr] (= the
+         base traversal) is only for [x] itself, where re-dispatching would
+         loop. *)
       | ArrayAccess (e1, (_, e2, _)) ->
-          self#with_context_visit_expr (env, ctx) e1;
-          self#with_context_visit_expr (env, { ctx with in_lvalue = false }) e2
+          self#visit_expr (env, ctx) e1;
+          self#visit_expr (env, { ctx with in_lvalue = false }) e2
       | Assign (e1, _, e2)
       | AssignOp (e1, _, e2) ->
-          self#with_context_visit_expr (env, { ctx with in_lvalue = true }) e1;
-          self#with_context_visit_expr (env, ctx) e2
+          self#visit_expr (env, { ctx with in_lvalue = true }) e1;
+          (* reset in_lvalue: even when the assignment itself sits in lvalue
+             position (e.g. `*(p = q) = v`, `(x = obj).prop = v`), its RHS is
+             a pure read *)
+          self#visit_expr (env, { ctx with in_lvalue = false }) e2
       | __else__ -> self#with_context_visit_expr (env, ctx) x
   end

--- a/tests/rules/cp_array_index_const.py
+++ b/tests/rules/cp_array_index_const.py
@@ -1,0 +1,12 @@
+AUTH_HEADER = "authorization"
+CONTENT_TYPE = "content-type"
+
+
+def set_header(headers):
+    # ruleid: cp-array-index-const-write
+    headers[AUTH_HEADER] = "token"
+
+
+def get_header(headers):
+    # ruleid: cp-array-index-const-read
+    return headers[CONTENT_TYPE]

--- a/tests/rules/cp_array_index_const.yaml
+++ b/tests/rules/cp_array_index_const.yaml
@@ -1,0 +1,18 @@
+rules:
+# Constants used as array/subscript indices must get their svalue stamped
+# even when the ArrayAccess is in lvalue position. Pins the
+# `in_lvalue = false` reset on the index in Iter_with_context.
+- id: cp-array-index-const-write
+  patterns:
+    - pattern: $H["authorization"] = $V
+  message: constant index folded in subscript store
+  languages:
+    - python
+  severity: WARNING
+- id: cp-array-index-const-read
+  patterns:
+    - pattern: $H["content-type"]
+  message: constant index folded in subscript read
+  languages:
+    - python
+  severity: WARNING

--- a/tests/rules/cp_assign_rhs_const.py
+++ b/tests/rules/cp_assign_rhs_const.py
@@ -1,0 +1,20 @@
+SQL_QUERY = "SELECT COUNT(*) FROM users"
+SAFE_VALUE = "safe"
+
+
+def via_const():
+    # ruleid: cp-assign-rhs-const
+    query = SQL_QUERY
+    return query
+
+
+def suppressed_by_pattern_not():
+    # ok: cp-assign-rhs-not-safe
+    value = SAFE_VALUE
+    return value
+
+
+def reported_by_pattern_not():
+    # ruleid: cp-assign-rhs-not-safe
+    value = "unsafe"
+    return value

--- a/tests/rules/cp_assign_rhs_const.yaml
+++ b/tests/rules/cp_assign_rhs_const.yaml
@@ -1,0 +1,27 @@
+rules:
+# A constant propagated into a bare-Id assignment RHS (query = SQL_QUERY)
+# must get its svalue stamped at the assignment site, so literal patterns
+# fold against it. Pins the self-dispatch of the Assign RHS in
+# Constant_propagation.propagate_basic_visitor for a language with true
+# Assign statements (the Go test's `:=` lowers to AssignOp and does not
+# exercise that branch).
+- id: cp-assign-rhs-const
+  patterns:
+    - pattern: query = "$SQL"
+    - metavariable-regex:
+        metavariable: $SQL
+        regex: (?i)^SELECT\s
+  message: constant SQL query propagated into assignment RHS
+  languages:
+    - python
+  severity: WARNING
+# The same stamping also affects negative matching: a pattern-not literal
+# now folds against the propagated constant, suppressing the finding.
+- id: cp-assign-rhs-not-safe
+  patterns:
+    - pattern: value = $X
+    - pattern-not: value = "safe"
+  message: pattern-not folds against propagated constants
+  languages:
+    - python
+  severity: WARNING

--- a/tests/rules/cp_container_store_write.py
+++ b/tests/rules/cp_container_store_write.py
@@ -1,0 +1,20 @@
+STORED = "abc"
+STORED[0] = "x"
+
+PLAIN = "abc"
+
+# A store into a temporary literal does not write the variables inside it.
+TEMP = "abc"
+[TEMP][0] = "x"
+(TEMP,)[0] = "x"
+
+
+def use():
+    # A subscript store counts as a write to STORED, so it is no longer
+    # "assigned just once" and its initial value must not propagate.
+    # ok: cp-container-store-write
+    f(STORED)
+    # ruleid: cp-container-store-write
+    f(PLAIN)
+    # ruleid: cp-container-store-write
+    f(TEMP)

--- a/tests/rules/cp_container_store_write.yaml
+++ b/tests/rules/cp_container_store_write.yaml
@@ -1,0 +1,10 @@
+rules:
+# Pins that a store through a subscript (`a[k] = v`) is counted as a write
+# to `a` by the const-prop stats pass (lvars_in_lhs), so a variable whose
+# contents are mutated does not keep propagating its initial literal.
+- id: cp-container-store-write
+  pattern: f("abc")
+  message: mutated variable must not propagate its initial value
+  languages:
+    - python
+  severity: WARNING

--- a/tests/rules/cp_field_store_write.js
+++ b/tests/rules/cp_field_store_write.js
@@ -1,0 +1,31 @@
+subscripted = "abc";
+subscripted[0] = "x";
+
+fielded = "abc";
+fielded.len = 3;
+
+nested = "abc";
+nested.a[0].b = 1;
+
+plain = "abc";
+
+// A store into a temporary literal does not write the variables inside it.
+temp = "abc";
+[temp][0] = "x";
+[temp].length = 0;
+
+function use() {
+  // A subscript store counts as a write to `subscripted`.
+  // ok: cp-container-store-write
+  f(subscripted);
+  // A field store counts as a write to `fielded`.
+  // ok: cp-container-store-write
+  f(fielded);
+  // Mixed field/subscript chains are peeled down to the base variable.
+  // ok: cp-container-store-write
+  f(nested);
+  // ruleid: cp-container-store-write
+  f(plain);
+  // ruleid: cp-container-store-write
+  f(temp);
+}

--- a/tests/rules/cp_field_store_write.yaml
+++ b/tests/rules/cp_field_store_write.yaml
@@ -1,0 +1,11 @@
+rules:
+# Pins that stores through a field (`a.f = v`) or a subscript (`a[i] = v`),
+# possibly chained, are counted as writes to `a` by the const-prop stats
+# pass (lvars_in_lhs), so a variable whose contents are mutated does not
+# keep propagating its initial literal.
+- id: cp-container-store-write
+  pattern: f("abc")
+  message: mutated variable must not propagate its initial value
+  languages:
+    - js
+  severity: WARNING

--- a/tests/rules/cp_nested_assign.js
+++ b/tests/rules/cp_nested_assign.js
@@ -1,0 +1,32 @@
+function f(x) {
+  return x;
+}
+
+// A nested assignment registers the write: the global `a` is assigned
+// exactly once, so "v" propagates into its uses in other functions.
+b = (a = "v");
+
+function usesA() {
+  // ruleid: cp-nested-assign-global
+  f(a);
+}
+
+// The nested reassignment of `q` also counts as a write, so `q` is no
+// longer "assigned just once" and "w" must NOT propagate.
+q = "w";
+
+function usesQ() {
+  // ok: cp-nested-assign-reassigned
+  f(q);
+}
+
+r = (q = null);
+
+// An assignment in lvalue position still has a purely-read RHS: V_CONST
+// must get its svalue stamped so the pattern literal folds.
+V_CONST = "v";
+
+function leak() {
+  // ruleid: cp-lvalue-rhs-read
+  (y = V_CONST).p = 1;
+}

--- a/tests/rules/cp_nested_assign.yaml
+++ b/tests/rules/cp_nested_assign.yaml
@@ -1,0 +1,28 @@
+rules:
+# Pins the nested-assignment write accounting introduced by dispatching
+# Assign/AssignOp children through self#visit_expr in Iter_with_context:
+# nested assigns now increment the lvalue count, flipping
+# is_assigned_just_once in both directions.
+- id: cp-nested-assign-global
+  patterns:
+    - pattern: f("v")
+  message: global assigned once via nested assignment propagates
+  languages:
+    - js
+  severity: WARNING
+- id: cp-nested-assign-reassigned
+  patterns:
+    - pattern: f("w")
+  message: nested reassignment defeats assigned-just-once propagation
+  languages:
+    - js
+  severity: WARNING
+# Pins the in_lvalue reset on the RHS of an assignment that itself sits in
+# lvalue position, e.g. (y = V_CONST).p = 1.
+- id: cp-lvalue-rhs-read
+  patterns:
+    - pattern: ($Y = "v").p = $B
+  message: RHS of assignment in lvalue position is a pure read
+  languages:
+    - js
+  severity: WARNING

--- a/tests/rules/cp_string_metavar_const.go
+++ b/tests/rules/cp_string_metavar_const.go
@@ -1,0 +1,19 @@
+package main
+
+import "strings"
+
+const sqlQueryGetCount = `SELECT COUNT(*) FROM #TABLE_NAME# #WHERE_CLAUSE#`
+
+func direct(label string) string {
+	// ruleid: cp-string-metavar-const
+	sqlQuery := `SELECT COUNT(*) FROM #TABLE_NAME# #WHERE_CLAUSE#`
+	sqlQuery = strings.Replace(sqlQuery, "#TABLE_NAME#", label, 1)
+	return sqlQuery
+}
+
+func viaConst(label string) string {
+	// ruleid: cp-string-metavar-const
+	sqlQuery := sqlQueryGetCount
+	sqlQuery = strings.Replace(sqlQuery, "#TABLE_NAME#", label, 1)
+	return sqlQuery
+}

--- a/tests/rules/cp_string_metavar_const.yaml
+++ b/tests/rules/cp_string_metavar_const.yaml
@@ -1,0 +1,14 @@
+rules:
+- id: cp-string-metavar-const
+  patterns:
+    - pattern: |
+        $STRING = "$SQL"
+        ...
+        strings.Replace($STRING, $_, $EXPR, ...)
+    - metavariable-regex:
+        metavariable: $SQL
+        regex: (?i)^(?![\s\S]*\?)\s*(SELECT|DELETE|INSERT|UPDATE|CALL|REPLACE)\s.*
+  message: SQL query string rewritten with strings.Replace
+  languages:
+    - go
+  severity: WARNING


### PR DESCRIPTION
## Summary

`Iter_with_context` dispatched the children of `Assign`, `AssignOp` and
`ArrayAccess` through the base traversal, bypassing subclass `visit_expr`
overrides on the child nodes themselves. As a result the basic constant
propagation pass never stamped an svalue on:

- an RHS that is exactly an identifier — `x = SOME_CONST`, Go `x := SOME_CONST`
  (`:=` lowers to `AssignOp(Eq)`);
- a constant index of a subscript in lvalue position — `h[KEY] = v`;
- the RHS of an assignment that itself sits in lvalue position —
  `(x = obj).prop = v`.

It also meant a nested assignment (`b = (a = "v")`) was never counted as a
write to `a`, so `a` was never treated as assigned-once, while a later
`r = (q = null)` did not defeat `q`'s assigned-once status (a false match
on `main`).

## Changes

- **`Iter_with_context`**: dispatch those children through `self#visit_expr`
  so overrides apply to them; treat the RHS of an assignment as a read
  (`in_lvalue = false`) even when the assignment is in lvalue position;
  document that `ArrayAccess`/`Assign`/`AssignOp` nodes never reach
  `with_context_visit_expr`.
- **`Constant_propagation`**: the hidden-VarDef `Assign` branch recurses via
  `super#visit_expr` on the whole node, so child traversal is encoded in one
  place.

## Behaviour change

Literal patterns now fold against constants in the positions above, e.g.
`$STRING = "$SQL"` matches `sqlQuery := sqlQueryGetCount`, and
`query = SQL_QUERY; return query` folds through the dataflow pass to
`return "SELECT …"`. This applies to `pattern-not` as well, so a finding can
now be suppressed by a propagated constant (`cp_assign_rhs_const` pins this).

## Tests

- `cp_string_metavar_const` (Go): bare-Id RHS via `:=`
- `cp_assign_rhs_const` (Python): bare-Id RHS on true `Assign`; `pattern-not` folding
- `cp_array_index_const` (Python): constant index in subscript read and write
- `cp_nested_assign` (JS): nested-assignment write accounting in both
  directions; RHS reset for an assignment in lvalue position

All four fail on `main` with the expected false negatives/positive and pass
here. Full `./test` run: no new failures.