### PR TITLE
taint: fix propagators when the 'to' precedes the 'from'

### DIFF
--- a/src/engine/Pro_hooks.ml
+++ b/src/engine/Pro_hooks.ml
@@ -52,7 +52,6 @@ let pro_hooks_refs =
     Pro_hook_ref Dataflow_svalue.hook_constness_of_function;
     Pro_hook_ref Dataflow_svalue.hook_transfer_of_assume;
     Pro_hook_ref Match_tainting_mode.hook_setup_hook_function_taint_signature;
-    Pro_hook_ref Taint_lval_env.hook_propagate_to;
     Pro_hook_ref Dataflow_tainting.hook_find_attribute_in_class;
     Pro_hook_ref Dataflow_tainting.hook_check_tainted_at_exit_sinks;
     Pro_hook_ref Dataflow_when.hook_annotate_facts;

--- a/src/tainting/Taint_lval_env.ml
+++ b/src/tainting/Taint_lval_env.ml
@@ -79,25 +79,6 @@ type t = {
 
 type env = t
 
-type prop_fn =
-  taints_to_propagate:taints_to_propagate ->
-  pending_propagation_dests:pending_propagation_dests ->
-  env
-
-type add_fn = IL.lval -> T.taints -> env -> env
-
-let hook_propagate_to :
-    (Var_env.var ->
-    T.taints ->
-    taints_to_propagate:taints_to_propagate ->
-    pending_propagation_dests:pending_propagation_dests ->
-    prop:prop_fn ->
-    add:add_fn ->
-    t)
-    option
-    ref =
-  ref None
-
 let empty =
   {
     tainted = NameMap.empty;
@@ -275,14 +256,22 @@ let propagate_to lang prop_var taints env =
         taints_to_propagate = VarMap.add prop_var taints env.taints_to_propagate;
       }
     in
-    match !hook_propagate_to with
+    (* If the 'to' was visited before this 'from' (e.g. 'to' is the first
+     * argument of a call, as in strcpy($DST, $SRC)), it was queued as a
+     * pending destination. Flush it now by side-effect: subsequent uses
+     * of the destination l-value see the propagated taints. *)
+    match VarMap.find_opt prop_var env.pending_propagation_dests with
+    | Some lval ->
+        let env =
+          {
+            env with
+            taints_to_propagate = VarMap.remove prop_var env.taints_to_propagate;
+            pending_propagation_dests =
+              VarMap.remove prop_var env.pending_propagation_dests;
+          }
+        in
+        add_lval lang lval taints env
     | None -> env
-    | Some hook ->
-        hook prop_var taints ~taints_to_propagate:env.taints_to_propagate
-          ~pending_propagation_dests:env.pending_propagation_dests
-          ~prop:(fun ~taints_to_propagate ~pending_propagation_dests ->
-            { env with taints_to_propagate; pending_propagation_dests })
-          ~add:(add_lval lang)
 
 let find_var { tainted; _ } var = NameMap.find_opt var tainted
 

--- a/src/tainting/Taint_lval_env.mli
+++ b/src/tainting/Taint_lval_env.mli
@@ -21,27 +21,6 @@ open Shape_and_sig.Shape
 
 type t
 type env = t
-type taints_to_propagate = Taint.taints Dataflow_var_env.VarMap.t
-type pending_propagation_dests = IL.lval Dataflow_var_env.VarMap.t
-
-type prop_fn =
-  taints_to_propagate:taints_to_propagate ->
-  pending_propagation_dests:pending_propagation_dests ->
-  env
-
-type add_fn = IL.lval -> Taint.taints -> env -> env
-
-val hook_propagate_to :
-  (Dataflow_var_env.var ->
-  Taint.taints ->
-  taints_to_propagate:taints_to_propagate ->
-  pending_propagation_dests:pending_propagation_dests ->
-  prop:prop_fn ->
-  add:add_fn ->
-  t)
-  option
-  ref
-(** Pro hook, this is a bit complicated to avoid exposing `t`s internals. *)
 
 val empty : env
 val empty_inout : env Dataflow_core.inout
@@ -62,8 +41,7 @@ val add_lval_shape : Lang.t -> IL.lval -> Taint.taints -> shape -> env -> env
 val add : IL.name -> Taint.offset list -> Taint.taints -> env -> env
 
 val add_lval : Lang.t -> IL.lval -> Taint.taints -> env -> env
-(** Assign a set of taints (but no specific shape) to an l-value.
-    [add_lval lang] is an [add_fn]. *)
+(** Assign a set of taints (but no specific shape) to an l-value. *)
 
 (* THINK: Perhaps keep propagators outside of this environment? *)
 val propagate_to : Lang.t -> Dataflow_var_env.var -> Taint.taints -> env -> env

--- a/tests/taint_maturity/c/taint_propagator.c
+++ b/tests/taint_maturity/c/taint_propagator.c
@@ -1,0 +1,28 @@
+/* 'to' precedes 'from' in the call: needs the pending-propagation flush */
+void test_to_before_from()
+{
+  char *str = "tainted";
+  char buff[256];
+  strcpy(buff, str);
+  /* ruleid: taint-propagator */
+  sink(buff);
+}
+
+/* 'from' precedes 'to' in the call */
+void test_from_before_to()
+{
+  char *str = "tainted";
+  char buff[256];
+  copy_into(str, buff);
+  /* ruleid: taint-propagator */
+  sink(buff);
+}
+
+void test_no_taint()
+{
+  char *str = "safe";
+  char buff[256];
+  strcpy(buff, str);
+  /* ok: taint-propagator */
+  sink(buff);
+}

--- a/tests/taint_maturity/c/taint_propagator.yaml
+++ b/tests/taint_maturity/c/taint_propagator.yaml
@@ -1,0 +1,21 @@
+rules:
+  - id: taint-propagator
+    mode: taint
+    languages:
+      - c
+    message: |
+      Propagators must work regardless of the order in which the 'from' and
+      'to' arguments occur in the call.
+    pattern-sources:
+      - pattern: |
+          "tainted"
+    pattern-propagators:
+      - pattern: strcpy($DST, $SRC)
+        from: $SRC
+        to: $DST
+      - pattern: copy_into($SRC, $DST)
+        from: $SRC
+        to: $DST
+    pattern-sinks:
+      - pattern: sink(...)
+    severity: ERROR


### PR DESCRIPTION
Within one instruction, propagator endpoints are processed in visit order. When the 'to' l-value is visited first (e.g. strcpy($DST, $SRC), where $DST is the first argument), it is queued as a pending propagation destination, but the flush of that queue lived only behind hook_propagate_to, a pro-engine hook that is never installed, so the taints were recorded and never delivered.

Flush the pending destination directly when the hook is absent: the taints are added to the destination l-value by side-effect, so subsequent uses of it are tainted.

