### PR TITLE
ci: unset GITHUB_ACTIONS for each ci e2e test

### DIFF
--- a/src/osemgrep/cli_ci/Test_ci_subcommand.ml
+++ b/src/osemgrep/cli_ci/Test_ci_subcommand.ml
@@ -1,6 +1,11 @@
 (* SPDX-License-Identifier: LGPL-2.1-only *)
 
-let t = Testo.create
+(* the tests may run on a CI runner whose own environment names a provider
+ * (GITHUB_ACTIONS on the macOS job); every test starts from none, an empty
+ * value counting as unset *)
+let t name ?checked_output ?normalize (func : unit -> unit) =
+  Testo.create name ?checked_output ?normalize (fun () ->
+      Semgrep_envvars.with_envvar "GITHUB_ACTIONS" "" func)
 
 module F = Testutil_files
 


### PR DESCRIPTION
The macOS job runs the tests on the runner itself, where `GITHUB_ACTIONS` is set, so every ci e2e test was detected as a GitHub Actions scan and 18 snapshot tests failed on `build-test-osx`. Each ci test now starts with `GITHUB_ACTIONS` unset; the test that wants GitHub Actions sets it itself.