### PR TITLE
PHP: `from` is not a keyword

### DIFF
--- a/languages/php/ast/cst_php.ml
+++ b/languages/php/ast/cst_php.ml
@@ -294,6 +294,7 @@ and expr =
    *)
   (* the operand is absent in a bare 'yield;' *)
   | Yield of tok * array_pair option (* should have no ref inside *)
+  | YieldFrom of tok * tok (* from *) * expr
   | YieldBreak of tok * tok
   (* php-facebook-ext: Just like yield, this should be at the statement level *)
   | Await of tok * expr

--- a/languages/php/ast/cst_php.ml
+++ b/languages/php/ast/cst_php.ml
@@ -16,54 +16,6 @@
 open Common
 
 (*****************************************************************************)
-(* Prelude *)
-(*****************************************************************************)
-(* Concrete Syntax Tree (CST) for PHP.
- *
- * Currently, the CST supports mostly PHP 5.2 with
- * a few extensions from PHP 5.3 (e.g. closures, namespace, const) and
- * PHP 5.4 (e.g. traits) as well as support for many Facebook
- * extensions (XHP, generators, annotations, generics, collections,
- * type definitions, implicit fields via constructor parameters).
- *
- * Update: I removed many facebook extensions to simplify (e.g., XHP).
- * Moreover, this CST is mostly used for semgrep now, so we may
- * gradually transform it into ast_php.ml to avoid an extra intermediate
- * when converting from PHP to the generic AST.
- * For example, use Foo\Bar\{A, B} is not represented faithfully anymore
- * in this CST, and it's unsugared in use Foo\Bar\A and use Foo\Bar\B
- * (like in ast_php.ml).
- * The main requirement for this hybrid CST/AST
- * is to get the range of an expr/stmt/... correct so you must keep
- * the first and last token of an expr/stmt/... in the AST.
- *
- *
- * A CST is convenient in a refactoring context or code visualization
- * context, but if you need to do some heavy static analysis, consider
- * instead lang_php/analyze/foundation/pil.ml which defines a
- * PHP Intermediate Language a la CIL.
- *
- * todo:
- *  - unify toplevel statement vs statements? hmmm maybe not
- *  - maybe even in a refactoring context a PIL+comment
- *    (see pretty/ast_pp.ml) would make more sense.
- *
- * NOTE: data from this type are often marshalled in berkeley DB tables
- * which means that if you add a new constructor or field in the types below,
- * you must erase the berkeley DB databases otherwise pfff
- * will probably ends with a segfault (OCaml serialization is not
- * type-safe). A hacky solution is to add new constructors only at the end
- * of a type definition.
- *
- * COUPLING: some programs in other languages (e.g. Python) may
- * use some of the pfff binding, or json/sexp exporters, so if you
- * change the name of constructors in this file, don't forget
- * to regenerate the json/sexp exporters, but also to modify the
- * dependent programs !!!! An easier solution is to not change this
- * file, or to only add new constructors.
- *)
-
-(*****************************************************************************)
 (* Token (leaf) *)
 (*****************************************************************************)
 

--- a/languages/php/menhir/ast_php_build.ml
+++ b/languages/php/menhir/ast_php_build.ml
@@ -561,6 +561,10 @@ and expr env = function
       A.Call
         ( A.Id [ (A.builtin "yield", wrap tok) ],
           fb tok [ A.Arg (array_pair env e) ] )
+  | YieldFrom (tok, tok2, e) ->
+      A.Call
+        ( A.Id [ (A.builtin "yield_from", wrap tok) ],
+          fb tok2 [ A.Arg (expr env e) ] )
   (* todo? merge in one yield_break? *)
   | YieldBreak (tok, tok2) ->
       A.Call

