### PR TITLE
PHP: Trailing comma in attribute arguments

### DIFF
--- a/languages/php/menhir/parser_php.mly
+++ b/languages/php/menhir/parser_php.mly
@@ -1087,7 +1087,7 @@ return_type:
 (*************************************************************************)
 (* PHP 8 extension (was using << >> in HPHP) *)
 attributes:
-| "#[" listc(attribute) "]" { ($1, $2, $3) }
+| "#[" attribute_list "]" { ($1, $2, $3) }
 | attributes attributes {match ($1, $2) with ((lp,xs1,_),(_,xs2,rp)) -> (lp,xs1@xs2,rp)}
 
 attribute:
@@ -1858,10 +1858,15 @@ class_name_no_array: qualified_class_name type_arguments { Hint ($1, $2) }
 (* xxx_list, xxx_opt *)
 (*************************************************************************)
 
+(* both lists accept a trailing comma, as every other PHP argument list does *)
+attribute_list:
+ | listc(attribute)     { $1 }
+ | listc(attribute) "," { $1 @ [Right $2] }
+
 attribute_argument_list:
- | (*empty*) { [] }
- | attribute_argument { [Left $1] }
- | attribute_argument_list "," attribute_argument { $1@[Right $2; Left $3]}
+ | (*empty*)                     { [] }
+ | listc(attribute_argument)     { $1 }
+ | listc(attribute_argument) "," { $1 @ [Right $2] }
 
 (* less: should we allow the "..." only for the end? *)
 non_empty_type_php_or_dots_list:

--- a/tests/parsing/php/php8_attribute_trailing_comma.php
+++ b/tests/parsing/php/php8_attribute_trailing_comma.php
@@ -1,0 +1,23 @@
+<?php
+
+// a trailing comma is allowed in the attribute list and in an attribute's
+// arguments, as it is in every other PHP argument list
+
+#[A("many", "arguments",)]
+class C
+{
+    #[B(x: 1, y: 2,)]
+    public int $p = 1;
+
+    #[C(1,)]
+    public function m(#[D(2,)] int $a) {}
+}
+
+#[E, F,]
+function f() {}
+
+#[G,]
+function g() {}
+
+#[H(),]
+function h() {}

--- a/tests/patterns/php/php8_attribute_trailing_comma.php
+++ b/tests/patterns/php/php8_attribute_trailing_comma.php
@@ -1,0 +1,16 @@
+<?php
+
+// the trailing comma is not part of the arguments, so an attribute carrying
+// one matches the same pattern as one written without
+
+//ERROR:
+#[Route("/a", name: "a",)]
+function a() {}
+
+//ERROR: the same attribute without the trailing comma
+#[Route("/a", name: "a")]
+function b() {}
+
+// OK: a different argument
+#[Route("/c", name: "c",)]
+function c() {}

--- a/tests/patterns/php/php8_attribute_trailing_comma.sgrep
+++ b/tests/patterns/php/php8_attribute_trailing_comma.sgrep
@@ -1,0 +1,2 @@
+#[Route("/a", name: "a")]
+function $F(...) {}


### PR DESCRIPTION
Zend test corpus coverage: 95.95% → 95.96%

e.g. `#[Route("/a", name: "a",)]`