### PR TITLE
Read and write CLI text files as UTF-8

### DIFF
--- a/cli/src/semgrep/config_resolver.py
+++ b/cli/src/semgrep/config_resolver.py
@@ -229,7 +229,7 @@ def read_config_at_path(loc: Path, base_path: Optional[Path] = None) -> ConfigFi
     if base_path:
         config_id = str(loc).replace(str(base_path), "")
 
-    return ConfigFile(config_id, loc.read_text(), str(loc))
+    return ConfigFile(config_id, loc.read_text(encoding="utf-8"), str(loc))
 
 
 def read_config_folder(loc: Path, relative: bool = False) -> List[ConfigFile]:
@@ -626,7 +626,7 @@ def parse_config_string(
     rules_tmp_path: Optional[str] = None
     try:
         fd, rules_tmp_path = mkstemp(suffix=".rules", prefix="semgrep-", text=True)
-        with os.fdopen(fd, "w") as fp:
+        with os.fdopen(fd, "w", encoding="utf-8") as fp:
             fp.write(contents)
         logger.debug(f"Saving rules to {rules_tmp_path}")
     except Exception as e:

--- a/cli/src/semgrep/meta.py
+++ b/cli/src/semgrep/meta.py
@@ -271,7 +271,7 @@ class GithubMeta(GitMeta):
     def event(self) -> Dict[str, Any]:
         value = os.getenv("GITHUB_EVENT_PATH")
         if value:
-            return json.loads(Path(value).read_text())  # type: ignore
+            return json.loads(Path(value).read_text(encoding="utf-8"))  # type: ignore
         return {}
 
     @property

--- a/cli/src/semgrep/test.py
+++ b/cli/src/semgrep/test.py
@@ -185,7 +185,7 @@ def get_expected_and_reported_lines(
 
     for test_file in test_files:
         test_file_resolved = str(test_file.resolve())
-        all_lines = test_file.read_text().split("\n")
+        all_lines = test_file.read_text(encoding="utf-8").split("\n")
         for i, line in enumerate(all_lines):
             # +1 because we are 0 based and semgrep output is not, plus skip the comment line
             effective_line_num = i + 2


### PR DESCRIPTION
## What

Adds an explicit `encoding="utf-8"` to the four remaining locale-dependent text operations in `cli/src/semgrep`.

## Why

`read_config_at_path` reads rule configuration with `pathlib.read_text()` and no encoding, so the codec is whatever the process locale resolves to. Under a `C`/`POSIX` locale that is ASCII, and a rule file containing any non-ASCII byte aborts the scan before a single rule runs:

```
File "semgrep/config_resolver.py", line 412, in read_config_at_path
File "pathlib/_local.py", line 546, in read_text
File "encodings/ascii.py", line 26, in decode
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 208519: ordinal not in range(128)
```

This is not exotic — non-ASCII shows up readily in rule `message:` fields (typographic quotes, arrows, accented author names). It reproduced consistently for us on opengrep v1.16.4 invoked through the Codacy CLI from a shell with `LANG` unset, which is the default in many hook, cron and container environments. The scan fails with an unreadable/empty SARIF report rather than a real finding, so it surfaces as a confusing tooling error rather than a locale problem.

#611 already moved the CLI to explicit UTF-8 for `wrapper.py`, `git.py`, `output.py` and `rpc.py`. This applies that same established convention to the sites it did not cover.

## Changes

| Site | Effect today |
|---|---|
| `config_resolver.read_config_at_path` | the crash above |
| `config_resolver.parse_config_string` | `os.fdopen(fd, "w")` raises `UnicodeEncodeError` on non-ASCII rules, silently swallowed by the surrounding `except Exception`, so the debug `.rules` temp file is never written |
| `test.get_expected_and_reported_lines` | annotated test files with non-ASCII content fail to read |
| `meta.GithubMeta.event` | `GITHUB_EVENT_PATH` payloads with non-ASCII fail to parse |

After this change no `read_text()` call in `cli/src/semgrep` depends on the ambient locale.

## Reproducing

```bash
printf 'rules:\n  - id: x\n    message: "caf\xc3\xa9 \xe2\x80\x94 test"\n    languages: [python]\n    severity: INFO\n    pattern: $X == $X\n' > /tmp/r.yaml
LC_ALL=C PYTHONCOERCECLOCALE=0 opengrep scan --config /tmp/r.yaml /tmp
```

## A note for reviewers on tests

I did not add a test, and I would rather say why than ship a misleading one. Forcing the failure inside pytest is not portable: monkeypatching `locale.getencoding` does not affect `open()` because CPython consults the C-level locale, and a subprocess test with `LC_ALL=C` is unreliable in CI because PEP 538 coercion promotes `C` to `C.UTF-8` on most Linux images — which is exactly why this stays latent until someone hits an environment where coercion is disabled. Happy to add a test in whatever shape you prefer, including an `xfail`-guarded subprocess test gated on `locale.getpreferredencoding()`, if you would like one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
