### PR TITLE
PHP: Fixes in `catch`

### DIFF
--- a/languages/php/ast/ast_php.ml
+++ b/languages/php/ast/ast_php.ml
@@ -323,10 +323,11 @@ and stmt =
 
 and case = Case of tok * expr * stmt list | Default of tok * stmt list | CaseEllipsis of (* ... *) tok 
 
-(* catch(Exception $exn) { ... } => ("Exception", "$exn", [...])
- * TODO: can now be a list of hint_type, Exn1 | Exn2 like in Java.
+(* catch(Exception $exn) { ... } => ("Exception", Some "$exn", [...]).
+ * 'Exn1 | Exn2' is a HintUnion, and the var is absent in a non-capturing
+ * catch.
  *)
-and catch = tok * hint_type * var * stmt
+and catch = tok * hint_type * var option * stmt
 and finally = tok * stmt
 
 (*****************************************************************************)

--- a/languages/php/ast/cst_php.ml
+++ b/languages/php/ast/cst_php.ml
@@ -496,7 +496,9 @@ and foreach_pattern =
   | ForeachList of tok (* list *) * list_assign comma_list paren
 
 and foreach_variable = is_ref * lvalue
-and catch = tok * (class_name * dname) paren * stmt_and_def list brace
+(* the class_name is a HintUnion for a multi-catch; the dname is absent in a
+ * non-capturing catch, as in 'catch (Exception) {}' *)
+and catch = tok * (class_name * dname option) paren * stmt_and_def list brace
 and finally = tok * stmt_and_def list brace
 and use_filename = UseDirect of string wrap | UseParen of string wrap paren
 and declare = ident * static_scalar_affect

--- a/languages/php/generic/php_to_generic.ml
+++ b/languages/php/generic/php_to_generic.ml
@@ -241,8 +241,8 @@ and case = function
   | CaseEllipsis tok -> G.CaseEllipsis tok
 
 and catch (t, v1, v2, v3) =
-  let v1 = hint_type v1 and v2 = var v2 and v3 = stmt v3 in
-  let exn = G.CatchParam (G.param_of_type v1 ~pname:v2) in
+  let v1 = hint_type v1 and v2 = option var v2 and v3 = stmt v3 in
+  let exn = G.CatchParam (G.param_of_type v1 ?pname:v2) in
   (t, exn, v3)
 
 (* a list of finally??? php ... *)

--- a/languages/php/menhir/ast_php_build.ml
+++ b/languages/php/menhir/ast_php_build.ml
@@ -1114,7 +1114,7 @@ and foreach_pattern tok env pat =
 and catch env (t, (_, (fq, dn), _), (lb, stdl, rb)) =
   let stdl = A.Block (lb, List_.fold_right (stmt_and_def env) stdl [], rb) in
   let fq = hint_type env fq in
-  let dn = dname dn in
+  let dn = Option.map dname dn in
   (t, fq, dn, stdl)
 
 and finally env (t, (lb, stdl, rb)) =

--- a/languages/php/menhir/parser_php.mly
+++ b/languages/php/menhir/parser_php.mly
@@ -418,13 +418,13 @@ statement:
  | T_RETURN expr_or_dots? ";"  { Return ($1, $2, $3)}
 
  | T_TRY   "{" inner_statement* "}"
-   T_CATCH "(" list_sep2(class_name, "|")  variable ")"
+   T_CATCH "(" catch_type_list variable? ")"
      "{" inner_statement* "}"
      additional_catch* finally_clause?
      { let try_block = ($2,$3,$4) in
        let catch_block = ($10, $11, $12) in
-       let t = List_.hd_exn "unexpected empty list" $7 in (* TODO: return a list of types *)
-       let catch = ($5, ($6, (t, DName $8), $9), catch_block) in
+       let catch = ($5, ($6, ($7, Option.map (fun v -> DName v) $8), $9),
+                    catch_block) in
        Try($1, try_block, [catch] @ $13, o2l $14)
      }
  | T_TRY "{" inner_statement* "}" finally_clause
@@ -564,11 +564,18 @@ new_else_single:
 
 
 additional_catch:
- | T_CATCH "(" class_name variable ")" "{" inner_statement* "}"
+ | T_CATCH "(" catch_type_list variable? ")" "{" inner_statement* "}"
      { let catch_block = ($6, $7, $8) in
-       let catch = ($1, ($2, ($3, DName $4), $5), catch_block) in
+       let catch =
+         ($1, ($2, ($3, Option.map (fun v -> DName v) $4), $5), catch_block) in
        catch
      }
+
+(* PHP 7.1 multi-catch: 'catch (Exn1 | Exn2 $e)'. Same shape as a union type,
+ * so a rule written for either exception matches the clause *)
+catch_type_list:
+ | list_sep(class_name, "|")
+     { match $1 with | [Left v] -> v | xs -> HintUnion xs }
 
 finally_clause: T_FINALLY "{" inner_statement* "}"  { ($1, ($2, $3, $4)) }
 

--- a/languages/php/tree-sitter/Parse_php_tree_sitter.ml
+++ b/languages/php/tree-sitter/Parse_php_tree_sitter.ml
@@ -1047,14 +1047,18 @@ and map_catch_clause (env : env) ((v1, v2, v3, v4, v5, v6) : CST.catch_clause) :
   let v1 = (* pattern [cC][aA][tT][cC][hH] *) token env v1 in
   let v2 = (* "(" *) token env v2 in
   let v3 = map_type_list env v3 in
-  let v4 =
-    match v4 with
-    | Some x -> map_variable_name env x
-    | None -> ("", Tok.fake_tok v2 "")
-  in
+  let v4 = Option.map (map_variable_name env) v4 in
   let v5 = (* ")" *) token env v5 in
   let v6 = map_compound_statement env v6 in
-  let ht = A.HintTuple (v2, v3, v5) in
+  (* 'catch (Exn1 | Exn2 $e)' is a union of the two, as the menhir parser
+   * builds it; a lone type stands for itself *)
+  let ht =
+    match v3 with
+    | [ ty ] -> ty
+    | tys -> A.HintUnion (List_.hd_exn "empty catch type list" tys,
+                          List_.tl_exn "empty catch type list" tys
+                          |> List_.map (fun ty -> (Tok.fake_tok v2 "|", ty)))
+  in
   (v1, ht, v4, v6)
 
 and map_class_constant_access_expression (env : env)

--- a/src/matching/Generic_vs_generic.ml
+++ b/src/matching/Generic_vs_generic.ml
@@ -2971,12 +2971,61 @@ and m_catch a b =
       m_tok at bt >>= fun () ->
       m_catch_exn a1 b1 >>= fun () -> m_stmt a2 b2
 
+(* the types of a union, left to right; a lone type is a union of one *)
+and union_members ty =
+  match ty.G.t with
+  | G.TyOr (t1, _, t2) -> union_members t1 @ union_members t2
+  | _ -> [ ty ]
+
+and is_union_type ty =
+  match ty.G.t with
+  | G.TyOr _ -> true
+  | _ -> false
+
+(* a lone '$T' stands for the whole union, so it needs no per-type pass *)
+and is_metavar_type ty =
+  match ty.G.t with
+  | G.TyN (G.Id ((s, _), _)) -> Mvar.is_metavar_name s
+  | _ -> false
+
 and m_catch_exn a b =
   match (a, b) with
   (* dots: *)
   | G.CatchPattern (G.PatEllipsis _), _ -> return ()
   (* boilerplate *)
   | G.CatchPattern a, CatchPattern b -> m_pattern a b
+  (* a multi-catch such as PHP's 'catch (Exn1 | Exn2 $e)' catches every one of
+   * its types, so it matches a pattern naming any of them: one type, or
+   * several in any order. Trying the union whole first lets a metavariable
+   * still bind to it in full.
+   *)
+  | G.CatchParam a, B.CatchParam ({ B.ptype = Some bty; _ } as b)
+    when is_union_type bty ->
+      let caught = union_members bty in
+      let named =
+        match a.G.ptype with
+        | Some aty when not (is_metavar_type aty) -> union_members aty
+        | _ -> []
+      in
+      m_parameter_classic a b
+      >||>
+      (match named with
+      | [] -> fail ()
+      | _ ->
+          (* every type the pattern names has to be one the clause catches *)
+          named
+          |> List.fold_left
+               (fun acc aty ->
+                 acc >>= fun () ->
+                 caught
+                 |> List.fold_left
+                      (fun acc bty -> acc >||> m_type_ aty bty)
+                      (fail ()))
+               (return ())
+          >>= fun () ->
+          m_parameter_classic
+            { a with G.ptype = None }
+            { b with B.ptype = None })
   | G.CatchParam a, B.CatchParam b -> m_parameter_classic a b
   | G.OtherCatch (a0, a1), B.OtherCatch (b0, b1) ->
       let* () = m_todo_kind a0 b0 in

--- a/tests/parsing/php/php71_multi_catch_forms.php
+++ b/tests/parsing/php/php71_multi_catch_forms.php
@@ -1,0 +1,21 @@
+<?php
+
+// every catch clause takes a list of exception types, not only the first one,
+// and the variable may be left out (PHP 8.0)
+
+try {
+    f();
+} catch (E1 | E2 $e) {
+} catch (E3 | E4 $e) {
+} catch (E5 $e) {
+} catch (E6) {
+} catch (E7 | E8) {
+} catch (\A\B | \C\D $e) {
+} finally {
+    g();
+}
+
+try {
+    h();
+} catch (Exception) {
+}

--- a/tests/patterns/php/php71_multi_catch_member.php
+++ b/tests/patterns/php/php71_multi_catch_member.php
@@ -1,0 +1,22 @@
+<?php
+
+// a multi-catch catches each of its types, so a rule naming any of them finds
+// the clause, whatever order they are written in
+
+//ERROR:
+try { a(); } catch (First | Second $e) { log($e); }
+
+//ERROR: the same two types, written the other way round
+try { b(); } catch (Second | First $e) { log($e); }
+
+//ERROR: among types the rule does not name
+try { c(); } catch (Other | Second | First $e) { log($e); }
+
+//ERROR: not the first catch of the try
+try { d(); } catch (Other $e) {} catch (Second | First $e) { log($e); }
+
+// OK: catches only one of the two
+try { e2(); } catch (First $e) { log($e); }
+
+// OK: catches neither
+try { f(); } catch (Other | Another $e) { log($e); }

--- a/tests/patterns/php/php71_multi_catch_member.sgrep
+++ b/tests/patterns/php/php71_multi_catch_member.sgrep
@@ -1,0 +1,1 @@
+try { ... } catch (First | Second $E) { ... }


### PR DESCRIPTION
Zend test corpus coverage: 96.01% -> 96.28%

Three defects in the `catch` grammar, and the matching they enable.

- Only the first `catch` of a `try` accepted several exception types, so `catch (A | B $e) {} catch (C | D $e) {}` failed on the second clause.
- A `catch` with no variable, as in `catch (Exception) {}` (PHP 8.0), was a syntax error.
- The types after the first were dropped on the floor, so `catch (A | B $e)` was recorded as catching only `A`. They are now kept as a union, the same node a union type annotation uses, and the tree-sitter parser agrees.

A multi-catch catches each of its types, so a rule naming any one of them now finds the clause:

```
catch (First $E) { ... }     // finds  catch (Second | First $e)
catch ($T $E) { ... }        // $T = Second | First
```

That last part is one case in `m_catch_exn` in `Generic_vs_generic`, the only change outside `languages/php/`. It is scoped to catch clauses: a union *type annotation* in TypeScript or Rust still does not match one of its members. Without it, preserving the union would silently stop `catch (\Exception $e)` rules from firing on `catch (\Exception | \Throwable $e)` — which they did before, since only the first type survived.