--- a/languages/php/menhir/lexer_php.mll
+++ b/languages/php/menhir/lexer_php.mll
@@ -199,7 +199,6 @@ let keyword_table = Hashtbl_.hash_of_list [
 
   (* recent PHP extensions (some were php-facebook-ext: before) *)
   "yield", (fun ii -> T_YIELD ii);
-  "from", (fun ii -> T_FROM ii);
 
   (* old: "__halt_compiler", (fun ii -> T_HALT_COMPILER ii); *)
 
@@ -363,8 +362,13 @@ let WHITESPACEOPT = [' ' '\n' '\r' '\t']*
 (* PHP identifiers are byte-based: any byte in 0x80-0xff is a valid identifier
  * character, which is how PHP supports non-ASCII (e.g. UTF-8) identifiers.
  * This mirrors the LABEL definition in Zend's zend_language_scanner.l. *)
-let LABEL =	['a'-'z''A'-'Z''_''\128'-'\255']['a'-'z''A'-'Z''0'-'9''_''\128'-'\255']*
+let LABEL_CHAR = ['a'-'z''A'-'Z''0'-'9''_''\128'-'\255']
+let LABEL =	['a'-'z''A'-'Z''_''\128'-'\255'] LABEL_CHAR*
 let BOOL = (['T''t']['R''r']['U''u']['E''e']) | (['F''f']['A''a']['L''l']['S''s']['E''e'])
+(* case-insensitive like every keyword, but needed as regexps because
+ * 'yield from' is recognised in a single match *)
+let YIELD = ['Y''y']['I''i']['E''e']['L''l']['D''d']
+let FROM = ['F''f']['R''r']['O''o']['M''m']
 (* the '_' of a numeric literal separator only ever sits between two digits,
  * as in '1_000' or '0x1_C'; leading, trailing and doubled ones are not
  * numbers. coupling: LNUM..ONUM in Zend's zend_language_scanner.l
@@ -639,6 +643,35 @@ rule st_in_scripting state = parse
      * but this is also ugly.
      *)
     | "async" { T_ASYNC (tokinfo lexbuf) }
+
+    (* 'from' is a reserved word only right after 'yield', so it is read here
+     * rather than in keyword_table. Zend has a single T_YIELD_FROM token for
+     * the pair; the grammar here wants two, and the trailing label characters
+     * are part of the match so that the 'from' of 'yield fromage' stays an
+     * identifier.
+     * coupling: the "yield"{WHITESPACE}"from" rule in Zend's
+     * zend_language_scanner.l
+     *)
+    | (YIELD as kwd) (WHITESPACE as white) ((FROM LABEL_CHAR*) as label) {
+        let info = tokinfo lexbuf in
+        let kwdinfo = Tok.rewrap_str kwd info in
+
+        let file = Tok.file_of_tok info in
+        let parse_info = Tok.unsafe_loc_of_tok info in
+        let pos_after_kwd = parse_info.Tok.pos.bytepos + String.length kwd in
+        let pos_after_white = pos_after_kwd + String.length white in
+
+        let whiteinfo = tokinfo_file_str_pos file white pos_after_kwd in
+        let lblinfo = tokinfo_file_str_pos file label pos_after_white in
+
+        push_token state
+          (if String.equal (String.lowercase_ascii label) "from"
+           then T_FROM lblinfo
+           else T_IDENT (case_str label, lblinfo));
+        push_token state (TSpaces whiteinfo);
+
+        T_YIELD kwdinfo
+      }
 
     | LABEL
         { let info = tokinfo lexbuf in

--- a/languages/php/menhir/parser_php.mly
+++ b/languages/php/menhir/parser_php.mly
@@ -1220,12 +1220,11 @@ expr:
  (* php-facebook-ext: in hphp.y yield are at the statement level
   * and are restricted to a few forms.
   * TODO: can't use expr_or_dots here
-  * TODO: keep T_FROM in AST
   *)
  | T_YIELD                   { Yield ($1, None) }
  | T_YIELD expr              { Yield ($1, Some (ArrayExpr $2)) }
  | T_YIELD expr "=>" expr { Yield ($1, Some (ArrayArrowExpr ($2, $3, $4))) }
- | T_YIELD T_FROM expr              { Yield ($1, Some (ArrayExpr $3)) }
+ | T_YIELD T_FROM expr       { YieldFrom ($1, $2, $3) }
  | T_YIELD T_BREAK { YieldBreak ($1, $2) }
  (* php-facebook-ext: Just like yield, await is at the statement level *)
  | T_AWAIT expr { Await ($1, $2) }

--- a/languages/php/tree-sitter/Parse_php_tree_sitter.ml
+++ b/languages/php/tree-sitter/Parse_php_tree_sitter.ml
@@ -1312,21 +1312,16 @@ and map_expression (env : env) (x : CST.expression) : A.expr =
       let v4 = map_expression env v4 in
       let v4 = map_ref_expr env v3 v4 in
       A.Assign (v1, v2, v4)
-  | `Yield_exp (v1, v2) ->
+  | `Yield_exp (v1, v2) -> (
       let v1 = (* "yield" *) _str env v1 in
-      let v2 =
-        match v2 with
-        | Some x -> (
-            match x with
-            | `Array_elem_init x -> [ map_array_element_initializer env x ]
-            | `From_exp (v1, v2) ->
-                let v1 = (* "from" *) token env v1 in
-                (* TODO handle `yield from` *)
-                let v2 = map_expression env v2 in
-                [ v2 ])
-        | None -> []
-      in
-      fake_call_to_builtin env v1 v2
+      match v2 with
+      | Some (`From_exp (v2, v3)) ->
+          let v2 = (* "from" *) token env v2 in
+          let v3 = map_expression env v3 in
+          fake_call_to_builtin env ("yield_from", v2) [ v3 ]
+      | Some (`Array_elem_init x) ->
+          fake_call_to_builtin env v1 [ map_array_element_initializer env x ]
+      | None -> fake_call_to_builtin env v1 [])
   | `Un_exp x -> map_unary_expression env x
   | `Bin_exp x -> map_binary_expression env x
   | `Incl_exp (v1, v2) ->

--- a/languages/php/tree-sitter/Parse_php_tree_sitter.ml
+++ b/languages/php/tree-sitter/Parse_php_tree_sitter.ml
@@ -1318,7 +1318,9 @@ and map_expression (env : env) (x : CST.expression) : A.expr =
       | Some (`From_exp (v2, v3)) ->
           let v2 = (* "from" *) token env v2 in
           let v3 = map_expression env v3 in
-          fake_call_to_builtin env ("yield_from", v2) [ v3 ]
+          A.Call
+            ( A.Id [ (A.builtin "yield_from", snd v1) ],
+              Tok.fake_bracket v2 [ A.Arg v3 ] )
       | Some (`Array_elem_init x) ->
           fake_call_to_builtin env v1 [ map_array_element_initializer env x ]
       | None -> fake_call_to_builtin env v1 [])

--- a/tests/parsing/php/php_from_identifier.php
+++ b/tests/parsing/php/php_from_identifier.php
@@ -1,0 +1,41 @@
+<?php
+
+// 'from' is only a keyword directly after 'yield'; everywhere else it is an
+// ordinary identifier.
+
+function from()
+{
+    return 1;
+}
+
+class C
+{
+    const from = 1;
+
+    public static $from = 2;
+
+    public function from()
+    {
+        return self::from;
+    }
+}
+
+$a = from();
+$b = (new C())->from();
+$c = C::from();
+$d = C::from;
+$e = ["from" => from];
+
+function g($gen)
+{
+    yield from $gen;
+    yield from from();
+    yield FROM [1, 2];
+
+    yield
+      from $gen;
+
+    // an identifier that merely starts with 'from'
+    yield fromage;
+    $f = fromage;
+}

--- a/tests/patterns/php/php70_yield_from.php
+++ b/tests/patterns/php/php70_yield_from.php
@@ -1,0 +1,20 @@
+<?php
+
+function g($gen)
+{
+    //ERROR:
+    yield from $gen;
+
+    //ERROR:
+    yield
+      from $gen;
+
+    //ERROR: as in PHP, 'from' is the keyword whatever follows it
+    yield from($gen);
+
+    // OK: delegating to a generator is not the same as yielding it
+    yield $gen;
+
+    // OK: 'from' outside a yield is an ordinary function
+    $x = from($gen);
+}

--- a/tests/patterns/php/php70_yield_from.sgrep
+++ b/tests/patterns/php/php70_yield_from.sgrep
@@ -1,0 +1,1 @@
+yield from $X


### PR DESCRIPTION
Zend test corpus coverage: 95.73% → 95.95%

## Before

The lexer treated `from` as a keyword.

## However...

In reality, `from` has a special meaning only if it directly follows the `yield` keyword. In all other contexts, `from` is a perfectly normal identifier.

## After the fix

The lexer treats `yield` + whitespace + `from` as a separate token, while otherwise `from` is not special. Incidentally, this is exactly how the PHP compiler works.